### PR TITLE
fix(wttrin): append LLM sentence after structured weather report

### DIFF
--- a/internal/wttrin/wttrin.go
+++ b/internal/wttrin/wttrin.go
@@ -321,15 +321,15 @@ func buildLLMWeatherOutro(s *discordgo.Session, m *discordgo.MessageCreate, loca
 		lang = "English"
 	}
 
-	systemPrompt := "You are a Discord bot. Write one sentence introducing the current weather for the given location — set the mood without repeating the raw numbers. " + llm.Personality + " Respond in " + lang + "."
+	systemPrompt := "You are a Discord bot. Write one sentence describing the current weather for the given location — set the mood without repeating the raw numbers. " + llm.Personality + " Respond in " + lang + "."
 	userPrompt := "Location: " + location + "\n" + weatherData
 
-	intro, err := generateLLMIntro(context.Background(), systemPrompt, userPrompt)
+	outro, err := generateLLMIntro(context.Background(), systemPrompt, userPrompt)
 	if err != nil {
-		slog.Warn("wttrin: LLM intro failed, skipping", "error", err)
+		slog.Warn("wttrin: LLM outro generation failed", "error", err)
 		return ""
 	}
-	return strings.TrimSpace(intro)
+	return strings.TrimSpace(outro)
 }
 
 func getWindDirectionEmoji(winddirDegree int) (windDirectionEmoji string) {

--- a/internal/wttrin/wttrin.go
+++ b/internal/wttrin/wttrin.go
@@ -245,6 +245,7 @@ type wttrinResponse struct {
 var (
 	detectLanguage   = llm.DetectChannelLanguage
 	generateLLMIntro = llm.GenerateMessage
+	getWeatherFn     = getWeather
 )
 
 // Start the plugin
@@ -289,7 +290,7 @@ func constructDiscordMessage(s *discordgo.Session, m *discordgo.MessageCreate, p
 	}
 
 	location := strings.Join(parts[1:], "+")
-	weatherResult, err := getWeather(location)
+	weatherResult, err := getWeatherFn(location)
 	if err != nil {
 		slog.Error("Failed to get weather", "MessageID", m.ID, "Location", location, "Error", err)
 		discordErrorMessage, err := s.ChannelMessageSend(m.ChannelID, "Failed to get weather for "+location+": "+err.Error())
@@ -306,14 +307,14 @@ func constructDiscordMessage(s *discordgo.Session, m *discordgo.MessageCreate, p
 		structured = buildWeatherString(weatherResult)
 	}
 
-	intro := buildLLMWeatherIntro(s, m, location, structured)
-	if intro != "" {
-		return intro + "\n" + structured
+	outro := buildLLMWeatherOutro(s, m, location, structured)
+	if outro != "" {
+		return structured + "\n" + outro
 	}
 	return structured
 }
 
-func buildLLMWeatherIntro(s *discordgo.Session, m *discordgo.MessageCreate, location, weatherData string) string {
+func buildLLMWeatherOutro(s *discordgo.Session, m *discordgo.MessageCreate, location, weatherData string) string {
 	lang, err := detectLanguage(s, m.ChannelID)
 	if err != nil {
 		slog.Warn("wttrin: language detection failed", "error", err)

--- a/internal/wttrin/wttrin_test.go
+++ b/internal/wttrin/wttrin_test.go
@@ -3,6 +3,7 @@ package wttrin
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
@@ -27,42 +28,51 @@ func stubDetectLanguage(t *testing.T, lang string) {
 	}
 }
 
-func TestBuildLLMWeatherIntro_PrependedOnSuccess(t *testing.T) {
+func stubGetWeather(t *testing.T, result wttrinResponse, err error) {
+	t.Helper()
+	prev := getWeatherFn
+	t.Cleanup(func() { getWeatherFn = prev })
+	getWeatherFn = func(_ string) (wttrinResponse, error) {
+		return result, err
+	}
+}
+
+func TestBuildLLMWeatherOutro_ReturnsOnSuccess(t *testing.T) {
 	stubDetectLanguage(t, "German")
 	stubLLM(t, "Das Wetter heute ist angenehm.", nil)
 
-	intro := buildLLMWeatherIntro(nil, &discordgo.MessageCreate{
+	outro := buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, "Berlin", "15°C sunny")
 
-	if intro != "Das Wetter heute ist angenehm." {
-		t.Errorf("unexpected intro: %q", intro)
+	if outro != "Das Wetter heute ist angenehm." {
+		t.Errorf("unexpected outro: %q", outro)
 	}
 }
 
-func TestBuildLLMWeatherIntro_EmptyOnLLMError(t *testing.T) {
+func TestBuildLLMWeatherOutro_EmptyOnLLMError(t *testing.T) {
 	stubDetectLanguage(t, "English")
 	stubLLM(t, "", errors.New("api error"))
 
-	intro := buildLLMWeatherIntro(nil, &discordgo.MessageCreate{
+	outro := buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, "London", "10°C rain")
 
-	if intro != "" {
-		t.Errorf("expected empty intro on LLM error, got %q", intro)
+	if outro != "" {
+		t.Errorf("expected empty outro on LLM error, got %q", outro)
 	}
 }
 
-func TestBuildLLMWeatherIntro_TrimsWhitespace(t *testing.T) {
+func TestBuildLLMWeatherOutro_TrimsWhitespace(t *testing.T) {
 	stubDetectLanguage(t, "English")
 	stubLLM(t, "  Nice weather!  ", nil)
 
-	intro := buildLLMWeatherIntro(nil, &discordgo.MessageCreate{
+	outro := buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, "London", "data")
 
-	if intro != "Nice weather!" {
-		t.Errorf("expected trimmed intro, got %q", intro)
+	if outro != "Nice weather!" {
+		t.Errorf("expected trimmed outro, got %q", outro)
 	}
 }
 
@@ -72,4 +82,175 @@ func TestDefaultsWiredToLLMPackage(t *testing.T) {
 		t.Error("generateLLMIntro must not be nil")
 	}
 	_ = llm.GenerateMessage // ensure llm package is referenced
+}
+
+func minimalWeatherResponse() wttrinResponse {
+	return wttrinResponse{
+		CurrentCondition: []struct {
+			FeelsLikeC       string `json:"FeelsLikeC"`
+			FeelsLikeF       string `json:"FeelsLikeF"`
+			Cloudcover       string `json:"cloudcover"`
+			Humidity         string `json:"humidity"`
+			LocalObsDateTime string `json:"localObsDateTime"`
+			ObservationTime  string `json:"observation_time"`
+			PrecipInches     string `json:"precipInches"`
+			PrecipMM         string `json:"precipMM"`
+			Pressure         string `json:"pressure"`
+			PressureInches   string `json:"pressureInches"`
+			TempC            string `json:"temp_C"`
+			TempF            string `json:"temp_F"`
+			UvIndex          string `json:"uvIndex"`
+			Visibility       string `json:"visibility"`
+			VisibilityMiles  string `json:"visibilityMiles"`
+			WeatherCode      string `json:"weatherCode"`
+			WeatherDesc      []struct {
+				Value string `json:"value"`
+			} `json:"weatherDesc"`
+			WeatherIconURL []struct {
+				Value string `json:"value"`
+			} `json:"weatherIconUrl"`
+			Winddir16Point string `json:"winddir16Point"`
+			WinddirDegree  string `json:"winddirDegree"`
+			WindspeedKmph  string `json:"windspeedKmph"`
+			WindspeedMiles string `json:"windspeedMiles"`
+		}{
+			{
+				TempC: "15", FeelsLikeC: "13", Humidity: "60",
+				WindspeedKmph: "20", WinddirDegree: "90",
+				WeatherCode: "113",
+				WeatherDesc: []struct {
+					Value string `json:"value"`
+				}{{Value: "Sunny"}},
+			},
+		},
+		NearestArea: []struct {
+			AreaName []struct {
+				Value string `json:"value"`
+			} `json:"areaName"`
+			Country []struct {
+				Value string `json:"value"`
+			} `json:"country"`
+			Latitude   string `json:"latitude"`
+			Longitude  string `json:"longitude"`
+			Population string `json:"population"`
+			Region     []struct {
+				Value string `json:"value"`
+			} `json:"region"`
+			WeatherURL []struct {
+				Value string `json:"value"`
+			} `json:"weatherUrl"`
+		}{
+			{
+				AreaName: []struct {
+					Value string `json:"value"`
+				}{{Value: "Berlin"}},
+				Country: []struct {
+					Value string `json:"value"`
+				}{{Value: "Germany"}},
+				Region: []struct {
+					Value string `json:"value"`
+				}{{Value: ""}},
+				Latitude: "52.5", Longitude: "13.4",
+			},
+		},
+		Weather: []struct {
+			Astronomy []struct {
+				MoonIllumination string `json:"moon_illumination"`
+				MoonPhase        string `json:"moon_phase"`
+				Moonrise         string `json:"moonrise"`
+				Moonset          string `json:"moonset"`
+				Sunrise          string `json:"sunrise"`
+				Sunset           string `json:"sunset"`
+			} `json:"astronomy"`
+			AvgtempC    string   `json:"avgtempC"`
+			AvgtempF    string   `json:"avgtempF"`
+			Date        string   `json:"date"`
+			Hourly      []hourly `json:"hourly"`
+			MaxtempC    string   `json:"maxtempC"`
+			MaxtempF    string   `json:"maxtempF"`
+			MintempC    string   `json:"mintempC"`
+			MintempF    string   `json:"mintempF"`
+			SunHour     string   `json:"sunHour"`
+			TotalSnowCm string   `json:"totalSnow_cm"`
+			UvIndex     string   `json:"uvIndex"`
+		}{
+			{
+				Date: "2026-05-04", MaxtempC: "18", MintempC: "10",
+				AvgtempC: "14", TotalSnowCm: "0",
+				Hourly: []hourly{
+					{
+						WinddirDegree: "90", WindspeedKmph: "20",
+						WeatherCode: "113",
+						WeatherDesc: []struct {
+							Value string `json:"value"`
+						}{{Value: "Sunny"}},
+						Chanceoffog: "0", Chanceoffrost: "0", Chanceofhightemp: "0",
+						Chanceofrain: "0", Chanceofsnow: "0", Chanceofthunder: "0",
+						Chanceofwindy: "0", PrecipMM: "0",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestConstructDiscordMessage_StructuredBeforeLLMOutro(t *testing.T) {
+	stubDetectLanguage(t, "English")
+	stubLLM(t, "Lovely day ahead!", nil)
+	stubGetWeather(t, minimalWeatherResponse(), nil)
+
+	msg := constructDiscordMessage(nil, &discordgo.MessageCreate{
+		Message: &discordgo.Message{ChannelID: "ch1"},
+	}, []string{"!wttr", "Berlin"}, &discordgo.Guild{}, false)
+
+	outroIdx := strings.Index(msg, "Lovely day ahead!")
+	if outroIdx == -1 {
+		t.Fatal("LLM outro missing from message")
+	}
+	structuredIdx := strings.Index(msg, "Berlin")
+	if structuredIdx == -1 {
+		t.Fatal("structured weather missing from message")
+	}
+	if structuredIdx > outroIdx {
+		t.Errorf("structured weather must appear before LLM outro: structuredIdx=%d outroIdx=%d", structuredIdx, outroIdx)
+	}
+}
+
+func TestConstructDiscordMessage_ForecastStructuredBeforeLLMOutro(t *testing.T) {
+	stubDetectLanguage(t, "English")
+	stubLLM(t, "Pack an umbrella!", nil)
+	stubGetWeather(t, minimalWeatherResponse(), nil)
+
+	msg := constructDiscordMessage(nil, &discordgo.MessageCreate{
+		Message: &discordgo.Message{ChannelID: "ch1"},
+	}, []string{"!wttrf", "Berlin"}, &discordgo.Guild{}, true)
+
+	outroIdx := strings.Index(msg, "Pack an umbrella!")
+	if outroIdx == -1 {
+		t.Fatal("LLM outro missing from forecast message")
+	}
+	structuredIdx := strings.Index(msg, "Berlin")
+	if structuredIdx == -1 {
+		t.Fatal("structured forecast missing from message")
+	}
+	if structuredIdx > outroIdx {
+		t.Errorf("structured forecast must appear before LLM outro: structuredIdx=%d outroIdx=%d", structuredIdx, outroIdx)
+	}
+}
+
+func TestConstructDiscordMessage_LLMFailureReturnsOnlyStructured(t *testing.T) {
+	stubDetectLanguage(t, "English")
+	stubLLM(t, "", errors.New("llm down"))
+	stubGetWeather(t, minimalWeatherResponse(), nil)
+
+	msg := constructDiscordMessage(nil, &discordgo.MessageCreate{
+		Message: &discordgo.Message{ChannelID: "ch1"},
+	}, []string{"!wttr", "Berlin"}, &discordgo.Guild{}, false)
+
+	if msg == "" {
+		t.Fatal("expected structured weather, got empty string")
+	}
+	if strings.Contains(msg, "llm down") {
+		t.Error("error message must not leak into output")
+	}
 }

--- a/internal/wttrin/wttrin_test.go
+++ b/internal/wttrin/wttrin_test.go
@@ -207,7 +207,7 @@ func TestConstructDiscordMessage_StructuredBeforeLLMOutro(t *testing.T) {
 	if outroIdx == -1 {
 		t.Fatal("LLM outro missing from message")
 	}
-	structuredIdx := strings.Index(msg, "Berlin")
+	structuredIdx := strings.Index(msg, "## 📍")
 	if structuredIdx == -1 {
 		t.Fatal("structured weather missing from message")
 	}
@@ -229,7 +229,7 @@ func TestConstructDiscordMessage_ForecastStructuredBeforeLLMOutro(t *testing.T) 
 	if outroIdx == -1 {
 		t.Fatal("LLM outro missing from forecast message")
 	}
-	structuredIdx := strings.Index(msg, "Berlin")
+	structuredIdx := strings.Index(msg, "### 📅")
 	if structuredIdx == -1 {
 		t.Fatal("structured forecast missing from message")
 	}


### PR DESCRIPTION
## Summary

- Flip ordering in `constructDiscordMessage`: structured weather now comes first, LLM sentence appended after
- Rename `buildLLMWeatherIntro` → `buildLLMWeatherOutro` since it's no longer a prefix
- Add `getWeatherFn` package-level var for testability
- Add 3 new ordering tests covering `!wttr`, `!wttrf`, and LLM failure fallback

Closes #140

## Test plan

- [ ] `go test ./internal/wttrin/...` — all 7 tests pass
- [ ] `!wttr <city>` shows structured report first, LLM sentence last
- [ ] `!wttrf <city>` shows structured forecast first, LLM sentence last
- [ ] LLM failure still returns usable weather report only

🤖 Generated with [Claude Code](https://claude.com/claude-code)