### PR TITLE
ci: skip lint and build when no Go files changed

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -19,9 +19,32 @@ jobs:
               id: determine_go_version
               run: echo "go_version=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_OUTPUT
 
+    detect_changes:
+        name: Detect file changes
+        runs-on: ubuntu-latest
+
+        outputs:
+            go: ${{ steps.filter.outputs.go }}
+
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      go:
+                        - '**/*.go'
+                        - 'go.mod'
+                        - 'go.sum'
+                        - 'Makefile'
+
     check_code:
         name: Check code
-        needs: preparation
+        needs:
+            - preparation
+            - detect_changes
+        if: needs.detect_changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
 
         steps:
@@ -40,6 +63,8 @@ jobs:
         needs:
             - check_code
             - preparation
+            - detect_changes
+        if: needs.detect_changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
## Summary

- Adds `detect_changes` job using `dorny/paths-filter@v3`
- `check_code` and `build` only run when `**/*.go`, `go.mod`, `go.sum`, or `Makefile` change
- `workflow_dispatch` bypasses the filter so manual deploys always run full pipeline
- `deploy` naturally skips when `build` skips (no redeploy needed for doc-only changes)

## Test plan

- [ ] Push a doc-only change — `Check code` and `Build` should be skipped
- [ ] Push a `.go` file change — all jobs run as before
- [ ] Trigger `workflow_dispatch` manually — all jobs run regardless of changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)