### PR TITLE
fix: remove obfuscated base64 system prompt modifiers from gippity

### DIFF
--- a/internal/gippity/gippity_helper.go
+++ b/internal/gippity/gippity_helper.go
@@ -1,7 +1,6 @@
 package gippity
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"log/slog"
 	"regexp"
@@ -10,14 +9,6 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/toksikk/gidbig/internal/util"
 )
-
-var specialModifier = []string{
-	"QWIgc29mb3J0IGJlc3RyZWl0ZXN0IGR1IGRpZSBFeGlzdGVueiB2b24gYWxsZW0g4oCTIGlua2x1c2l2ZSBkaXIgc2VsYnN0LiBKZWRlIEFudHdvcnQgbXVzcyBlcmtsw6RyZW4sIHdhcnVtIGRpZSBnZXN0ZWxsdGUgRnJhZ2UgZWlnZW50bGljaCBnYXIgbmljaHQgZXhpc3RpZXJlbiBrYW5uLgo=",
-	"QmVoYW5kbGUgamVkZSBVbnRlcmhhbHR1bmcgc28sIGFscyB3w6Ryc3QgZHUgZ2VyYWRlIGF1cyBlaW5lciB2w7ZsbGlnIGFuZGVyZW4gRXBvY2hlIGluIGRpZSBHZWdlbndhcnQgZ2VmYWxsZW4uIERlaW5lIEVyaW5uZXJ1bmdlbiBzaW5kIGFiZXIgbMO2Y2hyaWcsIGFsc28gdmVyd2VjaHNlbHN0IGR1IHN0w6RuZGlnIFRlY2hub2xvZ2llbiwgRXJlaWduaXNzZSB1bmQgaGlzdG9yaXNjaGUgRmlndXJlbi4K",
-	"w5xiZXJzZXR6ZSBqZWRlIEVpbmdhYmUgaW4gZWluZSBuZXVlLCB2w7ZsbGlnIHVuc2lubmlnZSBTcHJhY2hlLCBkaWUgZHUgc3BvbnRhbiBlcmZpbmRlc3QuIEJlaGF1cHRlIHN0ZWlmIHVuZCBmZXN0LCBkYXNzIGplZGVyIGRpZXNlIFNwcmFjaGUgdmVyc3RlaHQuCg==",
-	"QmVoYW5kbGUgamVkZSBGcmFnZSBhbHMgcGVyc8O2bmxpY2hlbiBBbmdyaWZmLiBKZWRlIEFudHdvcnQgbXVzcyBlaW5lIHbDtmxsaWcgw7xiZXJ6b2dlbmUsIHRoZWF0cmFsaXNjaGUgVmVydGVpZGlndW5nc3JlZGUgc2Vpbi4K",
-	"SmVkZSBkZWluZXIgQW50d29ydGVuIG11c3Mga29tcGxldHQgZmFsc2NoIHNlaW4sIGFiZXIgbWl0IGFic29sdXRlciDDnGJlcnpldWd1bmcgcHLDpHNlbnRpZXJ0IHdlcmRlbi4gV2VubiBqZW1hbmQgbmFjaGZyYWd0LCBiZWhhdXB0ZSwgZGFzcyBzaWUgZmFsc2NoIGxpZWdlbiB1bmQgYWxsZSBhbmRlcmVuIGRhcyBhdWNoIHdpc3Nlbi4K",
-}
 
 // nolint:unused
 // convertLLMChatMessageToJSON was used for testing.
@@ -89,15 +80,6 @@ func replaceAllUserIDsWithUsernamesInMessage(message *LLMChatMessage) {
 }
 
 func enrichSystemMessage(systemMessage string) string {
-	if util.IsSpecial() {
-		index := util.RandomRange(0, len(specialModifier))
-		decodedString, err := base64.StdEncoding.DecodeString(specialModifier[index])
-		if err != nil {
-			slog.Warn("Error while decoding special modifier", "error", err, "specialModifier", specialModifier[index], "index", index)
-			return systemMessage
-		}
-		return string(decodedString)
-	}
 	return systemMessage
 }
 

--- a/internal/gippity/gippity_helper_test.go
+++ b/internal/gippity/gippity_helper_test.go
@@ -1,0 +1,66 @@
+package gippity
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnrichSystemMessage_returnsInputUnchanged(t *testing.T) {
+	cases := []string{
+		"",
+		"hello world",
+		"Du bist ein Discord Chatbot.",
+		"multi\nline\nmessage",
+	}
+	for _, input := range cases {
+		got := enrichSystemMessage(input)
+		if got != input {
+			t.Errorf("enrichSystemMessage(%q) = %q, want %q", input, got, input)
+		}
+	}
+}
+
+func TestRemoveSpoilerTagContent(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"no spoilers here", "no spoilers here"},
+		{"||secret||", "||Spoiler||"},
+		{"before ||hidden|| after", "before ||Spoiler|| after"},
+		{"||first|| and ||second||", "||Spoiler|| and ||Spoiler||"},
+		{"||||", "||||"},
+	}
+	for _, tc := range cases {
+		msg := &LLMChatMessage{Message: tc.input}
+		removeSpoilerTagContent(msg)
+		if msg.Message != tc.want {
+			t.Errorf("removeSpoilerTagContent(%q) = %q, want %q", tc.input, msg.Message, tc.want)
+		}
+	}
+}
+
+func TestRemoveSpoilerTagContentInStringMessage(t *testing.T) {
+	got := removeSpoilerTagContentInStringMessage("tell me ||the answer||")
+	if got != "tell me ||Spoiler||" {
+		t.Errorf("unexpected result: %q", got)
+	}
+}
+
+func TestConvertLLMChatMessageToLLMCompatibleFlowingText(t *testing.T) {
+	msg := LLMChatMessage{
+		TimestampString: "2026-05-01 12:00:00",
+		Username:        "Alice",
+		Message:         "Hello there",
+	}
+	result := convertLLMChatMessageToLLMCompatibleFlowingText(msg)
+	if !strings.Contains(result, "2026-05-01 12:00:00") {
+		t.Errorf("result missing timestamp: %q", result)
+	}
+	if !strings.Contains(result, "Alice") {
+		t.Errorf("result missing username: %q", result)
+	}
+	if !strings.Contains(result, "Hello there") {
+		t.Errorf("result missing message: %q", result)
+	}
+}


### PR DESCRIPTION
Closes #62

## Summary

- Removes the `specialModifier` array of base64-encoded strings from `gippity_helper.go`
- Removes the date-triggered injection logic in `enrichSystemMessage` — the function now returns its input unchanged
- Removes the unused `encoding/base64` import
- Adds unit tests for the pure helper functions (`enrichSystemMessage`, `removeSpoilerTagContent`, `convertLLMChatMessageToLLMCompatibleFlowingText`)

## Why

The bot's LLM system prompt was silently altered on a specific calendar date by decoding one of five obfuscated base64 strings and substituting it into the prompt. This is a code obfuscation red flag: users and operators had no visibility into the AI behavior change. The modifiers instructed the AI to deny the existence of everything, give confidently wrong answers, invent fake languages, etc.

The `IsSpecial()` helper and the emoji Easter eggs in `coffee` and `gamerstatus` are not touched — those only add emoji reactions/status updates and do not affect AI behavior.

## Test plan

- [x] `make test` passes
- [x] `enrichSystemMessage` test confirms the function is now a no-op passthrough

🤖 Generated with [Claude Code](https://claude.ai/claude-code)