### PR TITLE
fix(wttrin): use daily forecast weather codes

### DIFF
--- a/internal/wttrin/wttrin.go
+++ b/internal/wttrin/wttrin.go
@@ -396,13 +396,18 @@ func buildWeatherString(weatherResult wttrinResponse) (result string) {
 	return
 }
 
-func mostOccurringWeatherCode(hours []hourly) (mostOccurringCode string) {
+func mostOccurringWeatherCodeForDay(hours []hourly) string {
+	if len(hours) == 0 {
+		return ""
+	}
+
 	weatherCodeCounts := make(map[string]int)
 	for _, hour := range hours {
 		weatherCodeCounts[hour.WeatherCode]++
 	}
 
 	maxCount := 0
+	mostOccurringCode := ""
 	for code, count := range weatherCodeCounts {
 		if count > maxCount {
 			mostOccurringCode = code
@@ -410,7 +415,7 @@ func mostOccurringWeatherCode(hours []hourly) (mostOccurringCode string) {
 		}
 	}
 
-	return
+	return mostOccurringCode
 }
 
 func checkForHighChances(hourly []hourly) (highChances string) {
@@ -516,7 +521,7 @@ func buildForecastString(weatherResult wttrinResponse) (result string) {
 			result += "```\n"
 		}
 
-		weatherCode := mostOccurringWeatherCode(day.Hourly)
+		weatherCode := mostOccurringWeatherCodeForDay(day.Hourly)
 		weatherConditionEmoji := getWeatherConditionEmoji(weatherCode)
 
 		avgWindDirDegree := 0

--- a/internal/wttrin/wttrin.go
+++ b/internal/wttrin/wttrin.go
@@ -396,12 +396,10 @@ func buildWeatherString(weatherResult wttrinResponse) (result string) {
 	return
 }
 
-func mostOccurringWeatherCode(resp wttrinResponse) (mostOccurringCode string) {
+func mostOccurringWeatherCode(hours []hourly) (mostOccurringCode string) {
 	weatherCodeCounts := make(map[string]int)
-	for _, day := range resp.Weather {
-		for _, hour := range day.Hourly {
-			weatherCodeCounts[hour.WeatherCode]++
-		}
+	for _, hour := range hours {
+		weatherCodeCounts[hour.WeatherCode]++
 	}
 
 	maxCount := 0
@@ -518,7 +516,7 @@ func buildForecastString(weatherResult wttrinResponse) (result string) {
 			result += "```\n"
 		}
 
-		weatherCode := mostOccurringWeatherCode(weatherResult)
+		weatherCode := mostOccurringWeatherCode(day.Hourly)
 		weatherConditionEmoji := getWeatherConditionEmoji(weatherCode)
 
 		avgWindDirDegree := 0

--- a/internal/wttrin/wttrin_test.go
+++ b/internal/wttrin/wttrin_test.go
@@ -194,6 +194,35 @@ func minimalWeatherResponse() wttrinResponse {
 	}
 }
 
+func TestBuildForecastString_UsesEachDaysMostOccurringWeatherCode(t *testing.T) {
+	weatherResult := minimalWeatherResponse()
+	weatherResult.Weather[0].Hourly = append(weatherResult.Weather[0].Hourly,
+		weatherResult.Weather[0].Hourly[0],
+		weatherResult.Weather[0].Hourly[0],
+	)
+
+	secondDay := weatherResult.Weather[0]
+	secondDay.Date = "2026-05-05"
+	secondDay.MaxtempC = "12"
+	secondDay.MintempC = "7"
+	secondDay.Hourly = nil
+	for range 4 {
+		hour := weatherResult.Weather[0].Hourly[0]
+		hour.WeatherCode = "308"
+		secondDay.Hourly = append(secondDay.Hourly, hour)
+	}
+	weatherResult.Weather = append(weatherResult.Weather, secondDay)
+
+	forecast := buildForecastString(weatherResult)
+
+	if !strings.Contains(forecast, "### 📅 2026-05-04\n```\n🌡️ 18°C / 10°C\n🌬️ ➡️ 20km/h\n☀️ Sunny") {
+		t.Errorf("first day should use its own dominant weather code, got:\n%s", forecast)
+	}
+	if !strings.Contains(forecast, "### 📅 2026-05-05\n```\n🌡️ 12°C / 7°C\n🌬️ ➡️ 20km/h\n🌧️ Heavy Rain") {
+		t.Errorf("second day should use its own dominant weather code, got:\n%s", forecast)
+	}
+}
+
 func TestConstructDiscordMessage_StructuredBeforeLLMOutro(t *testing.T) {
 	stubDetectLanguage(t, "English")
 	stubLLM(t, "Lovely day ahead!", nil)

--- a/internal/wttrin/wttrin_test.go
+++ b/internal/wttrin/wttrin_test.go
@@ -223,6 +223,26 @@ func TestBuildForecastString_UsesEachDaysMostOccurringWeatherCode(t *testing.T) 
 	}
 }
 
+func TestMostOccurringWeatherCodeForDay_EmptyInput(t *testing.T) {
+	if got := mostOccurringWeatherCodeForDay(nil); got != "" {
+		t.Errorf("expected empty string for nil input, got %q", got)
+	}
+	if got := mostOccurringWeatherCodeForDay([]hourly{}); got != "" {
+		t.Errorf("expected empty string for empty slice, got %q", got)
+	}
+}
+
+func TestMostOccurringWeatherCodeForDay_ReturnsDominantCode(t *testing.T) {
+	hours := []hourly{
+		{WeatherCode: "113"},
+		{WeatherCode: "113"},
+		{WeatherCode: "308"},
+	}
+	if got := mostOccurringWeatherCodeForDay(hours); got != "113" {
+		t.Errorf("expected %q, got %q", "113", got)
+	}
+}
+
 func TestConstructDiscordMessage_StructuredBeforeLLMOutro(t *testing.T) {
 	stubDetectLanguage(t, "English")
 	stubLLM(t, "Lovely day ahead!", nil)


### PR DESCRIPTION
## Summary
- calculate forecast weather codes from each day hourly data
- add regression coverage for per-day dominant weather codes

## Tests
- go test ./internal/wttrin -count=1
- go test ./... (fails: existing internal/core TestBanner_WritesToWriter expects literal gidbig in ASCII banner output)

Closes #133