### PR TITLE
fix: address PR #105 review — panic contract for RandomRange, guard chained collection

### DIFF
--- a/internal/core/soundboard.go
+++ b/internal/core/soundboard.go
@@ -22,6 +22,9 @@ var (
 
 // Random select sound
 func (sc *soundCollection) Random() *soundClip {
+	if len(sc.Sounds) == 0 {
+		return nil
+	}
 	var (
 		i      int
 		number = util.RandomRange(0, sc.soundRange)
@@ -136,12 +139,17 @@ func createPlay(user *discordgo.User, guild *discordgo.Guild, coll *soundCollect
 
 	// If the collection is a chained one, set the next sound
 	if coll.ChainWith != nil {
-		play.Next = &Play{
-			GuildID:   play.GuildID,
-			ChannelID: play.ChannelID,
-			UserID:    play.UserID,
-			Sound:     coll.ChainWith.Random(),
-			Forced:    play.Forced,
+		nextSound := coll.ChainWith.Random()
+		if nextSound == nil {
+			slog.Warn("chained collection is empty, skipping next sound", "prefix", coll.ChainWith.Prefix)
+		} else {
+			play.Next = &Play{
+				GuildID:   play.GuildID,
+				ChannelID: play.ChannelID,
+				UserID:    play.UserID,
+				Sound:     nextSound,
+				Forced:    play.Forced,
+			}
 		}
 	}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -21,10 +21,10 @@ var Ae = [][]byte{
 var da byte = byte(0b00100101) ^ byte(0x13) ^ byte(0x37)
 var mo byte = byte(0b00100000) ^ byte(0x13) ^ byte(0x37)
 
-// RandomRange returns a random integer in [min, max). Returns min when max <= min.
+// RandomRange returns a random integer in [min, max). Panics when max <= min.
 func RandomRange(min, max int) int {
 	if max <= min {
-		return min
+		panic("RandomRange: max must be greater than min")
 	}
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return r.Intn(max-min) + min

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -11,20 +11,29 @@ func TestRandomRange_normal(t *testing.T) {
 	}
 }
 
-func TestRandomRange_equalMinMax(t *testing.T) {
-	if v := RandomRange(5, 5); v != 5 {
-		t.Errorf("RandomRange(5,5) = %d, want 5", v)
-	}
+func TestRandomRange_panicOnEqualMinMax(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for RandomRange(5,5), got none")
+		}
+	}()
+	RandomRange(5, 5)
 }
 
-func TestRandomRange_maxLessThanMin(t *testing.T) {
-	if v := RandomRange(7, 3); v != 7 {
-		t.Errorf("RandomRange(7,3) = %d, want 7", v)
-	}
+func TestRandomRange_panicOnMaxLessThanMin(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for RandomRange(7,3), got none")
+		}
+	}()
+	RandomRange(7, 3)
 }
 
-func TestRandomRange_zeroRange(t *testing.T) {
-	if v := RandomRange(0, 0); v != 0 {
-		t.Errorf("RandomRange(0,0) = %d, want 0", v)
-	}
+func TestRandomRange_panicOnZeroRange(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for RandomRange(0,0), got none")
+		}
+	}()
+	RandomRange(0, 0)
 }


### PR DESCRIPTION
Addresses the two unresolved review comments from #105.

## Changes

**`RandomRange` contract** (#105 comment on `util.go:31`)

The previous fix returned `min` silently when `max <= min`. Reviewers correctly noted this masks downstream panics for callers that use the result as a slice index (e.g. `util.Ae[RandomRange(0, len(util.Ae))]` in `coffee.go`). The fix: `RandomRange` now panics with `"RandomRange: max must be greater than min"` on invalid input, giving a clear stack trace.

The empty-collection guard is pushed into `soundCollection.Random()` itself: it returns `nil` early when `len(sc.Sounds) == 0`, before ever calling `RandomRange`.

**Chained collection nil check** (#105 comment on `soundboard.go:129`)

`coll.ChainWith.Random()` was called without checking the return value. If the chained collection is empty, `play.Next.Sound` would be `nil` and panic in `playSound`. Fixed by extracting the result, logging a warning, and skipping `play.Next` assignment when nil.

## Tests

- `util_test.go`: equal/inverted/zero-range cases now assert the panic rather than expecting a return value
- `soundboard_init_test.go`: `TestSoundCollectionRandom_emptyCollection` (returns nil without panic) and `TestSoundCollectionRandom_returnsSound` (populated collection always returns clip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)