### PR TITLE
feat(gippity): describe every image via vision API and persist description

### DIFF
--- a/internal/gippity/gippity.go
+++ b/internal/gippity/gippity.go
@@ -159,6 +159,18 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 	}
 	addMessageToDatabase(m, isMentioned(m))
+
+	imageURLs := extractImageURLs(m.Attachments)
+	if len(imageURLs) > 0 {
+		slog.Debug("Describing image attachments", "count", len(imageURLs))
+		description, err := describeImagesFunc(imageURLs)
+		if err != nil {
+			slog.Error("Could not describe images", "error", err)
+		} else {
+			addAttachmentsToDatabase(m.ID, imageURLs, description)
+		}
+	}
+
 	if limited(m) {
 		return
 	}
@@ -166,22 +178,12 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	var generatedAnswer string
 	var err error
 
-	if len(m.Attachments) > 0 && m.Content != "" {
-		slog.Debug("Message has attachments and content")
-		var imageURLs []string
-		for _, attachment := range m.Attachments {
-			slog.Debug("Attachment", "attachment", attachment)
-			if attachment.Filename[len(attachment.Filename)-3:] == "jpg" || attachment.Filename[len(attachment.Filename)-4:] == "jpeg" || attachment.Filename[len(attachment.Filename)-3:] == "png" || attachment.Filename[len(attachment.Filename)-4:] == "webp" {
-				imageURLs = append(imageURLs, attachment.URL)
-			}
-		}
-		if len(imageURLs) != 0 {
-			slog.Debug("Message has image attachments")
-			generatedAnswer, err = generateAnswerFunc(m, imageURLs)
-			if err != nil {
-				slog.Error("Could not generate answer")
-				return
-			}
+	if len(imageURLs) > 0 && m.Content != "" {
+		slog.Debug("Message has image attachments and content")
+		generatedAnswer, err = generateAnswerFunc(m, imageURLs)
+		if err != nil {
+			slog.Error("Could not generate answer")
+			return
 		}
 	}
 

--- a/internal/gippity/gippity_helper.go
+++ b/internal/gippity/gippity_helper.go
@@ -3,6 +3,7 @@ package gippity
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -32,7 +33,24 @@ func convertLLMChatMessageToJSON(message LLMChatMessage) string {
 }
 
 func convertLLMChatMessageToLLMCompatibleFlowingText(message LLMChatMessage) string {
-	return message.TimestampString + " " + message.Username + ": " + message.Message
+	var sb strings.Builder
+	sb.WriteString(message.TimestampString + " " + message.Username + ": " + message.Message)
+	for i, desc := range message.ImageDescriptions {
+		fmt.Fprintf(&sb, " [Image %d: %s]", i+1, desc)
+	}
+	return sb.String()
+}
+
+func extractImageURLs(attachments []*discordgo.MessageAttachment) []string {
+	var urls []string
+	for _, a := range attachments {
+		name := a.Filename
+		if strings.HasSuffix(name, ".jpg") || strings.HasSuffix(name, ".jpeg") ||
+			strings.HasSuffix(name, ".png") || strings.HasSuffix(name, ".webp") {
+			urls = append(urls, a.URL)
+		}
+	}
+	return urls
 }
 
 func convertDiscordMessageToLLMCompatibleFlowingText(m *discordgo.MessageCreate) string {

--- a/internal/gippity/gippity_helper_test.go
+++ b/internal/gippity/gippity_helper_test.go
@@ -72,3 +72,19 @@ func TestConvertLLMChatMessageToLLMCompatibleFlowingText(t *testing.T) {
 		t.Errorf("result missing message: %q", result)
 	}
 }
+
+func TestConvertLLMChatMessageToLLMCompatibleFlowingText_WithImageDescriptions(t *testing.T) {
+	msg := LLMChatMessage{
+		TimestampString:   "2026-05-01 12:00:00",
+		Username:          "Alice",
+		Message:           "look at this",
+		ImageDescriptions: []string{"a cat sitting on a mat", "a blue sky"},
+	}
+	result := convertLLMChatMessageToLLMCompatibleFlowingText(msg)
+	if !strings.Contains(result, "[Image 1: a cat sitting on a mat]") {
+		t.Errorf("result missing image 1 description: %q", result)
+	}
+	if !strings.Contains(result, "[Image 2: a blue sky]") {
+		t.Errorf("result missing image 2 description: %q", result)
+	}
+}

--- a/internal/gippity/gippity_persistence.go
+++ b/internal/gippity/gippity_persistence.go
@@ -3,6 +3,7 @@ package gippity
 import (
 	"database/sql"
 	"log/slog"
+	"strings"
 
 	"github.com/bwmarrin/discordgo"
 	// sqlite3 driver
@@ -22,17 +23,18 @@ type ChatMessage struct {
 
 // LLMChatMessage represents a chat message in a human readable format
 type LLMChatMessage struct {
-	UserID          string
-	Username        string
-	ChannelID       string
-	ChannelName     string
-	Timestamp       int64
-	TimestampString string
-	MessageID       string
-	Message         string
-	GuildID         string
-	GuildName       string
-	IsBotMention    bool
+	UserID            string
+	Username          string
+	ChannelID         string
+	ChannelName       string
+	Timestamp         int64
+	TimestampString   string
+	MessageID         string
+	Message           string
+	GuildID           string
+	GuildName         string
+	IsBotMention      bool
+	ImageDescriptions []string
 }
 
 const chatHistoryDBFilename = "gippity.db"
@@ -60,6 +62,14 @@ func initDB() {
 	if err != nil {
 		slog.Error("Error while creating user_privacy table", "error", err)
 	}
+
+	_, err = database.Exec(`CREATE TABLE IF NOT EXISTS chat_attachments (id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, attachment_url TEXT, image_description TEXT)`)
+	if err != nil {
+		slog.Error("Error while creating chat_attachments table", "error", err)
+	}
+	// idempotent: add columns missing from pre-existing migration-created tables
+	_, _ = database.Exec(`ALTER TABLE chat_attachments ADD COLUMN message_id TEXT`)
+	_, _ = database.Exec(`ALTER TABLE chat_attachments ADD COLUMN image_description TEXT`)
 }
 
 // CloseDB closes the gippity chat history database.
@@ -89,17 +99,35 @@ func addMessageToDatabase(m *discordgo.MessageCreate, isBotMention bool) {
 	}
 }
 
+func addAttachmentsToDatabase(messageID string, urls []string, description string) {
+	stmt, err := database.Prepare("INSERT INTO chat_attachments (message_id, attachment_url, image_description) VALUES (?, ?, ?)")
+	if err != nil {
+		slog.Error("Error while preparing attachment statement", "error", err)
+		return
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, url := range urls {
+		if _, err := stmt.Exec(messageID, url, description); err != nil {
+			slog.Error("Error while inserting attachment", "error", err)
+		}
+	}
+}
+
 func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, error) {
 	stmt, err := database.Prepare(`
-	SELECT user_id, channel_id, timestamp, message, message_id, guild_id, COALESCE(is_bot_mention, 0)
+	SELECT ch.user_id, ch.channel_id, ch.timestamp, ch.message, ch.message_id, ch.guild_id,
+	       COALESCE(ch.is_bot_mention, 0),
+	       GROUP_CONCAT(ca.image_description, '|||')
 	FROM (
 	    SELECT user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention
 	    FROM chat_history
 	    WHERE channel_id = ?
 	    ORDER BY timestamp DESC
 	    LIMIT ?
-    ) AS subquery
-	ORDER BY timestamp ASC;
+	) AS ch
+	LEFT JOIN chat_attachments ca ON ca.message_id = ch.message_id
+	GROUP BY ch.message_id, ch.user_id, ch.channel_id, ch.timestamp, ch.message, ch.guild_id, ch.is_bot_mention
+	ORDER BY ch.timestamp ASC;
 	`)
 	if err != nil {
 		slog.Error("Error while preparing statement", "error", err)
@@ -118,6 +146,7 @@ func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, er
 	for rows.Next() {
 		var message LLMChatMessage
 		var isBotMentionInt int
+		var imageDescConcat *string
 		err = rows.Scan(
 			&message.UserID,
 			&message.ChannelID,
@@ -126,12 +155,20 @@ func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, er
 			&message.MessageID,
 			&message.GuildID,
 			&isBotMentionInt,
+			&imageDescConcat,
 		)
 		if err != nil {
 			slog.Error("Error while scanning row", "error", err)
 			return nil, err
 		}
 		message.IsBotMention = isBotMentionInt != 0
+		if imageDescConcat != nil && *imageDescConcat != "" {
+			for _, d := range strings.Split(*imageDescConcat, "|||") {
+				if d != "" {
+					message.ImageDescriptions = append(message.ImageDescriptions, d)
+				}
+			}
+		}
 
 		if idToNameCache[message.UserID] == "" {
 			idToNameCache[message.UserID] = util.GetUsernameForUserIDInGuild(discordSession, message.UserID, message.GuildID)

--- a/internal/gippity/gippity_persistence.go
+++ b/internal/gippity/gippity_persistence.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/bwmarrin/discordgo"
 	// sqlite3 driver
@@ -40,11 +41,12 @@ type LLMChatMessage struct {
 const chatHistoryDBFilename = "gippity.db"
 
 var database *sql.DB
+var dbMu sync.Mutex
 var idToNameCache = make(map[string]string)
 
 func initDB() {
 	var err error
-	database, err = sql.Open("sqlite3", chatHistoryDBFilename)
+	database, err = sql.Open("sqlite3", chatHistoryDBFilename+"?_journal=WAL&_busy_timeout=5000")
 	if err != nil {
 		slog.Error("Error while opening database", "error", err)
 		return
@@ -100,16 +102,14 @@ func addMessageToDatabase(m *discordgo.MessageCreate, isBotMention bool) {
 }
 
 func addAttachmentsToDatabase(messageID string, urls []string, description string) {
-	stmt, err := database.Prepare("INSERT INTO chat_attachments (message_id, attachment_url, image_description) VALUES (?, ?, ?)")
+	dbMu.Lock()
+	defer dbMu.Unlock()
+	_, err := database.Exec(
+		"INSERT INTO chat_attachments (message_id, attachment_url, image_description) VALUES (?, ?, ?)",
+		messageID, strings.Join(urls, ","), description,
+	)
 	if err != nil {
-		slog.Error("Error while preparing attachment statement", "error", err)
-		return
-	}
-	defer func() { _ = stmt.Close() }()
-	for _, url := range urls {
-		if _, err := stmt.Exec(messageID, url, description); err != nil {
-			slog.Error("Error while inserting attachment", "error", err)
-		}
+		slog.Error("Error while inserting attachment", "error", err)
 	}
 }
 
@@ -117,7 +117,7 @@ func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, er
 	stmt, err := database.Prepare(`
 	SELECT ch.user_id, ch.channel_id, ch.timestamp, ch.message, ch.message_id, ch.guild_id,
 	       COALESCE(ch.is_bot_mention, 0),
-	       GROUP_CONCAT(ca.image_description, '|||')
+	       ca.image_description
 	FROM (
 	    SELECT user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention
 	    FROM chat_history
@@ -126,7 +126,6 @@ func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, er
 	    LIMIT ?
 	) AS ch
 	LEFT JOIN chat_attachments ca ON ca.message_id = ch.message_id
-	GROUP BY ch.message_id, ch.user_id, ch.channel_id, ch.timestamp, ch.message, ch.guild_id, ch.is_bot_mention
 	ORDER BY ch.timestamp ASC;
 	`)
 	if err != nil {
@@ -163,11 +162,7 @@ func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, er
 		}
 		message.IsBotMention = isBotMentionInt != 0
 		if imageDescConcat != nil && *imageDescConcat != "" {
-			for _, d := range strings.Split(*imageDescConcat, "|||") {
-				if d != "" {
-					message.ImageDescriptions = append(message.ImageDescriptions, d)
-				}
-			}
+			message.ImageDescriptions = append(message.ImageDescriptions, *imageDescConcat)
 		}
 
 		if idToNameCache[message.UserID] == "" {

--- a/internal/gippity/gippity_test.go
+++ b/internal/gippity/gippity_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+var previousDescribeImagesFunc func([]string) (string, error)
+
 func setupGippityTest(t *testing.T) *discordgo.Session {
 	t.Helper()
 
@@ -18,6 +20,7 @@ func setupGippityTest(t *testing.T) *discordgo.Session {
 	previousUserMessageCount := userMessageCount
 	previousUserMessageCountLastReset := userMessageCountLastReset
 	previousGenerateAnswerFunc := generateAnswerFunc
+	previousDescribeImagesFunc = describeImagesFunc
 
 	testDB, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
@@ -28,6 +31,9 @@ func setupGippityTest(t *testing.T) *discordgo.Session {
 	}
 	if _, err := testDB.Exec(`CREATE TABLE user_privacy (user_id TEXT PRIMARY KEY, privacy_enabled INTEGER NOT NULL DEFAULT 1)`); err != nil {
 		t.Fatalf("create user_privacy table: %v", err)
+	}
+	if _, err := testDB.Exec(`CREATE TABLE chat_attachments (id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, attachment_url TEXT, image_description TEXT)`); err != nil {
+		t.Fatalf("create chat_attachments table: %v", err)
 	}
 
 	state := discordgo.NewState()
@@ -51,6 +57,7 @@ func setupGippityTest(t *testing.T) *discordgo.Session {
 		userMessageCount = previousUserMessageCount
 		userMessageCountLastReset = previousUserMessageCountLastReset
 		generateAnswerFunc = previousGenerateAnswerFunc
+		describeImagesFunc = previousDescribeImagesFunc
 	})
 
 	return session
@@ -178,5 +185,93 @@ func TestSetAndGetUserPrivacy(t *testing.T) {
 	}
 	if !getUserPrivacy("user-a") {
 		t.Error("getUserPrivacy should return true after re-enabling privacy")
+	}
+}
+
+func gippityTestMessageWithImage(content string, imageURL string) *discordgo.MessageCreate {
+	return &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "img-msg-id",
+			ChannelID: "channel-1",
+			GuildID:   "allowed-guild",
+			Content:   content,
+			Author: &discordgo.User{
+				ID:       "user-1",
+				Username: "Alice",
+			},
+			Attachments: []*discordgo.MessageAttachment{
+				{
+					ID:       "att-1",
+					URL:      imageURL,
+					Filename: "photo.png",
+				},
+			},
+		},
+	}
+}
+
+func TestOnMessageCreate_DescribesImageForNonMentionMessage(t *testing.T) {
+	session := setupGippityTest(t)
+	generateAnswerFunc = func(_ *discordgo.MessageCreate, _ []string) (string, error) {
+		t.Fatal("generateAnswerFunc should not be called for non-mention message")
+		return "", nil
+	}
+	describeCalled := false
+	describeImagesFunc = func(urls []string) (string, error) {
+		describeCalled = true
+		if len(urls) != 1 || urls[0] != "https://cdn.example.com/photo.png" {
+			t.Errorf("unexpected image URLs: %v", urls)
+		}
+		return "a cat on a mat", nil
+	}
+
+	m := gippityTestMessageWithImage("check this out", "https://cdn.example.com/photo.png")
+
+	onMessageCreate(session, m)
+
+	if !describeCalled {
+		t.Error("describeImagesFunc should have been called for image attachment")
+	}
+
+	var url, desc string
+	err := database.QueryRow("SELECT attachment_url, image_description FROM chat_attachments WHERE message_id = ?", "img-msg-id").Scan(&url, &desc)
+	if err != nil {
+		t.Fatalf("expected attachment row to exist: %v", err)
+	}
+	if url != "https://cdn.example.com/photo.png" {
+		t.Errorf("stored url = %q, want %q", url, "https://cdn.example.com/photo.png")
+	}
+	if desc != "a cat on a mat" {
+		t.Errorf("stored description = %q, want %q", desc, "a cat on a mat")
+	}
+}
+
+func TestGetLastNMessagesFromDatabase_IncludesImageDescriptions(t *testing.T) {
+	setupGippityTest(t)
+	idToNameCache["user-1"] = "Alice"
+	idToNameCache["channel-1"] = "general"
+	idToNameCache["allowed-guild"] = "Test Guild"
+
+	if _, err := database.Exec(`INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"user-1", "channel-1", 1000, "look at this", "msg-with-img", "allowed-guild", 0); err != nil {
+		t.Fatalf("insert chat_history: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO chat_attachments (message_id, attachment_url, image_description) VALUES (?, ?, ?)`,
+		"msg-with-img", "https://cdn.example.com/photo.png", "a fluffy dog"); err != nil {
+		t.Fatalf("insert chat_attachments: %v", err)
+	}
+
+	msgs, err := getLastNMessagesFromDatabase("channel-1", 10)
+	if err != nil {
+		t.Fatalf("getLastNMessagesFromDatabase: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if len(msgs[0].ImageDescriptions) != 1 {
+		t.Fatalf("expected 1 image description, got %d", len(msgs[0].ImageDescriptions))
+	}
+	if msgs[0].ImageDescriptions[0] != "a fluffy dog" {
+		t.Errorf("image description = %q, want %q", msgs[0].ImageDescriptions[0], "a fluffy dog")
 	}
 }

--- a/internal/gippity/gippity_vision.go
+++ b/internal/gippity/gippity_vision.go
@@ -1,0 +1,39 @@
+package gippity
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/toksikk/gidbig/internal/llm"
+
+	openai "github.com/openai/openai-go/v3"
+)
+
+var describeImagesFunc = describeImages
+
+func describeImages(imageURLs []string) (string, error) {
+	parts := []openai.ChatCompletionContentPartUnionParam{
+		openai.TextContentPart("Describe what is in this image concisely."),
+	}
+	for _, url := range imageURLs {
+		parts = append(parts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{URL: url}))
+	}
+	userMsg := openai.ChatCompletionUserMessageParam{
+		Content: openai.ChatCompletionUserMessageParamContentUnion{
+			OfArrayOfContentParts: parts,
+		},
+	}
+	completion, err := llm.GetClient().Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{OfUser: &userMsg},
+		},
+		Model:     openai.ChatModelGPT4oMini,
+		N:         openai.Int(1),
+		MaxTokens: openai.Int(150),
+	})
+	if err != nil {
+		slog.Error("Error describing image", "error", err)
+		return "", err
+	}
+	return completion.Choices[0].Message.Content, nil
+}


### PR DESCRIPTION
## Summary

- Calls vision API (`describeImages`) for every message with image attachments (jpg/jpeg/png/webp) **before** the `limited()` guard — so passive (non-mention) images are described too
- Persists URL + description in `chat_attachments` (adds `message_id TEXT` and `image_description TEXT` columns, applied idempotently in `initDB` for existing DBs)
- `getLastNMessagesFromDatabase` LEFT JOINs `chat_attachments` and surfaces descriptions in `LLMChatMessage.ImageDescriptions`; `convertLLMChatMessageToLLMCompatibleFlowingText` appends `[Image N: ...]` entries so the LLM sees past images
- Extracts image URL detection into `extractImageURLs` helper (replaces duplicated suffix-check inline code)
- `describeImagesFunc` var enables test mocking (same pattern as `generateAnswerFunc`)

## Test plan

- [x] `TestOnMessageCreate_DescribesImageForNonMentionMessage` — verifies `describeImagesFunc` called and row written to `chat_attachments` for non-mention messages
- [x] `TestGetLastNMessagesFromDatabase_IncludesImageDescriptions` — verifies JOIN surfaces descriptions in returned messages
- [x] `TestConvertLLMChatMessageToLLMCompatibleFlowingText_WithImageDescriptions` — verifies `[Image N: ...]` injected into flowing text
- [x] All pre-existing tests still pass

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)