### PR TITLE
feat(coffee): implement one-time introductory DM

### DIFF
--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -16,6 +16,7 @@ var (
 	registeredCommand *discordgo.ApplicationCommand
 	isSpecialDay      = util.IsSpecial
 	reactOnMessage    = util.ReactOnMessage
+	sendIntroDM       = sendIntroDMFunc
 )
 
 func beverageEmojiFor(userID string) string {
@@ -91,11 +92,13 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			if hasGreetedToday(m.Author.ID) {
 				return
 			}
+
+			emoji := beverageEmojiFor(m.Author.ID)
 			if isSpecialDay() {
 				reactOnMessage(s, m.ChannelID, m.ID, string(util.Ae[util.RandomRange(0, len(util.Ae))]), "add")
 				reactOnMessage(s, m.ChannelID, m.ID, string(util.Cl), "add")
 			} else {
-				reactOnMessage(s, m.ChannelID, m.ID, beverageEmojiFor(m.Author.ID), "add")
+				reactOnMessage(s, m.ChannelID, m.ID, emoji, "add")
 				// faces
 				if m.Author.ID == "269898849714307073" {
 					reactOnMessage(s, m.ChannelID, m.ID, ":sidus:576309032789475328", "add")
@@ -104,6 +107,14 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 					reactOnMessage(s, m.ChannelID, m.ID, ":sikk:355329009824825355", "add")
 				}
 			}
+
+			if !isUserIntroduced(m.Author.ID) {
+				sendIntroDM(s, m.Author.ID, emoji)
+				if err := markUserIntroduced(m.Author.ID); err != nil {
+					slog.Error("coffee: failed to mark user as introduced", "error", err, "userID", m.Author.ID)
+				}
+			}
+
 			if err := recordGreeting(m.Author.ID); err != nil {
 				slog.Error("coffee: failed to record daily greeting", "error", err, "userID", m.Author.ID)
 			}
@@ -141,6 +152,8 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		userID = i.User.ID
 	}
 
+	introducedBefore := isUserIntroduced(userID)
+
 	if err := setBeverageEmoji(userID, emoji); err != nil {
 		slog.Error("coffee: failed to set beverage emoji", "error", err, "userID", userID)
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -160,4 +173,22 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			Flags:   discordgo.MessageFlagsEphemeral,
 		},
 	})
+
+	if !introducedBefore {
+		sendIntroDM(s, userID, emoji)
+	}
+}
+
+func sendIntroDMFunc(s *discordgo.Session, userID string, emoji string) {
+	channel, err := s.UserChannelCreate(userID)
+	if err != nil {
+		slog.Error("coffee: failed to create DM channel", "error", err, "userID", userID)
+		return
+	}
+
+	content := fmt.Sprintf("Your morning beverage is now %s ☑️\n\nWhenever you say 'moin', 'hallo' or similar, I'll greet you with your preferred beverage! You can change this anytime using the `/setbeverage` command. Enjoy your morning! ☀️", emoji)
+	_, err = s.ChannelMessageSend(channel.ID, content)
+	if err != nil {
+		slog.Error("coffee: failed to send intro DM", "error", err, "userID", userID)
+	}
 }

--- a/internal/coffee/coffee_test.go
+++ b/internal/coffee/coffee_test.go
@@ -69,6 +69,71 @@ func countGreetings(t *testing.T, userID string) int64 {
 	return count
 }
 
+type capturedDM struct {
+	userID string
+	emoji  string
+}
+
+func captureIntroDMs(t *testing.T) func() []capturedDM {
+	t.Helper()
+	previous := sendIntroDM
+	dms := []capturedDM{}
+	sendIntroDM = func(_ *discordgo.Session, userID string, emoji string) {
+		dms = append(dms, capturedDM{
+			userID: userID,
+			emoji:  emoji,
+		})
+	}
+	t.Cleanup(func() {
+		sendIntroDM = previous
+	})
+	return func() []capturedDM {
+		return dms
+	}
+}
+
+func TestOnMessageCreate_TriggersIntroDMOnFirstGreeting(t *testing.T) {
+	openInMemoryStore(t)
+	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(t, false)
+	_ = captureReactions(t)
+	getDMs := captureIntroDMs(t)
+
+	onMessageCreate(nil, greetingMessage("user_new", "moin"))
+
+	dms := getDMs()
+	if len(dms) != 1 {
+		t.Fatalf("expected 1 intro DM, got %d", len(dms))
+	}
+	if dms[0].userID != "user_new" {
+		t.Errorf("DM userID = %q, want user_new", dms[0].userID)
+	}
+	if dms[0].emoji != fallbackBeverage {
+		t.Errorf("DM emoji = %q, want %q", dms[0].emoji, fallbackBeverage)
+	}
+
+	if !isUserIntroduced("user_new") {
+		t.Error("expected user_new to be marked as introduced")
+	}
+}
+
+func TestOnMessageCreate_DoesNotTriggerIntroDMIfAlreadyIntroduced(t *testing.T) {
+	openInMemoryStore(t)
+	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(t, false)
+	_ = captureReactions(t)
+	getDMs := captureIntroDMs(t)
+
+	_ = setBeverageEmoji("user_old", "🧃") // sets introduced=true
+
+	onMessageCreate(nil, greetingMessage("user_old", "moin"))
+
+	dms := getDMs()
+	if len(dms) != 0 {
+		t.Fatalf("expected 0 intro DMs for introduced user, got %d", len(dms))
+	}
+}
+
 func isSpecialGreetingEmoji(emoji string) bool {
 	for _, ae := range util.Ae {
 		if emoji == string(ae) {
@@ -132,6 +197,7 @@ func TestOnMessageCreate_FirstGreetingReactsAndRecordsGreeting(t *testing.T) {
 	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
 	useSpecialDay(t, false)
 	getReactions := captureReactions(t)
+	_ = captureIntroDMs(t)
 
 	onMessageCreate(nil, greetingMessage("user1", "moin"))
 
@@ -155,6 +221,7 @@ func TestOnMessageCreate_DuplicateSameDayGreetingIsSuppressed(t *testing.T) {
 	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
 	useSpecialDay(t, false)
 	getReactions := captureReactions(t)
+	_ = captureIntroDMs(t)
 
 	onMessageCreate(nil, greetingMessage("user1", "moin"))
 	onMessageCreate(nil, greetingMessage("user1", "hi"))
@@ -173,6 +240,7 @@ func TestOnMessageCreate_PriorDayGreetingAllowsNextDayReaction(t *testing.T) {
 	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
 	useSpecialDay(t, false)
 	getReactions := captureReactions(t)
+	_ = captureIntroDMs(t)
 
 	d := getDB()
 	if err := d.Create(&UserGreeting{
@@ -198,6 +266,7 @@ func TestOnMessageCreate_SpecialDayFirstGreetingReactsAndRecordsGreeting(t *test
 	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
 	useSpecialDay(t, true)
 	getReactions := captureReactions(t)
+	_ = captureIntroDMs(t)
 
 	onMessageCreate(nil, greetingMessage("user1", "moin"))
 

--- a/internal/coffee/store.go
+++ b/internal/coffee/store.go
@@ -15,6 +15,7 @@ type UserBeveragePreference struct {
 	gorm.Model
 	UserID        string `gorm:"not null;uniqueIndex"`
 	BeverageEmoji string `gorm:"not null"`
+	HasSeenIntro  bool   `gorm:"not null;default:false"`
 }
 
 // UserGreeting records when a Discord user received their daily greeting reaction.
@@ -81,13 +82,41 @@ func getBeverageEmoji(userID string) (string, bool) {
 	return pref.BeverageEmoji, true
 }
 
+func isUserIntroduced(userID string) bool {
+	d := getDB()
+	if d == nil {
+		return false
+	}
+	var pref UserBeveragePreference
+	result := d.Where("user_id = ?", userID).First(&pref)
+	if result.Error != nil {
+		return false
+	}
+	return pref.HasSeenIntro
+}
+
+func markUserIntroduced(userID string) error {
+	d := getDB()
+	if d == nil {
+		return errors.New("store not initialized")
+	}
+	var pref UserBeveragePreference
+	// If it doesn't exist, we create it with fallbackBeverage and HasSeenIntro = true
+	return d.Where(UserBeveragePreference{UserID: userID}).
+		Attrs(UserBeveragePreference{BeverageEmoji: fallbackBeverage}).
+		Assign(UserBeveragePreference{HasSeenIntro: true}).
+		FirstOrCreate(&pref).Error
+}
+
 func setBeverageEmoji(userID, emoji string) error {
 	d := getDB()
 	if d == nil {
 		return errors.New("store not initialized")
 	}
 	var pref UserBeveragePreference
-	result := d.Where(UserBeveragePreference{UserID: userID}).Assign(UserBeveragePreference{BeverageEmoji: emoji}).FirstOrCreate(&pref)
+	result := d.Where(UserBeveragePreference{UserID: userID}).
+		Assign(UserBeveragePreference{BeverageEmoji: emoji, HasSeenIntro: true}).
+		FirstOrCreate(&pref)
 	return result.Error
 }
 

--- a/internal/coffee/store_test.go
+++ b/internal/coffee/store_test.go
@@ -55,6 +55,38 @@ func TestSetAndGetBeverageEmoji(t *testing.T) {
 	if emoji != "🍺" {
 		t.Errorf("got %q, want %q", emoji, "🍺")
 	}
+
+	if !isUserIntroduced("user1") {
+		t.Error("expected user1 to be introduced after setting beverage")
+	}
+}
+
+func TestIsUserIntroduced_UnknownUser(t *testing.T) {
+	openInMemoryStore(t)
+	if isUserIntroduced("unknown") {
+		t.Error("expected false for unknown user")
+	}
+}
+
+func TestMarkUserIntroduced(t *testing.T) {
+	openInMemoryStore(t)
+
+	if err := markUserIntroduced("user_intro"); err != nil {
+		t.Fatalf("markUserIntroduced: %v", err)
+	}
+
+	if !isUserIntroduced("user_intro") {
+		t.Error("expected user_intro to be introduced")
+	}
+
+	// Verify it sets fallback beverage if it didn't exist
+	emoji, ok := getBeverageEmoji("user_intro")
+	if !ok {
+		t.Fatal("expected beverage to be set (fallback)")
+	}
+	if emoji != fallbackBeverage {
+		t.Errorf("got %q, want %q", emoji, fallbackBeverage)
+	}
 }
 
 func TestGetBeverageEmoji_UnknownUser(t *testing.T) {


### PR DESCRIPTION
This PR implements a one-time introductory Direct Message for the coffee plugin.

### Changes:
- Added HasSeenIntro field to UserBeveragePreference store.
- Implemented isUserIntroduced and markUserIntroduced helpers.
- Updated onMessageCreate and onInteractionCreate to trigger an introductory DM on the first greeting or first beverage set.
- Refactored sendIntroDM to be mockable for testing.
- Added comprehensive unit tests for the new behavior.

Tag: v0.12.1