### PR TITLE
feat(core): graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -303,4 +303,23 @@ func StartGidbig() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	<-c
+
+	slog.Info("shutting down")
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		if err := discord.Close(); err != nil {
+			slog.Error("error closing discord session", "error", err)
+		}
+		gippity.CloseDB()
+		leetoclock.Shutdown()
+	}()
+
+	select {
+	case <-shutdownDone:
+		slog.Info("shutdown complete")
+	case <-time.After(10 * time.Second):
+		slog.Warn("shutdown timed out after 10s, forcing exit")
+	}
 }

--- a/internal/gippity/gippity_persistence.go
+++ b/internal/gippity/gippity_persistence.go
@@ -53,6 +53,15 @@ func initDB() {
 	}
 }
 
+// CloseDB closes the gippity chat history database.
+func CloseDB() {
+	if database != nil {
+		if err := database.Close(); err != nil {
+			slog.Error("error closing gippity database", "error", err)
+		}
+	}
+}
+
 func addMessageToDatabase(m *discordgo.MessageCreate) {
 	stmt, err := database.Prepare("INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id) VALUES (?, ?, ?, ?, ?, ?)")
 	if err != nil {

--- a/internal/leetoclock/leetoclock.go
+++ b/internal/leetoclock/leetoclock.go
@@ -37,6 +37,15 @@ var announcementChannels = []string{}
 
 var store *datastore.Store
 
+// Shutdown closes the leetoclock database connection.
+func Shutdown() {
+	if store != nil {
+		if err := store.Close(); err != nil {
+			slog.Error("error closing leetoclock database", "error", err)
+		}
+	}
+}
+
 // Start the plugin
 func Start(discord *discordgo.Session) {
 	session = discord

--- a/internal/leetoclock/util/datastore/datastore.go
+++ b/internal/leetoclock/util/datastore/datastore.go
@@ -85,6 +85,15 @@ func NewStore(db *gorm.DB) *Store {
 	return &Store{db: db}
 }
 
+// Close closes the underlying database connection.
+func (s *Store) Close() error {
+	sqlDB, err := s.db.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Close()
+}
+
 // HELPER
 
 func getSeasonStartDateForDate(date time.Time) time.Time {


### PR DESCRIPTION
## Summary

- On `SIGTERM` or `SIGINT`, logs "shutting down" and runs a cleanup goroutine
- Calls `discord.Close()` to disconnect the gateway and all voice connections
- Closes the gippity `*sql.DB` (WAL flush)
- Closes the leetoclock GORM/SQLite connection via a new `Store.Close()` method
- Enforces a 10-second timeout; logs a warning if cleanup stalls

## Changes

- `internal/gippity/gippity_persistence.go` — added `CloseDB()` to close the chat history DB
- `internal/leetoclock/util/datastore/datastore.go` — added `Store.Close()` to close the GORM DB
- `internal/leetoclock/leetoclock.go` — added `Shutdown()` calling `store.Close()`
- `internal/core/cmd.go` — replaced bare `<-c` with a shutdown goroutine + timeout select

## Test plan

- [ ] `make test` passes (all existing tests green)
- [ ] `make build` succeeds

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)