### PR TITLE
feat(logging): add Discord lifecycle handlers and structured warn context

### DIFF
--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -41,7 +41,19 @@ var (
 )
 
 func onReady(s *discordgo.Session, event *discordgo.Ready) {
-	slog.Info("Received READY payload.")
+	slog.Info("Discord READY", "session_id", event.SessionID, "user", event.User.String(), "guilds", len(event.Guilds), "latency_ms", s.HeartbeatLatency().Milliseconds())
+}
+
+func onConnect(s *discordgo.Session, event *discordgo.Connect) {
+	slog.Info("Discord WebSocket connected")
+}
+
+func onDisconnect(s *discordgo.Session, event *discordgo.Disconnect) {
+	slog.Error("Discord WebSocket disconnected — bot is offline until reconnect")
+}
+
+func onResumed(s *discordgo.Session, event *discordgo.Resumed) {
+	slog.Info("Discord session resumed", "latency_ms", s.HeartbeatLatency().Milliseconds())
 }
 
 func scontains(key string, options ...string) bool {
@@ -327,6 +339,9 @@ func StartGidbig() {
 	}
 
 	discord.AddHandler(onReady)
+	discord.AddHandler(onConnect)
+	discord.AddHandler(onDisconnect)
+	discord.AddHandler(onResumed)
 	discord.AddHandler(onMessageCreate)
 	discord.AddHandler(onStatusInteractionCreate)
 

--- a/internal/util/discordhelper.go
+++ b/internal/util/discordhelper.go
@@ -79,7 +79,7 @@ func GetAllMembersOfChannelAsString(discordSession *discordgo.Session, channelID
 func GetChannelName(discordSession *discordgo.Session, channelID string) string {
 	channel, err := discordSession.Channel(channelID)
 	if err != nil {
-		slog.Warn("Error while getting channel", "error", err)
+		slog.Warn("Error while getting channel", "error", err, "channel_id", channelID)
 		return channelID
 	}
 	return channel.Name
@@ -89,7 +89,7 @@ func GetChannelName(discordSession *discordgo.Session, channelID string) string 
 func GetGuildName(discordSession *discordgo.Session, guildID string) string {
 	guild, err := discordSession.Guild(guildID)
 	if err != nil {
-		slog.Warn("Error while getting guild", "error", err)
+		slog.Warn("Error while getting guild", "error", err, "guild_id", guildID)
 		return guildID
 	}
 	return guild.Name
@@ -148,7 +148,7 @@ func getBotDisplayNames(discordSession *discordgo.Session) map[string]string {
 func GetUsernameInGuild(discordSession *discordgo.Session, m *discordgo.MessageCreate) string {
 	member, err := discordSession.GuildMember(m.GuildID, m.Author.ID)
 	if err != nil {
-		slog.Warn("Error while getting member", "error", err)
+		slog.Warn("Error while getting member", "error", err, "guild_id", m.GuildID, "user_id", m.Author.ID)
 		return m.Author.Username
 	}
 	return member.Nick
@@ -163,12 +163,12 @@ func GetUsernameForUserIDInGuild(discordSession *discordgo.Session, userid strin
 		}
 		return member.User.Username
 	}
-	slog.Warn("Error while getting member", "error", err)
+	slog.Warn("Error while getting member", "error", err, "guild_id", guildid, "user_id", userid)
 	user, err := discordSession.User(userid)
 	if err == nil {
 		return user.Username
 	}
-	slog.Warn("Error while getting user", "error", err)
+	slog.Warn("Error while getting user", "error", err, "user_id", userid)
 	return "Unbekannter Benutzer"
 }
 


### PR DESCRIPTION
## Summary

- Register `Connect`, `Disconnect`, `Resumed` event handlers — WS drops now log at `ERROR` level immediately; previously the process stayed alive with zero log evidence
- Enrich `onReady` with `session_id`, `user`, `guild count`, `latency_ms`
- Add `guild_id`/`user_id`/`channel_id` structured fields to all member/channel/guild 404 warn sites in `discordhelper.go`

## Test plan

- [ ] All existing tests pass (`make test`)
- [ ] Build clean (`make build`)
- [ ] After deploy: verify `Discord WebSocket disconnected` ERROR log appears when bot loses connection to Discord
- [ ] Verify `Discord READY` log includes session_id and latency on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)