### PR TITLE
Implement daily coffee greeting gate

### DIFF
--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -14,6 +14,8 @@ const fallbackBeverage = "☕"
 var (
 	discordSession    *discordgo.Session
 	registeredCommand *discordgo.ApplicationCommand
+	isSpecialDay      = util.IsSpecial
+	reactOnMessage    = util.ReactOnMessage
 )
 
 func beverageEmojiFor(userID string) string {
@@ -86,19 +88,26 @@ func Shutdown() {
 func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	for _, v := range messages {
 		if v == strings.ToLower(m.Content) {
-			if util.IsSpecial() {
-				util.ReactOnMessage(s, m.ChannelID, m.ID, string(util.Ae[util.RandomRange(0, len(util.Ae))]), "add")
-				util.ReactOnMessage(s, m.ChannelID, m.ID, string(util.Cl), "add")
+			if hasGreetedToday(m.Author.ID) {
+				return
+			}
+			if isSpecialDay() {
+				reactOnMessage(s, m.ChannelID, m.ID, string(util.Ae[util.RandomRange(0, len(util.Ae))]), "add")
+				reactOnMessage(s, m.ChannelID, m.ID, string(util.Cl), "add")
 			} else {
-				util.ReactOnMessage(s, m.ChannelID, m.ID, beverageEmojiFor(m.Author.ID), "add")
+				reactOnMessage(s, m.ChannelID, m.ID, beverageEmojiFor(m.Author.ID), "add")
 				// faces
 				if m.Author.ID == "269898849714307073" {
-					util.ReactOnMessage(s, m.ChannelID, m.ID, ":sidus:576309032789475328", "add")
+					reactOnMessage(s, m.ChannelID, m.ID, ":sidus:576309032789475328", "add")
 				}
 				if m.Author.ID == "125230846629249024" {
-					util.ReactOnMessage(s, m.ChannelID, m.ID, ":sikk:355329009824825355", "add")
+					reactOnMessage(s, m.ChannelID, m.ID, ":sikk:355329009824825355", "add")
 				}
 			}
+			if err := recordGreeting(m.Author.ID); err != nil {
+				slog.Error("coffee: failed to record daily greeting", "error", err, "userID", m.Author.ID)
+			}
+			return
 		}
 	}
 }

--- a/internal/coffee/coffee_test.go
+++ b/internal/coffee/coffee_test.go
@@ -1,6 +1,82 @@
 package coffee
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/toksikk/gidbig/internal/util"
+)
+
+type capturedReaction struct {
+	channelID    string
+	messageID    string
+	emoji        string
+	reactionType string
+}
+
+func captureReactions(t *testing.T) func() []capturedReaction {
+	t.Helper()
+	previous := reactOnMessage
+	reactions := []capturedReaction{}
+	reactOnMessage = func(_ *discordgo.Session, channelID, messageID, emoji, reactionType string) {
+		reactions = append(reactions, capturedReaction{
+			channelID:    channelID,
+			messageID:    messageID,
+			emoji:        emoji,
+			reactionType: reactionType,
+		})
+	}
+	t.Cleanup(func() {
+		reactOnMessage = previous
+	})
+	return func() []capturedReaction {
+		return reactions
+	}
+}
+
+func useSpecialDay(t *testing.T, special bool) {
+	t.Helper()
+	previous := isSpecialDay
+	isSpecialDay = func() bool {
+		return special
+	}
+	t.Cleanup(func() {
+		isSpecialDay = previous
+	})
+}
+
+func greetingMessage(userID, content string) *discordgo.MessageCreate {
+	return &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message1",
+			ChannelID: "channel1",
+			Content:   content,
+			Author: &discordgo.User{
+				ID: userID,
+			},
+		},
+	}
+}
+
+func countGreetings(t *testing.T, userID string) int64 {
+	t.Helper()
+	d := getDB()
+	var count int64
+	if err := d.Model(&UserGreeting{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count greetings: %v", err)
+	}
+	return count
+}
+
+func isSpecialGreetingEmoji(emoji string) bool {
+	for _, ae := range util.Ae {
+		if emoji == string(ae) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestIsValidBeverageEmoji(t *testing.T) {
 	tests := []struct {
@@ -48,5 +124,94 @@ func TestBeverageEmojiFor(t *testing.T) {
 		if got != tt.expected {
 			t.Errorf("beverageEmojiFor(%q) = %q; want %q", tt.userID, got, tt.expected)
 		}
+	}
+}
+
+func TestOnMessageCreate_FirstGreetingReactsAndRecordsGreeting(t *testing.T) {
+	openInMemoryStore(t)
+	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(t, false)
+	getReactions := captureReactions(t)
+
+	onMessageCreate(nil, greetingMessage("user1", "moin"))
+
+	reactions := getReactions()
+	if len(reactions) != 1 {
+		t.Fatalf("expected 1 reaction, got %d", len(reactions))
+	}
+	if reactions[0].emoji != fallbackBeverage {
+		t.Errorf("reaction emoji = %q, want %q", reactions[0].emoji, fallbackBeverage)
+	}
+	if reactions[0].reactionType != "add" {
+		t.Errorf("reaction type = %q, want add", reactions[0].reactionType)
+	}
+	if count := countGreetings(t, "user1"); count != 1 {
+		t.Errorf("expected 1 greeting row, got %d", count)
+	}
+}
+
+func TestOnMessageCreate_DuplicateSameDayGreetingIsSuppressed(t *testing.T) {
+	openInMemoryStore(t)
+	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(t, false)
+	getReactions := captureReactions(t)
+
+	onMessageCreate(nil, greetingMessage("user1", "moin"))
+	onMessageCreate(nil, greetingMessage("user1", "hi"))
+
+	reactions := getReactions()
+	if len(reactions) != 1 {
+		t.Fatalf("expected only the first greeting to react, got %d reactions", len(reactions))
+	}
+	if count := countGreetings(t, "user1"); count != 1 {
+		t.Errorf("expected duplicate greeting to keep 1 row, got %d", count)
+	}
+}
+
+func TestOnMessageCreate_PriorDayGreetingAllowsNextDayReaction(t *testing.T) {
+	openInMemoryStore(t)
+	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(t, false)
+	getReactions := captureReactions(t)
+
+	d := getDB()
+	if err := d.Create(&UserGreeting{
+		UserID:    "user1",
+		GreetedAt: time.Date(2026, 5, 2, 23, 0, 0, 0, time.Local),
+	}).Error; err != nil {
+		t.Fatalf("failed to create prior greeting: %v", err)
+	}
+
+	onMessageCreate(nil, greetingMessage("user1", "moin"))
+
+	reactions := getReactions()
+	if len(reactions) != 1 {
+		t.Fatalf("expected next-day greeting to react once, got %d reactions", len(reactions))
+	}
+	if count := countGreetings(t, "user1"); count != 2 {
+		t.Errorf("expected prior and new greeting rows, got %d", count)
+	}
+}
+
+func TestOnMessageCreate_SpecialDayFirstGreetingReactsAndRecordsGreeting(t *testing.T) {
+	openInMemoryStore(t)
+	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(t, true)
+	getReactions := captureReactions(t)
+
+	onMessageCreate(nil, greetingMessage("user1", "moin"))
+
+	reactions := getReactions()
+	if len(reactions) != 2 {
+		t.Fatalf("expected 2 special-day reactions, got %d", len(reactions))
+	}
+	if !isSpecialGreetingEmoji(reactions[0].emoji) {
+		t.Errorf("first special-day reaction = %q, want one of util.Ae", reactions[0].emoji)
+	}
+	if reactions[1].emoji != string(util.Cl) {
+		t.Errorf("second special-day reaction = %q, want %q", reactions[1].emoji, string(util.Cl))
+	}
+	if count := countGreetings(t, "user1"); count != 1 {
+		t.Errorf("expected 1 greeting row, got %d", count)
 	}
 }

--- a/internal/coffee/store.go
+++ b/internal/coffee/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"time"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -16,9 +17,17 @@ type UserBeveragePreference struct {
 	BeverageEmoji string `gorm:"not null"`
 }
 
+// UserGreeting records when a Discord user received their daily greeting reaction.
+type UserGreeting struct {
+	gorm.Model
+	UserID    string    `gorm:"not null;index"`
+	GreetedAt time.Time `gorm:"not null;index"`
+}
+
 var (
-	dbMu sync.RWMutex
-	db   *gorm.DB
+	dbMu    sync.RWMutex
+	db      *gorm.DB
+	nowFunc = time.Now
 )
 
 func getDB() *gorm.DB {
@@ -35,7 +44,7 @@ func openStore(path string) error {
 	if err != nil {
 		return err
 	}
-	return db.AutoMigrate(&UserBeveragePreference{})
+	return db.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{})
 }
 
 func closeStore() {
@@ -80,4 +89,37 @@ func setBeverageEmoji(userID, emoji string) error {
 	var pref UserBeveragePreference
 	result := d.Where(UserBeveragePreference{UserID: userID}).Assign(UserBeveragePreference{BeverageEmoji: emoji}).FirstOrCreate(&pref)
 	return result.Error
+}
+
+func hasGreetedToday(userID string) bool {
+	d := getDB()
+	if d == nil {
+		return false
+	}
+
+	now := nowFunc().Local()
+	year, month, day := now.Date()
+	startOfToday := time.Date(year, month, day, 0, 0, 0, 0, now.Location())
+	startOfTomorrow := startOfToday.AddDate(0, 0, 1)
+
+	var count int64
+	result := d.Model(&UserGreeting{}).
+		Where("user_id = ? AND greeted_at >= ? AND greeted_at < ?", userID, startOfToday, startOfTomorrow).
+		Count(&count)
+	if result.Error != nil {
+		slog.Error("coffee: error querying daily greeting", "error", result.Error, "userID", userID)
+		return false
+	}
+	return count > 0
+}
+
+func recordGreeting(userID string) error {
+	d := getDB()
+	if d == nil {
+		return errors.New("store not initialized")
+	}
+	return d.Create(&UserGreeting{
+		UserID:    userID,
+		GreetedAt: nowFunc(),
+	}).Error
 }

--- a/internal/coffee/store_test.go
+++ b/internal/coffee/store_test.go
@@ -2,6 +2,7 @@ package coffee
 
 import (
 	"testing"
+	"time"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -13,7 +14,7 @@ func openInMemoryStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open in-memory store: %v", err)
 	}
-	if err := gormDB.AutoMigrate(&UserBeveragePreference{}); err != nil {
+	if err := gormDB.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{}); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
 	dbMu.Lock()
@@ -27,6 +28,17 @@ func openInMemoryStore(t *testing.T) {
 			t.Logf("warning: failed to close test DB: %v", err)
 		}
 		db = nil
+	})
+}
+
+func useNow(t *testing.T, now time.Time) {
+	t.Helper()
+	previous := nowFunc
+	nowFunc = func() time.Time {
+		return now
+	}
+	t.Cleanup(func() {
+		nowFunc = previous
 	})
 }
 
@@ -77,5 +89,50 @@ func TestSetBeverageEmoji_Upsert(t *testing.T) {
 	d.Model(&UserBeveragePreference{}).Where("user_id = ?", "user2").Count(&count)
 	if count != 1 {
 		t.Errorf("expected 1 row, got %d (upsert created duplicate)", count)
+	}
+}
+
+func TestHasGreetedToday_UnknownUser(t *testing.T) {
+	openInMemoryStore(t)
+	useNow(t, time.Date(2026, 5, 3, 10, 0, 0, 0, time.Local))
+
+	if hasGreetedToday("unknown") {
+		t.Fatal("expected false for unknown user")
+	}
+}
+
+func TestHasGreetedToday_SameLocalDay(t *testing.T) {
+	openInMemoryStore(t)
+	now := time.Date(2026, 5, 3, 10, 0, 0, 0, time.Local)
+	useNow(t, now)
+
+	d := getDB()
+	if err := d.Create(&UserGreeting{
+		UserID:    "user1",
+		GreetedAt: time.Date(2026, 5, 3, 7, 30, 0, 0, time.Local),
+	}).Error; err != nil {
+		t.Fatalf("failed to create greeting: %v", err)
+	}
+
+	if !hasGreetedToday("user1") {
+		t.Fatal("expected true for greeting earlier on the same local day")
+	}
+}
+
+func TestHasGreetedToday_PreviousLocalDay(t *testing.T) {
+	openInMemoryStore(t)
+	now := time.Date(2026, 5, 3, 10, 0, 0, 0, time.Local)
+	useNow(t, now)
+
+	d := getDB()
+	if err := d.Create(&UserGreeting{
+		UserID:    "user1",
+		GreetedAt: time.Date(2026, 5, 2, 23, 59, 0, 0, time.Local),
+	}).Error; err != nil {
+		t.Fatalf("failed to create greeting: %v", err)
+	}
+
+	if hasGreetedToday("user1") {
+		t.Fatal("expected false for greeting on the previous local day")
 	}
 }


### PR DESCRIPTION
## Summary
- add persisted per-user greeting records for coffee greetings
- suppress duplicate greeting reactions within the same local calendar day
- keep special-day first greeting reactions intact and covered by tests

Fixes #124

## Tests
- env GOCACHE=/tmp/gocache-gidbig go test ./internal/coffee/...
- env GOCACHE=/tmp/gocache-gidbig make test