### PR TITLE
fix(audio): close .txt and .dca files to prevent FD leaks

### DIFF
--- a/internal/core/soundboard_init.go
+++ b/internal/core/soundboard_init.go
@@ -92,6 +92,7 @@ func (s *soundClip) Load(c *soundCollection) error {
 		slog.Error("error opening dca file", "error", err)
 		return err
 	}
+	defer func() { _ = file.Close() }()
 
 	var opuslen int16
 

--- a/internal/core/soundboard_init_test.go
+++ b/internal/core/soundboard_init_test.go
@@ -1,0 +1,96 @@
+package gidbig
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeDCAFile(t *testing.T, prefix, name string, frames [][]byte) {
+	t.Helper()
+	if err := os.MkdirAll("audio", 0o755); err != nil {
+		t.Fatalf("mkdir audio: %v", err)
+	}
+	path := filepath.Join("audio", prefix+"_"+name+".dca")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	for _, frame := range frames {
+		if err := binary.Write(f, binary.LittleEndian, int16(len(frame))); err != nil {
+			t.Fatalf("write frame length: %v", err)
+		}
+		if _, err := f.Write(frame); err != nil {
+			t.Fatalf("write frame data: %v", err)
+		}
+	}
+}
+
+func TestSoundClipLoad_missingFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	c := &soundCollection{Prefix: "missing"}
+	s := &soundClip{Name: "clip", buffer: make([][]byte, 0)}
+	if err := s.Load(c); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestSoundClipLoad_emptyFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeDCAFile(t, "empty", "clip", nil)
+
+	c := &soundCollection{Prefix: "empty"}
+	s := &soundClip{Name: "clip", buffer: make([][]byte, 0)}
+	if err := s.Load(c); err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(s.buffer) != 0 {
+		t.Errorf("buffer len = %d, want 0", len(s.buffer))
+	}
+}
+
+func TestSoundClipLoad_readsFrames(t *testing.T) {
+	t.Chdir(t.TempDir())
+	frames := [][]byte{
+		{0x01, 0x02, 0x03, 0x04},
+		{0xff, 0xee, 0xdd},
+	}
+	writeDCAFile(t, "frames", "clip", frames)
+
+	c := &soundCollection{Prefix: "frames"}
+	s := &soundClip{Name: "clip", buffer: make([][]byte, 0)}
+	if err := s.Load(c); err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(s.buffer) != len(frames) {
+		t.Fatalf("buffer len = %d, want %d", len(s.buffer), len(frames))
+	}
+	for i, want := range frames {
+		got := s.buffer[i]
+		if len(got) != len(want) {
+			t.Errorf("frame %d len = %d, want %d", i, len(got), len(want))
+			continue
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Errorf("frame %d byte %d = %#x, want %#x", i, j, got[j], want[j])
+			}
+		}
+	}
+}
+
+func TestSoundClipLoad_doesNotLeakFD(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeDCAFile(t, "leak", "clip", [][]byte{{0xaa, 0xbb}})
+
+	c := &soundCollection{Prefix: "leak"}
+	for i := 0; i < 5000; i++ {
+		s := &soundClip{Name: "clip", buffer: make([][]byte, 0)}
+		if err := s.Load(c); err != nil {
+			t.Fatalf("call %d returned error: %v", i, err)
+		}
+	}
+}

--- a/internal/core/webserver.go
+++ b/internal/core/webserver.go
@@ -81,6 +81,22 @@ func startWebServer(config *cfg.Config) {
 	}
 }
 
+func readSoundDescription(prefix, name string) (text, shortText string, ok bool) {
+	file, err := os.Open(fmt.Sprintf("audio/%v_%v.txt", prefix, name))
+	if err != nil {
+		return "", "", false
+	}
+	defer func() { _ = file.Close() }()
+	scanner := bufio.NewScanner(file)
+	scanner.Scan()
+	text = scanner.Text()
+	shortText = text
+	if len(text) > 20 {
+		shortText = text[0:20] + "..."
+	}
+	return text, shortText, true
+}
+
 func handlePlaySound(w http.ResponseWriter, r *http.Request) {
 	slog.Info("WebUI /playsound Request", "Requesting IP", r.RemoteAddr)
 	err := r.ParseForm()
@@ -141,17 +157,9 @@ func handleMain(w http.ResponseWriter, r *http.Request) {
 					Itemtext:      "!" + sc.Prefix + " " + snd.Name,
 					Itemshorttext: "!" + sc.Prefix + " " + snd.Name,
 				}
-				file, e := os.Open(fmt.Sprintf("audio/%v_%v.txt", sc.Prefix, snd.Name))
-				if e == nil {
-					scanner := bufio.NewScanner(file)
-					scanner.Scan()
-					text := scanner.Text()
+				if text, shortText, ok := readSoundDescription(sc.Prefix, snd.Name); ok {
 					newSoundItem.Itemtext = text
-					if len(text) > 20 {
-						text = text[0:20]
-						text += "..."
-					}
-					newSoundItem.Itemshorttext = text
+					newSoundItem.Itemshorttext = shortText
 				}
 				si = append(si, newSoundItem)
 			}

--- a/internal/core/webserver_test.go
+++ b/internal/core/webserver_test.go
@@ -1,0 +1,108 @@
+package gidbig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeAudioDescription(t *testing.T, prefix, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll("audio", 0o755); err != nil {
+		t.Fatalf("mkdir audio: %v", err)
+	}
+	path := filepath.Join("audio", prefix+"_"+name+".txt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestReadSoundDescription_missingFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	text, shortText, ok := readSoundDescription("nope", "missing")
+	if ok {
+		t.Fatal("ok = true, want false for missing file")
+	}
+	if text != "" || shortText != "" {
+		t.Errorf("got (%q, %q), want empty strings", text, shortText)
+	}
+}
+
+func TestReadSoundDescription_shortText(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeAudioDescription(t, "greet", "hi", "hello there")
+
+	text, shortText, ok := readSoundDescription("greet", "hi")
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if text != "hello there" {
+		t.Errorf("text = %q, want %q", text, "hello there")
+	}
+	if shortText != "hello there" {
+		t.Errorf("shortText = %q, want %q", shortText, "hello there")
+	}
+}
+
+func TestReadSoundDescription_longTextTruncated(t *testing.T) {
+	t.Chdir(t.TempDir())
+	long := "this description is definitely longer than twenty characters"
+	writeAudioDescription(t, "verbose", "clip", long)
+
+	text, shortText, ok := readSoundDescription("verbose", "clip")
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if text != long {
+		t.Errorf("text = %q, want full text", text)
+	}
+	if !strings.HasSuffix(shortText, "...") {
+		t.Errorf("shortText = %q, want trailing %q", shortText, "...")
+	}
+	if len(shortText) != 23 {
+		t.Errorf("shortText len = %d, want 23 (20 + len(\"...\"))", len(shortText))
+	}
+	if !strings.HasPrefix(shortText, long[0:20]) {
+		t.Errorf("shortText = %q, want prefix %q", shortText, long[0:20])
+	}
+}
+
+func TestReadSoundDescription_emptyFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeAudioDescription(t, "blank", "clip", "")
+
+	text, shortText, ok := readSoundDescription("blank", "clip")
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if text != "" || shortText != "" {
+		t.Errorf("got (%q, %q), want empty strings", text, shortText)
+	}
+}
+
+func TestReadSoundDescription_onlyFirstLine(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeAudioDescription(t, "multi", "line", "first line\nsecond line\nthird line")
+
+	text, _, ok := readSoundDescription("multi", "line")
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if text != "first line" {
+		t.Errorf("text = %q, want %q", text, "first line")
+	}
+}
+
+func TestReadSoundDescription_doesNotLeakFD(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeAudioDescription(t, "leak", "test", "some description")
+
+	for i := 0; i < 5000; i++ {
+		_, _, ok := readSoundDescription("leak", "test")
+		if !ok {
+			t.Fatalf("call %d returned ok = false", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two file-descriptor leaks in audio file handling — both `os.Open` calls without matching `Close()`.

### 1. `webserver.go` (per-request, fixes #66)
`handleMain` opened `audio/{prefix}_{name}.txt` for every sound on every page load and never closed it. Once the process hit the OS fd limit (~1024 by default), all subsequent `os.Open` calls — including Discord API and SQLite — would fail.

Extracted the read into `readSoundDescription` with `defer Close`. Behaviour preserved exactly: missing file → keep fallback text; file present → override.

### 2. `soundboard_init.go` (per-startup, surfaced in review)
`soundClip.Load` opened each `.dca` file at startup but never closed the descriptor — every loaded sound held one fd for the lifetime of the process. With many sounds this could exhaust the limit at startup before any request was served.

## Test plan
- [x] `go test ./internal/core/...` — new tests for both helpers covering missing/empty/short/long/multi-line/multi-frame files
- [x] 5000-iteration leak guards on both helpers (would hit `EMFILE` without `defer Close`)
- [x] Full `make test` suite green
- [x] `golangci-lint run ./internal/core/...` clean

Fixes #66