### PR TITLE
docs: rewrite README to reflect current codebase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,40 @@
-# Gidbig
+# Gidbig 🤖
 
 Gidbig is a Discord bot written in Go — soundboard playback in voice channels, AI chat, weather, time-based games, and more.
 
-## Features
+> **⚠️ Fair warning:** This project has evolved into an AI agent adventure park and LLM testing ground. Features have been written, reviewed, refactored, and occasionally broken by a rotating cast of AI models. The fact that it's still running is either a testament to Go's resilience or proof that LLMs are, at the very least, okayish at writing code. Possibly both. 🎢🦾
+
+## ✨ Features
 
 ### Core
 
-- **Ping/Pong** — type `ping` → bot replies `Pong!` (and vice versa)
-- **Soundboard** — plays pre-encoded `.dca` audio files in your voice channel
+- 🏓 **Ping/Pong** — type `ping` → bot replies `Pong!` (and vice versa)
+- 🔊 **Soundboard** — plays pre-encoded `.dca` audio files in your voice channel
   - `!<prefix>` — play a random sound from that collection
   - `!<prefix> <soundname>` — play a specific sound
   - `!list` — list all available sound collections
   - `!uptime` — show bot uptime
   - Files live in `audio/` as `{prefix}_{soundname}.dca`; optional `.txt` file with the same name adds a description
-- **Web UI** — browser interface to trigger sounds; requires Discord OAuth2 credentials in config
-- **`/status`** — slash command showing bot version and uptime
+- 🌐 **Web UI** — browser interface to trigger sounds; requires Discord OAuth2 credentials in config
+- 📊 **`/status`** — slash command showing bot version and uptime
 
-### Built-in plugins
+### 🔌 Built-in plugins
 
 | Plugin | What it does |
 |---|---|
-| **coffee** | Greets users with their preferred morning beverage when they say "moin", "hallo", etc. `/setbeverage <emoji>` to configure, `/brew` to trigger manually |
-| **eso** | `!eso` — Elder Scrolls Online utility commands |
-| **gamerstatus** | Rotates the bot's Discord custom status periodically |
-| **gippity** | AI chat via `/gippity`; backed by an LLM, stores conversation history in SQLite; restricted to configured guild IDs |
-| **leetoclock** | Daily 13:37 game — first to post in the channel wins; scores by reaction time; posts a scoreboard at end of game |
-| **stoll** | `!stoll` — Stoll-related commands |
-| **wttrin** | `!wttr <location>` / `!wttrf <location>` — current weather / forecast with an LLM-generated outro |
+| ☕ **coffee** | Greets users with their preferred morning beverage when they say "moin", "hallo", etc. `/setbeverage <emoji>` to configure, `/brew` to trigger manually |
+| 🗡️ **eso** | `!eso` — Elder Scrolls Online utility commands |
+| 🎮 **gamerstatus** | Rotates the bot's Discord custom status periodically |
+| 🤖 **gippity** | AI chat via `/gippity`; backed by an LLM, stores conversation history in SQLite; restricted to configured guild IDs |
+| 🕐 **leetoclock** | Daily 13:37 game — first to post in the channel wins; scores by reaction time; posts a scoreboard at end of game |
+| 🧌 **stoll** | `!stoll` — Stoll-related commands |
+| 🌤️ **wttrin** | `!wttr <location>` / `!wttrf <location>` — current weather / forecast with an LLM-generated outro |
 
-### Dynamic plugins
+### 🧩 Dynamic plugins
 
 Gidbig loads `.so` plugin files from `./plugins/` at startup. A plugin must export `Start(*discordgo.Session)`, `PluginName string`, and `PluginVersion string`.
 
-## Quickstart
+## 🚀 Quickstart
 
 ### 1. Configure
 
@@ -64,19 +66,19 @@ dev_mode: true
 
 The web server only starts when `web.port`, `web.oauth.client_id`, and `web.oauth.client_secret` are all set. `gippity.allowed_guilds` restricts which servers can use `/gippity`.
 
-### 2. Add audio files
+### 2. Add audio files 🎵
 
 Drop `.dca` files into `./audio/` following the naming scheme `{prefix}_{soundname}.dca`.  
 Example: `airhorn_default.dca` → `!airhorn default`
 
-### 3. Build and run
+### 3. Build and run 🔨
 
 ```bash
 make build
 ./bin/gidbig
 ```
 
-## Build
+## 🛠️ Build
 
 ```bash
 make build                    # Build binary → ./bin/gidbig
@@ -88,7 +90,7 @@ make update                   # go get -u -t ./... && go mod tidy
 make build_with_local_plugins # Build with local plugin path replacements (see Makefile)
 ```
 
-## Docker
+## 🐳 Docker
 
 ```bash
 make docker
@@ -102,12 +104,12 @@ docker run -it \
 
 Or use `docker-compose.yml` in the repo root.
 
-## Roadmap
+## 🗺️ Roadmap
 
-- **Migrate all `!`-prefix commands to Discord slash commands** — soundboard, `!wttr`, `!stoll`, `!eso`, etc.
-- **Remove dynamic plugin system** — retire the `.so` loader; consolidate everything into built-in plugins
-- **Refactor architecture** — move from the current event-handler-per-plugin pattern toward a cleaner command/handler abstraction
+- 🔀 **Migrate all `!`-prefix commands to Discord slash commands** — soundboard, `!wttr`, `!stoll`, `!eso`, etc.
+- 🗑️ **Remove dynamic plugin system** — retire the `.so` loader; consolidate everything into built-in plugins
+- 🏗️ **Refactor architecture** — move from the current event-handler-per-plugin pattern toward a cleaner command/handler abstraction
 
-## License
+## 📄 License
 
 See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Gidbig is a Discord bot written in Go — soundboard playback in voice channels,
 | Plugin | What it does |
 |---|---|
 | ☕ **coffee** | Greets users with their preferred morning beverage when they say "moin", "hallo", etc. `/setbeverage <emoji>` to configure, `/brew` to trigger manually |
-| 🗡️ **eso** | `!eso` — Elder Scrolls Online utility commands |
+| 🔮 **eso** | `!eso` — generates random esoteric pseudoscience nonsense: tachyonized homeopathic energy cards irradiated with scalar waves to combat the Illuminati mind control agenda |
 | 🎮 **gamerstatus** | Rotates the bot's Discord custom status periodically |
 | 🤖 **gippity** | AI chat via `/gippity`; backed by an LLM, stores conversation history in SQLite; restricted to configured guild IDs |
 | 🕐 **leetoclock** | Daily 13:37 game — first to post in the channel wins; scores by reaction time; posts a scoreboard at end of game |

--- a/README.md
+++ b/README.md
@@ -1,27 +1,113 @@
-# Gidbig 🤖
+# Gidbig
 
-Gidbig is a Discord Bot in Go based on
-[Airhorn Bot by Hammer and Chisel](https://github.com/discord/airhornbot/tree/golang).
+Gidbig is a Discord bot written in Go — soundboard playback in voice channels, AI chat, weather, time-based games, and more.
 
 ## Features
 
-* Plays Ping Pong with you, if you type "ping" or "pong" in any channel he has access to.
-* Airhorn-Feature to play sound files in the voice channel you are currently in.
-They are named after the scheme `command_soundname.dca` and would result in a channel command like `!command soundname` like in `!airhorn default`.
-Typing only the `!command` without an argument results in a random sound of this command's collection.
-* Comfortable web interface to trigger sounds
-* Automatically detect all `.dca` files in `audio/`
-* Optional sound descriptions via `.txt` files in `audio/` with the same name as the soundfile
-* Plugin functionality
-  * Example plugin: [gbp-wttrin](https://github.com/toksikk/gbp-wttrin/) (deprecated but still working)
+### Core
 
-## Building Docker image
+- **Ping/Pong** — type `ping` → bot replies `Pong!` (and vice versa)
+- **Soundboard** — plays pre-encoded `.dca` audio files in your voice channel
+  - `!<prefix>` — play a random sound from that collection
+  - `!<prefix> <soundname>` — play a specific sound
+  - `!list` — list all available sound collections
+  - `!uptime` — show bot uptime
+  - Files live in `audio/` as `{prefix}_{soundname}.dca`; optional `.txt` file with the same name adds a description
+- **Web UI** — browser interface to trigger sounds; requires Discord OAuth2 credentials in config
+- **`/status`** — slash command showing bot version and uptime
 
-From the root directory of this repo run the following commands.
+### Built-in plugins
+
+| Plugin | What it does |
+|---|---|
+| **coffee** | Greets users with their preferred morning beverage when they say "moin", "hallo", etc. `/setbeverage <emoji>` to configure, `/brew` to trigger manually |
+| **eso** | `!eso` — Elder Scrolls Online utility commands |
+| **gamerstatus** | Rotates the bot's Discord custom status periodically |
+| **gippity** | AI chat via `/gippity`; backed by an LLM, stores conversation history in SQLite; restricted to configured guild IDs |
+| **leetoclock** | Daily 13:37 game — first to post in the channel wins; scores by reaction time; posts a scoreboard at end of game |
+| **stoll** | `!stoll` — Stoll-related commands |
+| **wttrin** | `!wttr <location>` / `!wttrf <location>` — current weather / forecast with an LLM-generated outro |
+
+### Dynamic plugins
+
+Gidbig loads `.so` plugin files from `./plugins/` at startup. A plugin must export `Start(*discordgo.Session)`, `PluginName string`, and `PluginVersion string`.
+
+## Quickstart
+
+### 1. Configure
+
+```bash
+cp config.example.yaml config.yaml
+```
+
+Edit `config.yaml`:
+
+```yaml
+discord:
+    token: "YOUR_DISCORD_BOT_TOKEN"
+    owner_id: "YOUR_DISCORD_USER_ID"
+    shard_id: 0
+    shard_count: 0
+web:
+    oauth:
+        client_id: "YOUR_OAUTH_CLIENT_ID"
+        client_secret: "YOUR_OAUTH_CLIENT_SECRET"
+        redirect_uri: "YOUR_REDIRECT_URI"
+    session_secret: "base64-encoded-32-random-bytes"
+    port: 8080
+gippity:
+    allowed_guilds:
+        - "YOUR_DISCORD_GUILD_ID"
+    ignored_users: []
+dev_mode: true
+```
+
+The web server only starts when `web.port`, `web.oauth.client_id`, and `web.oauth.client_secret` are all set. `gippity.allowed_guilds` restricts which servers can use `/gippity`.
+
+### 2. Add audio files
+
+Drop `.dca` files into `./audio/` following the naming scheme `{prefix}_{soundname}.dca`.  
+Example: `airhorn_default.dca` → `!airhorn default`
+
+### 3. Build and run
+
+```bash
+make build
+./bin/gidbig
+```
+
+## Build
+
+```bash
+make build                    # Build binary → ./bin/gidbig
+make test                     # go test -v ./...
+make lint                     # golangci-lint run ./...
+make release                  # Cross-compile: linux/amd64, arm64, 386, arm and darwin/amd64
+make docker                   # Build Docker image
+make update                   # go get -u -t ./... && go mod tidy
+make build_with_local_plugins # Build with local plugin path replacements (see Makefile)
+```
+
+## Docker
 
 ```bash
 make docker
 
-# run container with mounted config.yaml file
-docker run -it --mount type=bind,source=$(pwd)/config.yaml,target=/gidbig/config.yaml gidbig:$(git describe --tags)
+# Run with mounted config and audio directory
+docker run -it \
+  --mount type=bind,source=$(pwd)/config.yaml,target=/gidbig/config.yaml \
+  --mount type=bind,source=$(pwd)/audio,target=/gidbig/audio \
+  gidbig:$(git describe --tags)
 ```
+
+Or use `docker-compose.yml` in the repo root.
+
+## Roadmap
+
+- **Migrate all `!`-prefix commands to Discord slash commands** — soundboard, `!wttr`, `!stoll`, `!eso`, etc.
+- **Remove dynamic plugin system** — retire the `.so` loader; consolidate everything into built-in plugins
+- **Refactor architecture** — move from the current event-handler-per-plugin pattern toward a cleaner command/handler abstraction
+
+## License
+
+See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Replaces stale Airhorn Bot lineage reference with accurate description
- Documents all built-in plugins (coffee, eso, gamerstatus, gippity, leetoclock, stoll, wttrin) with commands
- Adds quickstart / configuration section based on `config.example.yaml`
- Lists all `make` targets
- Fixes Docker run command (adds audio mount)
- Adds Roadmap section: slash-command migration, `.so` plugin removal, architecture refactor

Closes #153

## Test plan

- [ ] Read through README and verify each command/feature matches the codebase
- [ ] Verify config block matches `config.example.yaml`
- [ ] Verify make targets match Makefile

🤖 Generated with [Claude Code](https://claude.com/claude-code)