### PR TITLE
fix(voice): wait for DAVE E2EE handshake before sending Opus frames

### DIFF
--- a/internal/core/soundboard.go
+++ b/internal/core/soundboard.go
@@ -9,6 +9,16 @@ import (
 	"github.com/toksikk/gidbig/internal/util"
 )
 
+const (
+	// daveHandshakeWarmup is the minimum time to wait after joining a voice channel
+	// before sending Opus frames.  Discord now enforces DAVE (E2EE) on all voice
+	// channels: ChannelVoiceJoin returns when the transport is ready (OP4) but the
+	// DAVE key exchange (Welcome → PrepareTransition → ExecuteTransition) needs an
+	// additional 100–300 ms.  Frames sent before the exchange completes are discarded
+	// by Discord clients.  500 ms gives ample margin even on slow connections.
+	daveHandshakeWarmup = 500 * time.Millisecond
+)
+
 var (
 	// Map of Guild id's to *Play channels, used for queuing and rate-limiting guilds
 	queues = make(map[string]chan *Play)
@@ -216,6 +226,12 @@ func playSound(play *Play, vc *discordgo.VoiceConnection, vcChannelID string) (r
 			return nil, "", err
 		}
 		vcChannelID = play.ChannelID
+		// Discord now enforces DAVE (E2EE) on all voice channels. ChannelVoiceJoin
+		// returns as soon as the transport is ready (OP4), but the DAVE key exchange
+		// (Welcome → PrepareTransition → ExecuteTransition) takes an additional
+		// 100–300 ms. Audio sent before that exchange completes is dropped by Discord
+		// clients.  Wait long enough for the handshake to finish before sending frames.
+		time.Sleep(daveHandshakeWarmup)
 	}
 
 	// If we need to change channels, disconnect and rejoin
@@ -232,10 +248,11 @@ func playSound(play *Play, vc *discordgo.VoiceConnection, vcChannelID string) (r
 			return nil, "", err
 		}
 		vcChannelID = play.ChannelID
-		time.Sleep(time.Millisecond * 125)
+		// Same DAVE warmup needed after a channel change.
+		time.Sleep(daveHandshakeWarmup)
 	}
 
-	// Sleep for a specified amount of time before playing the sound
+	// Small buffer before starting playback.
 	time.Sleep(time.Millisecond * 32)
 
 	mutex.Lock()

--- a/internal/core/soundboard_test.go
+++ b/internal/core/soundboard_test.go
@@ -1,0 +1,20 @@
+package gidbig
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDAVEHandshakeWarmup_minimum verifies that the DAVE warmup constant is at
+// least 400 ms.  Discord's DAVE (E2EE) key exchange requires roughly 100–300 ms
+// (two gateway round-trips: key-package → Welcome, then ReadyForTransition →
+// ExecuteTransition).  Frames sent before ExecuteTransition is processed are
+// discarded by Discord clients in DAVE-enabled channels.  A warmup below 400 ms
+// risks the exchange not completing before audio starts, especially on connections
+// with higher latency.
+func TestDAVEHandshakeWarmup_minimum(t *testing.T) {
+	const minWarmup = 400 * time.Millisecond
+	if daveHandshakeWarmup < minWarmup {
+		t.Errorf("daveHandshakeWarmup = %v; must be >= %v to cover the DAVE key exchange on slow connections", daveHandshakeWarmup, minWarmup)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `daveHandshakeWarmup` constant (500 ms) in `soundboard.go`
- Sleeps for that duration after every `ChannelVoiceJoin` call (initial join **and** channel change) before sending any Opus frames
- Replaces the old 125 ms channel-change sleep with the same constant

## Root cause

Discord now enforces the **DAVE (E2EE) protocol** on all voice channels (see the earlier 4017 fix). `ChannelVoiceJoin` returns as soon as the transport layer is ready (OP4 received), but the DAVE key exchange still needs to finish:

1. Bot sends KeyPackage → server responds with **Welcome** (~100 ms round-trip)
2. Bot sends ReadyForTransition → server sends **PrepareTransition + ExecuteTransition** (~100 ms round-trip)

The Renovate update on 2026-05-01 (commit 12ccab1) tightened the fork's `CanEncrypt()` from `frameCipher != nil` to `active && frameCipher != nil`, where `active` is only set after step 2. With the old 32 ms window, frames were always sent before `active = true`, so the `opusSender` goroutine skipped DAVE encryption for every frame. Discord clients in DAVE channels discard non-DAVE audio, producing total silence.

The 500 ms warmup covers the full two-round-trip exchange with margin for slow connections.

## Test plan

- [x] `TestDAVEHandshakeWarmup_minimum` — asserts the constant stays >= 400 ms so future drift is caught in CI
- [ ] Manual: trigger a sound via `!<prefix>` in a Discord voice channel and confirm audio is audible

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)