### PR TITLE
fix(util): use math/rand/v2, return min for degenerate range

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"time"
 )
 
@@ -21,13 +21,12 @@ var Ae = [][]byte{
 var da byte = byte(0b00100101) ^ byte(0x13) ^ byte(0x37)
 var mo byte = byte(0b00100000) ^ byte(0x13) ^ byte(0x37)
 
-// RandomRange returns a random integer in [min, max). Panics when max <= min.
+// RandomRange returns a random integer in [min, max). Returns min when max <= min.
 func RandomRange(min, max int) int {
 	if max <= min {
-		panic("RandomRange: max must be greater than min")
+		return min
 	}
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return r.Intn(max-min) + min
+	return rand.IntN(max-min) + min
 }
 
 // IsSpecial returns true if today is a special day

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -11,29 +11,20 @@ func TestRandomRange_normal(t *testing.T) {
 	}
 }
 
-func TestRandomRange_panicOnEqualMinMax(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for RandomRange(5,5), got none")
-		}
-	}()
-	RandomRange(5, 5)
+func TestRandomRange_equalMinMax(t *testing.T) {
+	if v := RandomRange(5, 5); v != 5 {
+		t.Errorf("RandomRange(5,5) = %d, want 5", v)
+	}
 }
 
-func TestRandomRange_panicOnMaxLessThanMin(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for RandomRange(7,3), got none")
-		}
-	}()
-	RandomRange(7, 3)
+func TestRandomRange_maxLessThanMin(t *testing.T) {
+	if v := RandomRange(7, 3); v != 7 {
+		t.Errorf("RandomRange(7,3) = %d, want 7", v)
+	}
 }
 
-func TestRandomRange_panicOnZeroRange(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for RandomRange(0,0), got none")
-		}
-	}()
-	RandomRange(0, 0)
+func TestRandomRange_zeroRange(t *testing.T) {
+	if v := RandomRange(0, 0); v != 0 {
+		t.Errorf("RandomRange(0,0) = %d, want 0", v)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #69 — tech debt in `RandomRange` (`internal/util/util.go`).

- Replaces `rand.New(rand.NewSource(time.Now().UnixNano()))` on every call with the goroutine-safe global `rand.IntN` from `math/rand/v2` — no per-call heap allocation, no nanosecond seed collisions.
- Degenerate ranges (`max <= min`) now return `min` silently instead of panicking.
- Tests updated to assert the new non-panicking behaviour.

## Test plan

- [x] `go test ./internal/util/...` — all 4 cases pass
- [x] `make test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)