### PR TITLE
ci: skip bot-driven deployments

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -56,7 +56,18 @@ jobs:
 
     deploy:
         name: Deploy
-        if: ${{ github.event_name == 'push' }}
+        if: >-
+            ${{
+                github.event_name == 'workflow_dispatch' ||
+                (
+                    github.event_name == 'push' &&
+                    github.ref == 'refs/heads/master' &&
+                    github.actor != 'renovate[bot]' &&
+                    github.actor != 'dependabot[bot]' &&
+                    !startsWith(github.ref_name, 'renovate/') &&
+                    !startsWith(github.ref_name, 'dependabot/')
+                )
+            }}
         needs: build
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Summary:
- Restrict deploy job to manual dispatch or non-bot master pushes.
- Keep PR and branch checks intact for bot updates.

Tests:
- git diff --check
- python3 yaml parse
- make test (fails: pre-existing internal/core TestBanner_WritesToWriter expects literal gidbig in ASCII banner output)

Closes #146