### PR TITLE
gippity: remove unsolicited random replies

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,5 +14,4 @@ gippity:
     allowed_guilds:
         - "YOUR_DISCORD_GUILD_ID"
     ignored_users: []
-    random_ignored_guilds: []
 dev_mode: true

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -27,9 +27,8 @@ type Config struct {
 		Port          int    `yaml:"port,omitempty" default:"8080"`
 	} `yaml:"web"`
 	Gippity struct {
-		AllowedGuilds       []string `yaml:"allowed_guilds"`
-		IgnoredUsers        []string `yaml:"ignored_users"`
-		RandomIgnoredGuilds []string `yaml:"random_ignored_guilds"`
+		AllowedGuilds []string `yaml:"allowed_guilds"`
+		IgnoredUsers  []string `yaml:"ignored_users"`
 	} `yaml:"gippity"`
 	DevMode bool `yaml:"dev_mode,omitempty" default:"false"`
 }

--- a/internal/gippity/gippity.go
+++ b/internal/gippity/gippity.go
@@ -16,14 +16,11 @@ import (
 
 var discordSession *discordgo.Session
 
-var messageCount int = 0
-var messageGoal int = 0
-var messageGoalRange [2]int = [2]int{10, 20}
+var generateAnswerFunc = generateAnswer
 
 var (
-	allowedGuildIDs       map[string]bool
-	ignoredUserIDs        map[string]bool
-	randomIgnoredGuildIDs map[string]bool
+	allowedGuildIDs map[string]bool
+	ignoredUserIDs  map[string]bool
 )
 
 var userMessageCount map[string]int
@@ -44,16 +41,12 @@ func Start(discord *discordgo.Session) {
 	config := cfg.GetConfig()
 	allowedGuildIDs = make(map[string]bool)
 	ignoredUserIDs = make(map[string]bool)
-	randomIgnoredGuildIDs = make(map[string]bool)
 
 	for _, id := range config.Gippity.AllowedGuilds {
 		allowedGuildIDs[id] = true
 	}
 	for _, id := range config.Gippity.IgnoredUsers {
 		ignoredUserIDs[id] = true
-	}
-	for _, id := range config.Gippity.RandomIgnoredGuilds {
-		randomIgnoredGuildIDs[id] = true
 	}
 
 	discordSession = discord
@@ -106,31 +99,18 @@ func limited(m *discordgo.MessageCreate) bool {
 		return true
 	}
 
-	if isMentioned(m) && !isLimitedUser(m) {
-		return false
-	}
-
-	if isMentioned(m) && isLimitedUser(m) {
-		slog.Info("not answering because of user limitation", "userMessageCount", userMessageCount[m.Author.ID], "userMessageLimit", userMessageLimit, "userMessageCountLastReset", userMessageCountLastReset[m.Author.ID])
-		_, err := discordSession.ChannelMessageSend(m.ChannelID, "Du hast heute schon genug Nachrichten geschrieben. Komm wann anders wieder.")
-		if err != nil {
-			slog.Info("Error while sending message", "error", err)
-		}
-		return true
-	}
-
-	if messageCount >= messageGoal || messageGoal == 0 {
-		if randomIgnoredGuildIDs[m.GuildID] {
-			// they don't want the bot to answer randomly in this guild
+	if isMentioned(m) {
+		if isLimitedUser(m) {
+			slog.Info("not answering because of user limitation", "userMessageCount", userMessageCount[m.Author.ID], "userMessageLimit", userMessageLimit, "userMessageCountLastReset", userMessageCountLastReset[m.Author.ID])
+			_, err := discordSession.ChannelMessageSend(m.ChannelID, "Du hast heute schon genug Nachrichten geschrieben. Komm wann anders wieder.")
+			if err != nil {
+				slog.Info("Error while sending message", "error", err)
+			}
 			return true
 		}
-		messageCount = 0
-		messageGoal = util.RandomRange(messageGoalRange[0], messageGoalRange[1])
 		return false
 	}
 
-	messageCount++
-	slog.Info("not answering because of message limitation", "messageCount", messageCount, "messageGoal", messageGoal)
 	return true
 }
 
@@ -161,7 +141,7 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 		if len(imageURLs) != 0 {
 			slog.Debug("Message has image attachments")
-			generatedAnswer, err = generateAnswer(m, imageURLs)
+			generatedAnswer, err = generateAnswerFunc(m, imageURLs)
 			if err != nil {
 				slog.Error("Could not generate answer")
 				return
@@ -171,7 +151,7 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	if len(m.Attachments) == 0 && m.Content != "" {
 		slog.Debug("Message has content but no attachments")
-		generatedAnswer, err = generateAnswer(m, nil)
+		generatedAnswer, err = generateAnswerFunc(m, nil)
 		if err != nil {
 			slog.Error("Could not generate answer")
 			return

--- a/internal/gippity/gippity_test.go
+++ b/internal/gippity/gippity_test.go
@@ -1,0 +1,110 @@
+package gippity
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func setupGippityTest(t *testing.T) *discordgo.Session {
+	t.Helper()
+
+	previousDatabase := database
+	previousDiscordSession := discordSession
+	previousAllowedGuildIDs := allowedGuildIDs
+	previousIgnoredUserIDs := ignoredUserIDs
+	previousUserMessageCount := userMessageCount
+	previousUserMessageCountLastReset := userMessageCountLastReset
+	previousGenerateAnswerFunc := generateAnswerFunc
+
+	testDB, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	if _, err := testDB.Exec(`CREATE TABLE chat_history (user_id text, channel_id text, timestamp integer, message text, message_id text, guild_id text)`); err != nil {
+		t.Fatalf("create chat_history table: %v", err)
+	}
+
+	state := discordgo.NewState()
+	state.User = &discordgo.User{ID: "bot-user"}
+	session := &discordgo.Session{State: state}
+
+	database = testDB
+	discordSession = session
+	allowedGuildIDs = map[string]bool{"allowed-guild": true}
+	ignoredUserIDs = map[string]bool{}
+	userMessageCount = map[string]int{}
+	userMessageCountLastReset = map[string]time.Time{}
+	generateAnswerFunc = generateAnswer
+
+	t.Cleanup(func() {
+		_ = testDB.Close()
+		database = previousDatabase
+		discordSession = previousDiscordSession
+		allowedGuildIDs = previousAllowedGuildIDs
+		ignoredUserIDs = previousIgnoredUserIDs
+		userMessageCount = previousUserMessageCount
+		userMessageCountLastReset = previousUserMessageCountLastReset
+		generateAnswerFunc = previousGenerateAnswerFunc
+	})
+
+	return session
+}
+
+func gippityTestMessage(content string, mentions ...*discordgo.User) *discordgo.MessageCreate {
+	return &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "1367540149316120650",
+			ChannelID: "channel-1",
+			GuildID:   "allowed-guild",
+			Content:   content,
+			Author: &discordgo.User{
+				ID:       "user-1",
+				Username: "Alice",
+			},
+			Mentions: mentions,
+		},
+	}
+}
+
+func TestOnMessageCreate_StoresNonMentionedMessageWithoutGeneratingAnswer(t *testing.T) {
+	session := setupGippityTest(t)
+	generateAnswerFunc = func(_ *discordgo.MessageCreate, _ []string) (string, error) {
+		t.Fatal("generateAnswerFunc should not be called for non-mentioned messages")
+		return "", nil
+	}
+
+	onMessageCreate(session, gippityTestMessage("ordinary channel message"))
+
+	var message string
+	err := database.QueryRow("SELECT message FROM chat_history WHERE message_id = ?", "1367540149316120650").Scan(&message)
+	if err != nil {
+		t.Fatalf("expected non-mentioned message to be stored: %v", err)
+	}
+	if message != "ordinary channel message" {
+		t.Errorf("stored message = %q, want %q", message, "ordinary channel message")
+	}
+	if len(userMessageCount) != 0 {
+		t.Errorf("non-mentioned message should not count toward mention rate limit, got %d users", len(userMessageCount))
+	}
+}
+
+func TestLimited_AllowsMentionedMessageInAllowedGuild(t *testing.T) {
+	setupGippityTest(t)
+
+	m := gippityTestMessage("hey <@bot-user>", &discordgo.User{ID: "bot-user"})
+
+	if limited(m) {
+		t.Fatal("mentioned message in allowed guild should not be limited")
+	}
+}
+
+func TestLimited_BlocksNonMentionedMessageInAllowedGuild(t *testing.T) {
+	setupGippityTest(t)
+
+	if !limited(gippityTestMessage("ordinary channel message")) {
+		t.Fatal("non-mentioned message in allowed guild should be limited")
+	}
+}


### PR DESCRIPTION
## Summary
- Remove gippity's random unsolicited response counter and guild suppression config
- Keep gippity responses gated to direct bot mentions in allowed guilds
- Add regression coverage for non-mentioned messages being stored without answer generation

Closes #139

## Tests
- go test ./internal/gippity
- go test ./internal/cfg ./internal/gippity
- git diff --check

Full suite note: go test ./... still fails in existing internal/core TestBanner_WritesToWriter because the ASCII banner output does not contain the literal string gidbig.