### PR TITLE
chore(renovate): disable auto-updates for discordgo-fork pin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended"
+    ],
+    "packageRules": [
+        {
+            "matchPackageNames": ["github.com/yeongaori/discordgo-fork", "github.com/bwmarrin/discordgo"],
+            "enabled": false,
+            "description": "Pinned to 930441e7 — later commits break DAVE voice encryption (see go.mod comment and issue #113)"
+        }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds a `packageRules` block to `renovate.json` that disables updates for `github.com/yeongaori/discordgo-fork` (and `github.com/bwmarrin/discordgo`) permanently.
- `go.mod` is pinned to fork commit `930441e7` (2026-03-07) — the last revision where DAVE voice encryption activates correctly after the Welcome message. Commits from 2026-03-08 onward removed the immediate `HandleExecuteTransition` call, leaving DAVE in a "prepared" state forever, which caused Discord to silently drop every audio frame (issue #113).
- Closes #115 (Renovate PR that would have bumped to `16ef341`, re-breaking audio).

## Test plan

- [ ] Verify `renovate.json` schema is valid (Renovate bot will report config errors if not)
- [ ] Confirm Renovate no longer opens PRs for `discordgo-fork` after merge