### PR TITLE
feat(core): replace !status with ephemeral /status slash command

### DIFF
--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -70,8 +70,12 @@ func buildBotStatsMessage(s *discordgo.Session) string {
 	runtime.ReadMemStats(&stats)
 
 	users := 0
-	for _, guild := range s.State.Guilds {
-		users += len(guild.Members)
+	servers := 0
+	if s.State != nil {
+		servers = len(s.State.Guilds)
+		for _, guild := range s.State.Guilds {
+			users += len(guild.Members)
+		}
 	}
 
 	uptime := time.Since(startTime).Round(time.Second)
@@ -118,7 +122,7 @@ Loaded Plugins:
 		humanize.Bytes(stats.HeapAlloc), humanize.Bytes(stats.HeapInuse), humanize.Bytes(stats.HeapSys),
 		humanize.Bytes(stats.HeapIdle), humanize.Bytes(stats.HeapReleased),
 		humanize.Bytes(stats.StackInuse), humanize.Bytes(stats.StackSys),
-		stats.Lookups, runtime.NumGoroutine(), len(s.State.Guilds), users, len(*gbploader.GetLoadedPlugins()), uptime, startDateTime)
+		stats.Lookups, runtime.NumGoroutine(), servers, users, len(*gbploader.GetLoadedPlugins()), uptime, startDateTime)
 
 	var sb strings.Builder
 	sb.WriteString(msg)

--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -38,6 +38,9 @@ var (
 
 	// Start time for uptime calculation
 	startTime = time.Now()
+
+	// registered slash command for /status
+	registeredStatusCmd *discordgo.ApplicationCommand
 )
 
 func onReady(s *discordgo.Session, event *discordgo.Ready) {
@@ -62,19 +65,19 @@ func displayUptime(channelid string) {
 	}
 }
 
-func displayBotStats(cid string) {
+func buildBotStatsMessage(s *discordgo.Session) string {
 	stats := runtime.MemStats{}
 	runtime.ReadMemStats(&stats)
 
 	users := 0
-	for _, guild := range discord.State.Guilds {
+	for _, guild := range s.State.Guilds {
 		users += len(guild.Members)
 	}
 
 	uptime := time.Since(startTime).Round(time.Second)
 	startDateTime := startTime.Format("2006-01-02 15:04:05")
 
-	statusMessage := fmt.Sprintf(`Gidbig:          %s
+	msg := fmt.Sprintf(`Gidbig:          %s
 Discordgo:       %s
 Go:              %s
 
@@ -115,15 +118,58 @@ Loaded Plugins:
 		humanize.Bytes(stats.HeapAlloc), humanize.Bytes(stats.HeapInuse), humanize.Bytes(stats.HeapSys),
 		humanize.Bytes(stats.HeapIdle), humanize.Bytes(stats.HeapReleased),
 		humanize.Bytes(stats.StackInuse), humanize.Bytes(stats.StackSys),
-		stats.Lookups, runtime.NumGoroutine(), len(discord.State.Guilds), users, len(*gbploader.GetLoadedPlugins()), uptime, startDateTime)
+		stats.Lookups, runtime.NumGoroutine(), len(s.State.Guilds), users, len(*gbploader.GetLoadedPlugins()), uptime, startDateTime)
 
+	var sb strings.Builder
+	sb.WriteString(msg)
 	for n, p := range *gbploader.GetLoadedPlugins() {
-		statusMessage += fmt.Sprintf("%s %s\n", n, p[0])
+		fmt.Fprintf(&sb, "%s %s\n", n, p[0])
 	}
 
-	_, err := discord.ChannelMessageSend(cid, "```"+statusMessage+"```")
-	if err != nil {
-		slog.Error("could not send channel message", "error", err)
+	return sb.String()
+}
+
+// statusInteractionResponse builds the ephemeral interaction response for /status.
+// Owner gets the stats block; non-owners get a denial. buildStats is injectable for testing.
+func statusInteractionResponse(userID, ownerID string, buildStats func() string) *discordgo.InteractionResponse {
+	if userID != ownerID {
+		return &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "Access denied.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		}
+	}
+	return &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: "```" + buildStats() + "```",
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	}
+}
+
+func onStatusInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type != discordgo.InteractionApplicationCommand {
+		return
+	}
+	if i.ApplicationCommandData().Name != "status" {
+		return
+	}
+
+	var userID string
+	if i.Member != nil {
+		userID = i.Member.User.ID
+	} else if i.User != nil {
+		userID = i.User.ID
+	}
+
+	resp := statusInteractionResponse(userID, conf.Discord.OwnerID, func() string {
+		return buildBotStatsMessage(s)
+	})
+	if err := s.InteractionRespond(i.Interaction, resp); err != nil {
+		slog.Error("could not respond to /status interaction", "error", err)
 	}
 }
 
@@ -190,9 +236,6 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// If this is a mention, it should come from the owner (otherwise we don't care)
 	if m.Author.ID == conf.Discord.OwnerID && len(parts) > 0 {
 		if len(parts) == 1 {
-			if scontains(parts[0], "!status") {
-				displayBotStats(m.ChannelID)
-			}
 			if scontains(parts[0], "!uptime") {
 				displayUptime(m.ChannelID)
 			}
@@ -284,12 +327,23 @@ func StartGidbig() {
 
 	discord.AddHandler(onReady)
 	discord.AddHandler(onMessageCreate)
+	discord.AddHandler(onStatusInteractionCreate)
 
 	err = discord.Open()
 	if err != nil {
 		slog.Error("Failed to create discord websocket connection", "error", err)
 		os.Exit(1)
 		return
+	}
+
+	statusCmd, err := discord.ApplicationCommandCreate(discord.State.User.ID, "", &discordgo.ApplicationCommand{
+		Name:        "status",
+		Description: "Show bot runtime status (owner only)",
+	})
+	if err != nil {
+		slog.Error("Failed to register /status command", "error", err)
+	} else {
+		registeredStatusCmd = statusCmd
 	}
 
 	llm.Initialize()
@@ -318,6 +372,11 @@ func StartGidbig() {
 	shutdownDone := make(chan struct{})
 	go func() {
 		defer close(shutdownDone)
+		if registeredStatusCmd != nil {
+			if err := discord.ApplicationCommandDelete(discord.State.User.ID, "", registeredStatusCmd.ID); err != nil {
+				slog.Error("Failed to delete /status command", "error", err)
+			}
+		}
 		if err := discord.Close(); err != nil {
 			slog.Error("error closing discord session", "error", err)
 		}

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/bwmarrin/discordgo"
 )
 
 func TestScontains(t *testing.T) {
@@ -165,5 +167,52 @@ func TestAddNewSoundCollection(t *testing.T) {
 	}
 	if len(COLLECTIONS[0].Sounds) != 1 || COLLECTIONS[0].Sounds[0].Name != "sound1" {
 		t.Errorf("Sounds[0].Name = %q, want %q", COLLECTIONS[0].Sounds[0].Name, "sound1")
+	}
+}
+
+func TestStatusInteractionResponse_Owner(t *testing.T) {
+	ownerID := "owner123"
+	statsOutput := "some stats"
+
+	resp := statusInteractionResponse(ownerID, ownerID, func() string { return statsOutput })
+
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if resp.Type != discordgo.InteractionResponseChannelMessageWithSource {
+		t.Errorf("Type = %v, want InteractionResponseChannelMessageWithSource", resp.Type)
+	}
+	if resp.Data.Flags != discordgo.MessageFlagsEphemeral {
+		t.Errorf("Flags = %v, want Ephemeral", resp.Data.Flags)
+	}
+	if !strings.Contains(resp.Data.Content, statsOutput) {
+		t.Errorf("Content %q does not contain stats output %q", resp.Data.Content, statsOutput)
+	}
+	if !strings.HasPrefix(resp.Data.Content, "```") || !strings.HasSuffix(resp.Data.Content, "```") {
+		t.Errorf("Content %q not wrapped in code block", resp.Data.Content)
+	}
+}
+
+func TestStatusInteractionResponse_NonOwner(t *testing.T) {
+	ownerID := "owner123"
+	callerID := "rando456"
+
+	called := false
+	resp := statusInteractionResponse(callerID, ownerID, func() string {
+		called = true
+		return "stats"
+	})
+
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if called {
+		t.Error("buildStats should not be called for non-owner")
+	}
+	if resp.Data.Flags != discordgo.MessageFlagsEphemeral {
+		t.Errorf("Flags = %v, want Ephemeral", resp.Data.Flags)
+	}
+	if resp.Data.Content != "Access denied." {
+		t.Errorf("Content = %q, want %q", resp.Data.Content, "Access denied.")
 	}
 }


### PR DESCRIPTION
## Summary

- Registers `/status` as a Discord ApplicationCommand on startup; deleted cleanly on shutdown
- Extracts `buildBotStatsMessage(s *discordgo.Session) string` — same stats block, now testable without a real channel send
- `statusInteractionResponse(userID, ownerID, buildStats)` handles access control: owner gets ephemeral code-block reply, non-owner gets ephemeral "Access denied." — `buildStats` never called for non-owners
- Removes the `!status` text-command path from `onMessageCreate`

Closes #138

## Test plan

- [ ] `go test ./internal/core/... -run TestStatus` — both owner and non-owner cases pass
- [ ] Full suite: `make test`
- [ ] Live: `/status` as owner → ephemeral stats block; as non-owner → ephemeral denial; no public message posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)