### PR TITLE
feat(gippity): persist message edits and track edit history

### DIFF
--- a/internal/gippity/gippity.go
+++ b/internal/gippity/gippity.go
@@ -216,7 +216,10 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 }
 
 func onMessageUpdate(_ *discordgo.Session, m *discordgo.MessageUpdate) {
-	if m.Author == nil || m.Author.Bot {
+	if m.Message == nil || m.Author == nil || m.Author.Bot {
+		return
+	}
+	if m.EditedTimestamp == nil || m.Content == "" {
 		return
 	}
 	if !allowedGuildIDs[m.GuildID] {
@@ -229,11 +232,7 @@ func onMessageUpdate(_ *discordgo.Session, m *discordgo.MessageUpdate) {
 	if err := database.QueryRow(`SELECT COUNT(*) FROM chat_history WHERE message_id = ?`, m.ID).Scan(&count); err != nil || count == 0 {
 		return
 	}
-	editedAt := time.Now().Unix()
-	if m.EditedTimestamp != nil {
-		editedAt = m.EditedTimestamp.Unix()
-	}
-	addMessageEditToDatabase(m.ID, m.Content, editedAt)
+	addMessageEditToDatabase(m.ID, m.Content, m.EditedTimestamp.Unix())
 }
 
 func onGippityInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/internal/gippity/gippity.go
+++ b/internal/gippity/gippity.go
@@ -61,6 +61,7 @@ func Start(discord *discordgo.Session) {
 	discordSession = discord
 
 	discord.AddHandler(onMessageCreate)
+	discord.AddHandler(onMessageUpdate)
 	discord.AddHandler(onGippityInteractionCreate)
 
 	slog.Info("gippity function registered")
@@ -212,6 +213,27 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			slog.Info("Error while sending message", "error", err)
 		}
 	}
+}
+
+func onMessageUpdate(_ *discordgo.Session, m *discordgo.MessageUpdate) {
+	if m.Author == nil || m.Author.Bot {
+		return
+	}
+	if !allowedGuildIDs[m.GuildID] {
+		return
+	}
+	if getUserPrivacy(m.Author.ID) {
+		return
+	}
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM chat_history WHERE message_id = ?`, m.ID).Scan(&count); err != nil || count == 0 {
+		return
+	}
+	editedAt := time.Now().Unix()
+	if m.EditedTimestamp != nil {
+		editedAt = m.EditedTimestamp.Unix()
+	}
+	addMessageEditToDatabase(m.ID, m.Content, editedAt)
 }
 
 func onGippityInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/internal/gippity/gippity_persistence.go
+++ b/internal/gippity/gippity_persistence.go
@@ -77,6 +77,10 @@ func initDB() {
 	if err != nil {
 		slog.Error("Error while creating chat_history_edits table", "error", err)
 	}
+	_, err = database.Exec(`CREATE INDEX IF NOT EXISTS idx_chat_history_edits_original ON chat_history_edits(original_message_id, version)`)
+	if err != nil {
+		slog.Error("Error while creating index on chat_history_edits", "error", err)
+	}
 }
 
 // CloseDB closes the gippity chat history database.
@@ -110,7 +114,10 @@ func addMessageEditToDatabase(messageID, content string, editedAt int64) {
 	dbMu.Lock()
 	defer dbMu.Unlock()
 	var maxVersion int
-	_ = database.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM chat_history_edits WHERE original_message_id = ?`, messageID).Scan(&maxVersion)
+	if err := database.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM chat_history_edits WHERE original_message_id = ?`, messageID).Scan(&maxVersion); err != nil {
+		slog.Error("Error while querying max edit version", "error", err)
+		return
+	}
 	_, err := database.Exec(
 		`INSERT INTO chat_history_edits (original_message_id, edited_content, version, edited_at) VALUES (?, ?, ?, ?)`,
 		messageID, content, maxVersion+1, editedAt,

--- a/internal/gippity/gippity_persistence.go
+++ b/internal/gippity/gippity_persistence.go
@@ -72,6 +72,11 @@ func initDB() {
 	// idempotent: add columns missing from pre-existing migration-created tables
 	_, _ = database.Exec(`ALTER TABLE chat_attachments ADD COLUMN message_id TEXT`)
 	_, _ = database.Exec(`ALTER TABLE chat_attachments ADD COLUMN image_description TEXT`)
+
+	_, err = database.Exec(`CREATE TABLE IF NOT EXISTS chat_history_edits (id INTEGER PRIMARY KEY AUTOINCREMENT, original_message_id TEXT, edited_content TEXT, version INTEGER, edited_at INTEGER)`)
+	if err != nil {
+		slog.Error("Error while creating chat_history_edits table", "error", err)
+	}
 }
 
 // CloseDB closes the gippity chat history database.
@@ -101,6 +106,20 @@ func addMessageToDatabase(m *discordgo.MessageCreate, isBotMention bool) {
 	}
 }
 
+func addMessageEditToDatabase(messageID, content string, editedAt int64) {
+	dbMu.Lock()
+	defer dbMu.Unlock()
+	var maxVersion int
+	_ = database.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM chat_history_edits WHERE original_message_id = ?`, messageID).Scan(&maxVersion)
+	_, err := database.Exec(
+		`INSERT INTO chat_history_edits (original_message_id, edited_content, version, edited_at) VALUES (?, ?, ?, ?)`,
+		messageID, content, maxVersion+1, editedAt,
+	)
+	if err != nil {
+		slog.Error("Error while inserting message edit", "error", err)
+	}
+}
+
 func addAttachmentsToDatabase(messageID string, urls []string, description string) {
 	dbMu.Lock()
 	defer dbMu.Unlock()
@@ -115,7 +134,9 @@ func addAttachmentsToDatabase(messageID string, urls []string, description strin
 
 func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, error) {
 	stmt, err := database.Prepare(`
-	SELECT ch.user_id, ch.channel_id, ch.timestamp, ch.message, ch.message_id, ch.guild_id,
+	SELECT ch.user_id, ch.channel_id, ch.timestamp,
+	       COALESCE((SELECT edited_content FROM chat_history_edits WHERE original_message_id = ch.message_id ORDER BY version DESC LIMIT 1), ch.message) as message,
+	       ch.message_id, ch.guild_id,
 	       COALESCE(ch.is_bot_mention, 0),
 	       ca.image_description
 	FROM (
@@ -188,7 +209,9 @@ func getLastNMessagesFromDatabase(channelID string, n int) ([]LLMChatMessage, er
 
 func getMessageFromDatabase(messageID string) (*LLMChatMessage, error) {
 	stmt, err := database.Prepare(`
-	SELECT ch.user_id, ch.channel_id, ch.timestamp, ch.message, ch.message_id, ch.guild_id,
+	SELECT ch.user_id, ch.channel_id, ch.timestamp,
+	       COALESCE((SELECT edited_content FROM chat_history_edits WHERE original_message_id = ch.message_id ORDER BY version DESC LIMIT 1), ch.message) as message,
+	       ch.message_id, ch.guild_id,
 	       COALESCE(ch.is_bot_mention, 0),
 	       GROUP_CONCAT(ca.image_description, '||') as image_desc_concat
 	FROM chat_history ch

--- a/internal/gippity/gippity_test.go
+++ b/internal/gippity/gippity_test.go
@@ -40,6 +40,9 @@ func setupGippityTest(t *testing.T) *discordgo.Session {
 	if _, err := testDB.Exec(`CREATE TABLE chat_attachments (id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, attachment_url TEXT, image_description TEXT)`); err != nil {
 		t.Fatalf("create chat_attachments table: %v", err)
 	}
+	if _, err := testDB.Exec(`CREATE TABLE chat_history_edits (id INTEGER PRIMARY KEY AUTOINCREMENT, original_message_id TEXT, edited_content TEXT, version INTEGER, edited_at INTEGER)`); err != nil {
+		t.Fatalf("create chat_history_edits table: %v", err)
+	}
 
 	session, err := discordgo.New("")
 	if err != nil {
@@ -459,6 +462,145 @@ func TestGenerateAnswer_ReferencedMessageOptInAuthor_ContentInjected(t *testing.
 	}
 	if !found {
 		t.Error("expected system note with visible content in messages passed to LLM")
+	}
+}
+
+func gippityTestMessageUpdate(msgID, content, guildID, authorID string) *discordgo.MessageUpdate {
+	return &discordgo.MessageUpdate{
+		Message: &discordgo.Message{
+			ID:        msgID,
+			ChannelID: "channel-1",
+			GuildID:   guildID,
+			Content:   content,
+			Author:    &discordgo.User{ID: authorID, Username: "Alice"},
+		},
+	}
+}
+
+func TestOnMessageUpdate_PrivacyEnabledUser_EditNotPersisted(t *testing.T) {
+	session := setupGippityTest(t)
+
+	if _, err := database.Exec(`INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"user-1", "channel-1", 1000, "original", "edit-msg-id", "allowed-guild", 0); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// privacy on by default for user-1
+	onMessageUpdate(session, gippityTestMessageUpdate("edit-msg-id", "edited content", "allowed-guild", "user-1"))
+
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM chat_history_edits WHERE original_message_id = ?`, "edit-msg-id").Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("edit should not be persisted for privacy-on user, got %d row(s)", count)
+	}
+}
+
+func TestOnMessageUpdate_PrivacyDisabledUser_EditPersisted(t *testing.T) {
+	session := setupGippityTest(t)
+
+	if err := setUserPrivacy("user-1", false); err != nil {
+		t.Fatalf("setUserPrivacy: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"user-1", "channel-1", 1000, "original", "edit-msg-id2", "allowed-guild", 0); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	onMessageUpdate(session, gippityTestMessageUpdate("edit-msg-id2", "first edit", "allowed-guild", "user-1"))
+	onMessageUpdate(session, gippityTestMessageUpdate("edit-msg-id2", "second edit", "allowed-guild", "user-1"))
+
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM chat_history_edits WHERE original_message_id = ?`, "edit-msg-id2").Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 edit rows, got %d", count)
+	}
+
+	var version int
+	var content string
+	if err := database.QueryRow(`SELECT version, edited_content FROM chat_history_edits WHERE original_message_id = ? ORDER BY version DESC LIMIT 1`, "edit-msg-id2").Scan(&version, &content); err != nil {
+		t.Fatalf("query latest edit: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("latest version = %d, want 2", version)
+	}
+	if content != "second edit" {
+		t.Errorf("latest content = %q, want %q", content, "second edit")
+	}
+}
+
+func TestOnMessageUpdate_NilAuthor_Skipped(t *testing.T) {
+	session := setupGippityTest(t)
+
+	m := &discordgo.MessageUpdate{
+		Message: &discordgo.Message{
+			ID:        "nil-author-msg",
+			ChannelID: "channel-1",
+			GuildID:   "allowed-guild",
+			Content:   "embed update",
+			Author:    nil,
+		},
+	}
+	onMessageUpdate(session, m)
+
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM chat_history_edits WHERE original_message_id = ?`, "nil-author-msg").Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("nil-author update should not be persisted, got %d row(s)", count)
+	}
+}
+
+func TestOnMessageUpdate_MessageNotInHistory_Skipped(t *testing.T) {
+	session := setupGippityTest(t)
+
+	if err := setUserPrivacy("user-1", false); err != nil {
+		t.Fatalf("setUserPrivacy: %v", err)
+	}
+
+	onMessageUpdate(session, gippityTestMessageUpdate("unknown-msg-id", "edit of unknown", "allowed-guild", "user-1"))
+
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM chat_history_edits WHERE original_message_id = ?`, "unknown-msg-id").Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("edit of message not in chat_history should not be persisted, got %d row(s)", count)
+	}
+}
+
+func TestGetLastNMessagesFromDatabase_ShowsLatestEdit(t *testing.T) {
+	setupGippityTest(t)
+	idToNameCache["user-1"] = "Alice"
+	idToNameCache["channel-1"] = "general"
+	idToNameCache["allowed-guild"] = "Test Guild"
+
+	if _, err := database.Exec(`INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"user-1", "channel-1", 1000, "original message", "edited-hist-msg", "allowed-guild", 0); err != nil {
+		t.Fatalf("insert chat_history: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO chat_history_edits (original_message_id, edited_content, version, edited_at) VALUES (?, ?, ?, ?)`,
+		"edited-hist-msg", "v1 edit", 1, 1001); err != nil {
+		t.Fatalf("insert edit v1: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO chat_history_edits (original_message_id, edited_content, version, edited_at) VALUES (?, ?, ?, ?)`,
+		"edited-hist-msg", "v2 edit", 2, 1002); err != nil {
+		t.Fatalf("insert edit v2: %v", err)
+	}
+
+	msgs, err := getLastNMessagesFromDatabase("channel-1", 10)
+	if err != nil {
+		t.Fatalf("getLastNMessagesFromDatabase: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Message != "v2 edit" {
+		t.Errorf("message content = %q, want %q", msgs[0].Message, "v2 edit")
 	}
 }
 

--- a/internal/gippity/gippity_test.go
+++ b/internal/gippity/gippity_test.go
@@ -466,13 +466,15 @@ func TestGenerateAnswer_ReferencedMessageOptInAuthor_ContentInjected(t *testing.
 }
 
 func gippityTestMessageUpdate(msgID, content, guildID, authorID string) *discordgo.MessageUpdate {
+	ts := time.Unix(1000, 0)
 	return &discordgo.MessageUpdate{
 		Message: &discordgo.Message{
-			ID:        msgID,
-			ChannelID: "channel-1",
-			GuildID:   guildID,
-			Content:   content,
-			Author:    &discordgo.User{ID: authorID, Username: "Alice"},
+			ID:              msgID,
+			ChannelID:       "channel-1",
+			GuildID:         guildID,
+			Content:         content,
+			EditedTimestamp: &ts,
+			Author:          &discordgo.User{ID: authorID, Username: "Alice"},
 		},
 	}
 }
@@ -601,6 +603,31 @@ func TestGetLastNMessagesFromDatabase_ShowsLatestEdit(t *testing.T) {
 	}
 	if msgs[0].Message != "v2 edit" {
 		t.Errorf("message content = %q, want %q", msgs[0].Message, "v2 edit")
+	}
+}
+
+func TestGetMessageFromDatabase_ShowsLatestEdit(t *testing.T) {
+	setupGippityTest(t)
+
+	if _, err := database.Exec(`INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"user-1", "channel-1", 1000, "original message", "getmsg-edit-id", "allowed-guild", 0); err != nil {
+		t.Fatalf("insert chat_history: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO chat_history_edits (original_message_id, edited_content, version, edited_at) VALUES (?, ?, ?, ?)`,
+		"getmsg-edit-id", "v1 edit", 1, 1001); err != nil {
+		t.Fatalf("insert edit v1: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO chat_history_edits (original_message_id, edited_content, version, edited_at) VALUES (?, ?, ?, ?)`,
+		"getmsg-edit-id", "v2 edit", 2, 1002); err != nil {
+		t.Fatalf("insert edit v2: %v", err)
+	}
+
+	msg, err := getMessageFromDatabase("getmsg-edit-id")
+	if err != nil {
+		t.Fatalf("getMessageFromDatabase: %v", err)
+	}
+	if msg.Message != "v2 edit" {
+		t.Errorf("message content = %q, want %q", msg.Message, "v2 edit")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Registers `onMessageUpdate` handler in `Start()` that stores each edit in a new `chat_history_edits` table (`original_message_id`, `edited_content`, `version`, `edited_at`)
- Skips nil/bot authors, non-allowed guilds, messages absent from `chat_history`, and users with privacy enabled (default)
- `getLastNMessagesFromDatabase` and `getMessageFromDatabase` now `COALESCE` to the highest-version edit so the LLM always sees the most recent content

## Test plan

- [x] `TestOnMessageUpdate_PrivacyEnabledUser_EditNotPersisted` — default privacy blocks storage
- [x] `TestOnMessageUpdate_PrivacyDisabledUser_EditPersisted` — two edits produce two rows with incrementing versions
- [x] `TestOnMessageUpdate_NilAuthor_Skipped` — embed-only updates ignored
- [x] `TestOnMessageUpdate_MessageNotInHistory_Skipped` — edit of unknown message not stored
- [x] `TestGetLastNMessagesFromDatabase_ShowsLatestEdit` — query returns latest edited content, not original

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)