### PR TITLE
refactor(coffee): extract beverage emoji selection into lookup function

### DIFF
--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -8,6 +8,20 @@ import (
 	"github.com/toksikk/gidbig/internal/util"
 )
 
+var defaultBeverages = map[string]string{
+	"263959699764805642": "🍵",
+	"217697101818232832": "🍵",
+}
+
+const fallbackBeverage = "☕"
+
+func beverageEmojiFor(userID string) string {
+	if emoji, ok := defaultBeverages[userID]; ok {
+		return emoji
+	}
+	return fallbackBeverage
+}
+
 var messages = []string{
 	"moin",
 	"hi",
@@ -42,11 +56,7 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 				util.ReactOnMessage(s, m.ChannelID, m.ID, string(util.Ae[util.RandomRange(0, len(util.Ae))]), "add")
 				util.ReactOnMessage(s, m.ChannelID, m.ID, string(util.Cl), "add")
 			} else {
-				if m.Author.ID == "263959699764805642" || m.Author.ID == "217697101818232832" {
-					util.ReactOnMessage(s, m.ChannelID, m.ID, "🍵", "add")
-				} else {
-					util.ReactOnMessage(s, m.ChannelID, m.ID, "☕", "add")
-				}
+				util.ReactOnMessage(s, m.ChannelID, m.ID, beverageEmojiFor(m.Author.ID), "add")
 				// faces
 				if m.Author.ID == "269898849714307073" {
 					util.ReactOnMessage(s, m.ChannelID, m.ID, ":sidus:576309032789475328", "add")

--- a/internal/coffee/coffee_test.go
+++ b/internal/coffee/coffee_test.go
@@ -1,0 +1,21 @@
+package coffee
+
+import "testing"
+
+func TestBeverageEmojiFor(t *testing.T) {
+	tests := []struct {
+		userID   string
+		expected string
+	}{
+		{"263959699764805642", "🍵"},
+		{"217697101818232832", "🍵"},
+		{"000000000000000000", "☕"},
+		{"", "☕"},
+	}
+	for _, tt := range tests {
+		got := beverageEmojiFor(tt.userID)
+		if got != tt.expected {
+			t.Errorf("beverageEmojiFor(%q) = %q; want %q", tt.userID, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `defaultBeverages map[string]string` and `fallbackBeverage` const to hold the existing hardcoded defaults
- Adds `beverageEmojiFor(userID string) string` that looks up the map and falls back to `☕`
- Replaces the bare `if/else` in `onMessageCreate` with a single `beverageEmojiFor` call
- Adds unit tests covering known users and the fallback case

No behaviour change. Step 1 of 3 toward user-configurable morning beverage reactions.

Closes #117

## Test plan

- [x] `go test ./internal/coffee/...` passes
- [x] `golangci-lint run ./internal/coffee/...` reports no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)