### PR TITLE
fix: prevent nil pointer panic when config.yaml is missing or invalid

### DIFF
--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -1,6 +1,8 @@
 package cfg
 
 import (
+	"errors"
+	"io"
 	"log/slog"
 	"os"
 
@@ -40,14 +42,27 @@ func loadFile() *Config {
 	configFile, err := os.Open("config.yaml")
 	if err != nil {
 		slog.Error("Could not load config file.", "error", err)
+		os.Exit(1)
 	}
 	defer configFile.Close()
 
-	configDecoder := yaml.NewDecoder(configFile)
-
-	if err := configDecoder.Decode(&initializedConfig); err != nil {
-		slog.Error("could not decode config.", "error", err)
+	cfg, err := decodeConfig(configFile)
+	if err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
-
+	initializedConfig = *cfg
 	return &initializedConfig
+}
+
+// decodeConfig decodes YAML from r into a Config and validates required fields.
+func decodeConfig(r io.Reader) (*Config, error) {
+	var cfg Config
+	if err := yaml.NewDecoder(r).Decode(&cfg); err != nil {
+		return nil, errors.New("could not decode config: " + err.Error())
+	}
+	if cfg.Discord.Token == "" {
+		return nil, errors.New("discord.token is required but not set in config.yaml")
+	}
+	return &cfg, nil
 }

--- a/internal/cfg/cfg_test.go
+++ b/internal/cfg/cfg_test.go
@@ -1,0 +1,83 @@
+package cfg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeConfig_validConfig(t *testing.T) {
+	yaml := `
+discord:
+  token: "test-token"
+  owner_id: "123"
+dev_mode: true
+`
+	cfg, err := decodeConfig(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Discord.Token != "test-token" {
+		t.Errorf("token = %q, want %q", cfg.Discord.Token, "test-token")
+	}
+	if cfg.Discord.OwnerID != "123" {
+		t.Errorf("owner_id = %q, want %q", cfg.Discord.OwnerID, "123")
+	}
+	if !cfg.DevMode {
+		t.Error("dev_mode should be true")
+	}
+}
+
+func TestDecodeConfig_missingToken(t *testing.T) {
+	yaml := `
+discord:
+  owner_id: "123"
+`
+	_, err := decodeConfig(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for missing discord.token, got nil")
+	}
+	if !strings.Contains(err.Error(), "discord.token") {
+		t.Errorf("error should mention discord.token, got: %v", err)
+	}
+}
+
+func TestDecodeConfig_invalidYAML(t *testing.T) {
+	_, err := decodeConfig(strings.NewReader(":::not valid yaml:::"))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestDecodeConfig_emptyToken(t *testing.T) {
+	yaml := `
+discord:
+  token: ""
+`
+	_, err := decodeConfig(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for empty discord.token, got nil")
+	}
+}
+
+func TestDecodeConfig_webFields(t *testing.T) {
+	yaml := `
+discord:
+  token: "tok"
+web:
+  port: 9090
+  oauth:
+    client_id: "cid"
+    client_secret: "csec"
+    redirect_uri: "http://localhost/callback"
+`
+	cfg, err := decodeConfig(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Web.Port != 9090 {
+		t.Errorf("port = %d, want 9090", cfg.Web.Port)
+	}
+	if cfg.Web.Oauth.ClientID != "cid" {
+		t.Errorf("client_id = %q, want %q", cfg.Web.Oauth.ClientID, "cid")
+	}
+}


### PR DESCRIPTION
Closes #63

## Summary

- `loadFile` previously called `defer configFile.Close()` before checking whether `os.Open` succeeded — a nil pointer panic when `config.yaml` is absent.
- Decode errors were also logged but execution continued, resulting in a partially-configured (zero-value) bot.
- Extracted `decodeConfig(io.Reader) (*Config, error)` to separate the pure parsing/validation logic from the file-open and exit calls, making it testable.

## Changes

- `os.Exit(1)` with a clear `slog.Error` message on: missing file, YAML decode failure, or empty `discord.token`.
- `decodeConfig` validates that `discord.token` is non-empty and returns an error if not.
- Five new unit tests in `cfg_test.go` covering all error paths and the happy path.

## Test plan

- [x] `make test` passes
- [x] `TestDecodeConfig_missingToken` / `TestDecodeConfig_emptyToken` confirm validation fires
- [x] `TestDecodeConfig_invalidYAML` confirms decode errors are caught

🤖 Generated with [Claude Code](https://claude.ai/claude-code)