### PR TITLE
feat(admin): owner-only /admin slash commands (read-only)

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1,0 +1,219 @@
+package admin
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/toksikk/gidbig/internal/coffee"
+	"github.com/toksikk/gidbig/internal/gippity"
+)
+
+var (
+	ownerID string
+	infoFn  func(s *discordgo.Session) string
+)
+
+// Start registers the /admin interaction handler.
+func Start(s *discordgo.Session, oid string, info func(s *discordgo.Session) string) {
+	ownerID = oid
+	infoFn = info
+	s.AddHandler(onAdminInteractionCreate)
+	slog.Info("admin commands registered")
+}
+
+// Commands returns the /admin slash command definition.
+func Commands() []*discordgo.ApplicationCommand {
+	userOpt := func(desc string) *discordgo.ApplicationCommandOption {
+		return &discordgo.ApplicationCommandOption{
+			Type:        discordgo.ApplicationCommandOptionUser,
+			Name:        "user",
+			Description: desc,
+			Required:    false,
+		}
+	}
+	return []*discordgo.ApplicationCommand{
+		{
+			Name:        "admin",
+			Description: "Admin commands (owner only)",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+					Name:        "coffee",
+					Description: "Coffee admin queries",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Name:        "beverages",
+							Description: "Show beverage settings for a user or all users",
+							Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
+						},
+					},
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+					Name:        "gippity",
+					Description: "Gippity admin queries",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Name:        "privacy",
+							Description: "Show gippity privacy setting for a user or all users",
+							Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
+						},
+						{
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Name:        "history",
+							Description: "Show whether a user has stored conversation history",
+							Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
+						},
+					},
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "info",
+					Description: "General bot info: uptime, guild count, loaded plugins",
+				},
+			},
+		},
+	}
+}
+
+func callerID(i *discordgo.InteractionCreate) string {
+	if i.Member != nil {
+		return i.Member.User.ID
+	}
+	if i.User != nil {
+		return i.User.ID
+	}
+	return ""
+}
+
+func ephemeral(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: content,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	}); err != nil {
+		slog.Error("admin: failed to respond to interaction", "error", err)
+	}
+}
+
+func onAdminInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type != discordgo.InteractionApplicationCommand {
+		return
+	}
+	data := i.ApplicationCommandData()
+	if data.Name != "admin" {
+		return
+	}
+	if callerID(i) != ownerID {
+		ephemeral(s, i, "Access denied.")
+		return
+	}
+	if len(data.Options) == 0 {
+		return
+	}
+	top := data.Options[0]
+	switch top.Name {
+	case "info":
+		ephemeral(s, i, "```"+infoFn(s)+"```")
+	case "coffee":
+		if len(top.Options) > 0 {
+			handleCoffeeAdmin(s, i, top.Options[0])
+		}
+	case "gippity":
+		if len(top.Options) > 0 {
+			handleGippityAdmin(s, i, top.Options[0])
+		}
+	}
+}
+
+func optUserID(s *discordgo.Session, opts []*discordgo.ApplicationCommandInteractionDataOption) string {
+	for _, o := range opts {
+		if o.Name == "user" {
+			return o.UserValue(s).ID
+		}
+	}
+	return ""
+}
+
+func handleCoffeeAdmin(s *discordgo.Session, i *discordgo.InteractionCreate, sub *discordgo.ApplicationCommandInteractionDataOption) {
+	if sub.Name != "beverages" {
+		return
+	}
+	targetID := optUserID(s, sub.Options)
+	if targetID != "" {
+		pref, found := coffee.AdminGetBeveragePreference(targetID)
+		if !found {
+			ephemeral(s, i, fmt.Sprintf("No beverage preference found for <@%s>.", targetID))
+			return
+		}
+		ephemeral(s, i, fmt.Sprintf("<@%s>: %s (introduced: %v)", targetID, pref.BeverageEmoji, pref.HasSeenIntro))
+		return
+	}
+	prefs, err := coffee.AdminGetAllBeveragePreferences()
+	if err != nil {
+		ephemeral(s, i, fmt.Sprintf("Error querying beverage preferences: %v", err))
+		return
+	}
+	if len(prefs) == 0 {
+		ephemeral(s, i, "No beverage preferences stored.")
+		return
+	}
+	var sb strings.Builder
+	for _, p := range prefs {
+		fmt.Fprintf(&sb, "<@%s>: %s (introduced: %v)\n", p.UserID, p.BeverageEmoji, p.HasSeenIntro)
+	}
+	ephemeral(s, i, sb.String())
+}
+
+func handleGippityAdmin(s *discordgo.Session, i *discordgo.InteractionCreate, sub *discordgo.ApplicationCommandInteractionDataOption) {
+	switch sub.Name {
+	case "privacy":
+		targetID := optUserID(s, sub.Options)
+		if targetID != "" {
+			privacy := gippity.AdminGetUserPrivacy(targetID)
+			ephemeral(s, i, fmt.Sprintf("<@%s> privacy: %v (true = messages anonymized in AI context)", targetID, privacy))
+			return
+		}
+		settings, err := gippity.AdminGetAllUserPrivacy()
+		if err != nil {
+			ephemeral(s, i, fmt.Sprintf("Error querying privacy settings: %v", err))
+			return
+		}
+		if len(settings) == 0 {
+			ephemeral(s, i, "No explicit privacy settings stored (all users default to: on).")
+			return
+		}
+		var sb strings.Builder
+		for uid, enabled := range settings {
+			fmt.Fprintf(&sb, "<@%s>: %v\n", uid, enabled)
+		}
+		ephemeral(s, i, sb.String())
+	case "history":
+		targetID := optUserID(s, sub.Options)
+		if targetID != "" {
+			has := gippity.AdminHasConversationHistory(targetID)
+			ephemeral(s, i, fmt.Sprintf("<@%s> has history: %v", targetID, has))
+			return
+		}
+		users, err := gippity.AdminGetUsersWithHistory()
+		if err != nil {
+			ephemeral(s, i, fmt.Sprintf("Error querying history: %v", err))
+			return
+		}
+		if len(users) == 0 {
+			ephemeral(s, i, "No conversation history stored.")
+			return
+		}
+		var sb strings.Builder
+		for _, uid := range users {
+			fmt.Fprintf(&sb, "<@%s>\n", uid)
+		}
+		ephemeral(s, i, "Users with stored history:\n"+sb.String())
+	}
+}

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -135,7 +135,11 @@ func onAdminInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCrea
 func optUserID(s *discordgo.Session, opts []*discordgo.ApplicationCommandInteractionDataOption) string {
 	for _, o := range opts {
 		if o.Name == "user" {
-			return o.UserValue(s).ID
+			u := o.UserValue(s)
+			if u == nil {
+				return ""
+			}
+			return u.ID
 		}
 	}
 	return ""

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -1,0 +1,158 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestCommands_Structure(t *testing.T) {
+	cmds := Commands()
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	cmd := cmds[0]
+	if cmd.Name != "admin" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "admin")
+	}
+
+	names := make(map[string]bool)
+	for _, opt := range cmd.Options {
+		names[opt.Name] = true
+	}
+	for _, want := range []string{"coffee", "gippity", "info"} {
+		if !names[want] {
+			t.Errorf("missing top-level option %q", want)
+		}
+	}
+}
+
+func TestCommands_CoffeeBeveragesSubcommand(t *testing.T) {
+	cmds := Commands()
+	cmd := cmds[0]
+	var coffeeGroup *discordgo.ApplicationCommandOption
+	for _, o := range cmd.Options {
+		if o.Name == "coffee" {
+			coffeeGroup = o
+		}
+	}
+	if coffeeGroup == nil {
+		t.Fatal("no coffee subcommand group")
+	}
+	if coffeeGroup.Type != discordgo.ApplicationCommandOptionSubCommandGroup {
+		t.Errorf("coffee Type = %v, want SubCommandGroup", coffeeGroup.Type)
+	}
+
+	var beverages *discordgo.ApplicationCommandOption
+	for _, o := range coffeeGroup.Options {
+		if o.Name == "beverages" {
+			beverages = o
+		}
+	}
+	if beverages == nil {
+		t.Fatal("no beverages subcommand under coffee")
+	}
+	if beverages.Type != discordgo.ApplicationCommandOptionSubCommand {
+		t.Errorf("beverages Type = %v, want SubCommand", beverages.Type)
+	}
+}
+
+func TestCommands_GippitySubcommands(t *testing.T) {
+	cmds := Commands()
+	cmd := cmds[0]
+	var gippityGroup *discordgo.ApplicationCommandOption
+	for _, o := range cmd.Options {
+		if o.Name == "gippity" {
+			gippityGroup = o
+		}
+	}
+	if gippityGroup == nil {
+		t.Fatal("no gippity subcommand group")
+	}
+
+	subNames := make(map[string]bool)
+	for _, o := range gippityGroup.Options {
+		subNames[o.Name] = true
+	}
+	for _, want := range []string{"privacy", "history"} {
+		if !subNames[want] {
+			t.Errorf("missing gippity subcommand %q", want)
+		}
+	}
+}
+
+func TestCommands_InfoSubcommand(t *testing.T) {
+	cmds := Commands()
+	cmd := cmds[0]
+	var info *discordgo.ApplicationCommandOption
+	for _, o := range cmd.Options {
+		if o.Name == "info" {
+			info = o
+		}
+	}
+	if info == nil {
+		t.Fatal("no info subcommand")
+	}
+	if info.Type != discordgo.ApplicationCommandOptionSubCommand {
+		t.Errorf("info Type = %v, want SubCommand", info.Type)
+	}
+}
+
+func TestCallerID_Member(t *testing.T) {
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Member: &discordgo.Member{
+				User: &discordgo.User{ID: "member-user-id"},
+			},
+		},
+	}
+	got := callerID(i)
+	if got != "member-user-id" {
+		t.Errorf("callerID = %q, want %q", got, "member-user-id")
+	}
+}
+
+func TestCallerID_User(t *testing.T) {
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			User: &discordgo.User{ID: "direct-user-id"},
+		},
+	}
+	got := callerID(i)
+	if got != "direct-user-id" {
+		t.Errorf("callerID = %q, want %q", got, "direct-user-id")
+	}
+}
+
+func TestCallerID_Neither(t *testing.T) {
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{},
+	}
+	got := callerID(i)
+	if got != "" {
+		t.Errorf("callerID = %q, want empty string", got)
+	}
+}
+
+func TestOptUserID_Present(t *testing.T) {
+	user := &discordgo.User{ID: "target-user"}
+	opts := []*discordgo.ApplicationCommandInteractionDataOption{
+		{
+			Name:  "user",
+			Type:  discordgo.ApplicationCommandOptionUser,
+			Value: user.ID,
+		},
+	}
+	got := optUserID(nil, opts)
+	if got != user.ID {
+		t.Errorf("optUserID = %q, want %q", got, user.ID)
+	}
+}
+
+func TestOptUserID_Absent(t *testing.T) {
+	opts := []*discordgo.ApplicationCommandInteractionDataOption{}
+	got := optUserID(nil, opts)
+	if got != "" {
+		t.Errorf("optUserID = %q, want empty string", got)
+	}
+}

--- a/internal/coffee/admin.go
+++ b/internal/coffee/admin.go
@@ -1,0 +1,27 @@
+package coffee
+
+import "errors"
+
+// AdminGetBeveragePreference returns the stored beverage preference for one user.
+func AdminGetBeveragePreference(userID string) (*UserBeveragePreference, bool) {
+	d := getDB()
+	if d == nil {
+		return nil, false
+	}
+	var pref UserBeveragePreference
+	if err := d.Where("user_id = ?", userID).First(&pref).Error; err != nil {
+		return nil, false
+	}
+	return &pref, true
+}
+
+// AdminGetAllBeveragePreferences returns all stored beverage preferences.
+func AdminGetAllBeveragePreferences() ([]UserBeveragePreference, error) {
+	d := getDB()
+	if d == nil {
+		return nil, errors.New("store not initialized")
+	}
+	var prefs []UserBeveragePreference
+	result := d.Find(&prefs)
+	return prefs, result.Error
+}

--- a/internal/coffee/admin_test.go
+++ b/internal/coffee/admin_test.go
@@ -1,0 +1,105 @@
+package coffee
+
+import (
+	"testing"
+)
+
+func TestAdminGetBeveragePreference_NotFound(t *testing.T) {
+	openInMemoryStore(t)
+
+	pref, found := AdminGetBeveragePreference("unknown-user")
+	if found {
+		t.Errorf("expected found=false for unknown user, got pref=%v", pref)
+	}
+}
+
+func TestAdminGetBeveragePreference_Found(t *testing.T) {
+	openInMemoryStore(t)
+
+	if err := setBeverageEmoji("user1", "🍵"); err != nil {
+		t.Fatalf("setBeverageEmoji: %v", err)
+	}
+
+	pref, found := AdminGetBeveragePreference("user1")
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if pref.BeverageEmoji != "🍵" {
+		t.Errorf("BeverageEmoji = %q, want %q", pref.BeverageEmoji, "🍵")
+	}
+	if pref.UserID != "user1" {
+		t.Errorf("UserID = %q, want %q", pref.UserID, "user1")
+	}
+}
+
+func TestAdminGetAllBeveragePreferences_Empty(t *testing.T) {
+	openInMemoryStore(t)
+
+	prefs, err := AdminGetAllBeveragePreferences()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prefs) != 0 {
+		t.Errorf("expected 0 prefs, got %d", len(prefs))
+	}
+}
+
+func TestAdminGetAllBeveragePreferences_Multiple(t *testing.T) {
+	openInMemoryStore(t)
+
+	users := []struct {
+		id    string
+		emoji string
+	}{
+		{"user-a", "☕"},
+		{"user-b", "🍺"},
+		{"user-c", "🧃"},
+	}
+	for _, u := range users {
+		if err := setBeverageEmoji(u.id, u.emoji); err != nil {
+			t.Fatalf("setBeverageEmoji(%q): %v", u.id, err)
+		}
+	}
+
+	prefs, err := AdminGetAllBeveragePreferences()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prefs) != 3 {
+		t.Fatalf("expected 3 prefs, got %d", len(prefs))
+	}
+}
+
+func TestAdminGetBeveragePreference_NilDB(t *testing.T) {
+	dbMu.Lock()
+	prev := db
+	db = nil
+	dbMu.Unlock()
+	t.Cleanup(func() {
+		dbMu.Lock()
+		db = prev
+		dbMu.Unlock()
+	})
+
+	_, found := AdminGetBeveragePreference("user1")
+	if found {
+		t.Error("expected found=false when DB is nil")
+	}
+}
+
+func TestAdminGetAllBeveragePreferences_NilDB(t *testing.T) {
+	dbMu.Lock()
+	prev := db
+	db = nil
+	dbMu.Unlock()
+	t.Cleanup(func() {
+		dbMu.Lock()
+		db = prev
+		dbMu.Unlock()
+	})
+
+	_, err := AdminGetAllBeveragePreferences()
+	if err == nil {
+		t.Error("expected error when DB is nil")
+	}
+}

--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	humanize "github.com/dustin/go-humanize"
+	"github.com/toksikk/gidbig/internal/admin"
 	"github.com/toksikk/gidbig/internal/cfg"
 	"github.com/toksikk/gidbig/internal/coffee"
 	"github.com/toksikk/gidbig/internal/eso"
@@ -353,6 +354,7 @@ func StartGidbig() {
 	}
 
 	llm.Initialize()
+	admin.Start(discord, conf.Discord.OwnerID, buildBotStatsMessage)
 	coffee.Start(discord)
 	eso.Start(discord)
 	gamerstatus.Start(discord)
@@ -364,6 +366,7 @@ func StartGidbig() {
 	cmds := []*discordgo.ApplicationCommand{
 		{Name: "status", Description: "Show bot runtime status (owner only)"},
 	}
+	cmds = append(cmds, admin.Commands()...)
 	cmds = append(cmds, coffee.Commands()...)
 	cmds = append(cmds, gippity.Commands()...)
 	if _, err := discord.ApplicationCommandBulkOverwrite(discord.State.User.ID, "", cmds); err != nil {

--- a/internal/gippity/admin.go
+++ b/internal/gippity/admin.go
@@ -1,9 +1,25 @@
 package gippity
 
+import (
+	"database/sql"
+	"log/slog"
+)
+
 // AdminGetUserPrivacy returns true (privacy on/anonymized) for a user.
-// Defaults to true if no explicit setting exists.
+// Defaults to true if no explicit setting exists. Acquires dbMu for safe concurrent access.
 func AdminGetUserPrivacy(userID string) bool {
-	return getUserPrivacy(userID)
+	dbMu.Lock()
+	defer dbMu.Unlock()
+	var enabled int
+	err := database.QueryRow(`SELECT privacy_enabled FROM user_privacy WHERE user_id = ?`, userID).Scan(&enabled)
+	if err == sql.ErrNoRows {
+		return true
+	}
+	if err != nil {
+		slog.Error("admin: error querying user_privacy", "error", err)
+		return true
+	}
+	return enabled != 0
 }
 
 // AdminGetAllUserPrivacy returns a map of userID -> privacy_enabled for all users

--- a/internal/gippity/admin.go
+++ b/internal/gippity/admin.go
@@ -1,0 +1,60 @@
+package gippity
+
+// AdminGetUserPrivacy returns true (privacy on/anonymized) for a user.
+// Defaults to true if no explicit setting exists.
+func AdminGetUserPrivacy(userID string) bool {
+	return getUserPrivacy(userID)
+}
+
+// AdminGetAllUserPrivacy returns a map of userID -> privacy_enabled for all users
+// with an explicit setting in the database.
+func AdminGetAllUserPrivacy() (map[string]bool, error) {
+	dbMu.Lock()
+	defer dbMu.Unlock()
+	rows, err := database.Query(`SELECT user_id, privacy_enabled FROM user_privacy ORDER BY user_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	result := make(map[string]bool)
+	for rows.Next() {
+		var uid string
+		var enabled int
+		if err := rows.Scan(&uid, &enabled); err != nil {
+			return nil, err
+		}
+		result[uid] = enabled != 0
+	}
+	return result, nil
+}
+
+// AdminHasConversationHistory returns true if the user has any stored chat messages.
+func AdminHasConversationHistory(userID string) bool {
+	dbMu.Lock()
+	defer dbMu.Unlock()
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM chat_history WHERE user_id = ?`, userID).Scan(&count); err != nil {
+		return false
+	}
+	return count > 0
+}
+
+// AdminGetUsersWithHistory returns all distinct user IDs that have stored chat history.
+func AdminGetUsersWithHistory() ([]string, error) {
+	dbMu.Lock()
+	defer dbMu.Unlock()
+	rows, err := database.Query(`SELECT DISTINCT user_id FROM chat_history ORDER BY user_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var users []string
+	for rows.Next() {
+		var uid string
+		if err := rows.Scan(&uid); err != nil {
+			return nil, err
+		}
+		users = append(users, uid)
+	}
+	return users, nil
+}

--- a/internal/gippity/admin_test.go
+++ b/internal/gippity/admin_test.go
@@ -1,0 +1,118 @@
+package gippity
+
+import (
+	"testing"
+)
+
+func TestAdminGetUserPrivacy_Default(t *testing.T) {
+	setupGippityTest(t)
+
+	if !AdminGetUserPrivacy("unknown-user") {
+		t.Error("expected default privacy=true for unknown user")
+	}
+}
+
+func TestAdminGetUserPrivacy_ExplicitOff(t *testing.T) {
+	setupGippityTest(t)
+
+	if err := setUserPrivacy("user1", false); err != nil {
+		t.Fatalf("setUserPrivacy: %v", err)
+	}
+
+	if AdminGetUserPrivacy("user1") {
+		t.Error("expected privacy=false after explicit opt-out")
+	}
+}
+
+func TestAdminGetAllUserPrivacy_Empty(t *testing.T) {
+	setupGippityTest(t)
+
+	settings, err := AdminGetAllUserPrivacy()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(settings) != 0 {
+		t.Errorf("expected 0 settings, got %d", len(settings))
+	}
+}
+
+func TestAdminGetAllUserPrivacy_Multiple(t *testing.T) {
+	setupGippityTest(t)
+
+	if err := setUserPrivacy("user-a", true); err != nil {
+		t.Fatalf("setUserPrivacy user-a: %v", err)
+	}
+	if err := setUserPrivacy("user-b", false); err != nil {
+		t.Fatalf("setUserPrivacy user-b: %v", err)
+	}
+
+	settings, err := AdminGetAllUserPrivacy()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(settings) != 2 {
+		t.Fatalf("expected 2 settings, got %d", len(settings))
+	}
+	if !settings["user-a"] {
+		t.Error("expected user-a privacy=true")
+	}
+	if settings["user-b"] {
+		t.Error("expected user-b privacy=false")
+	}
+}
+
+func TestAdminHasConversationHistory_NoHistory(t *testing.T) {
+	setupGippityTest(t)
+
+	if AdminHasConversationHistory("unknown-user") {
+		t.Error("expected false for user with no history")
+	}
+}
+
+func TestAdminHasConversationHistory_WithHistory(t *testing.T) {
+	setupGippityTest(t)
+
+	if _, err := database.Exec(
+		`INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"user1", "chan1", 1000, "hello", "msg1", "guild1", 0,
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	if !AdminHasConversationHistory("user1") {
+		t.Error("expected true for user with history")
+	}
+}
+
+func TestAdminGetUsersWithHistory_Empty(t *testing.T) {
+	setupGippityTest(t)
+
+	users, err := AdminGetUsersWithHistory()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(users))
+	}
+}
+
+func TestAdminGetUsersWithHistory_Multiple(t *testing.T) {
+	setupGippityTest(t)
+
+	for i, uid := range []string{"user-a", "user-b", "user-a"} {
+		if _, err := database.Exec(
+			`INSERT INTO chat_history (user_id, channel_id, timestamp, message, message_id, guild_id, is_bot_mention) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			uid, "chan1", int64(1000+i), "msg", "msg"+string(rune('0'+i)), "guild1", 0,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	users, err := AdminGetUsersWithHistory()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 distinct users, got %d: %v", len(users), users)
+	}
+}


### PR DESCRIPTION
Closes #151

## Summary

- Add `/admin` slash command group (owner-only, all responses ephemeral)
- `/admin coffee beverages [@user]` — beverage emoji + intro status for one or all users
- `/admin gippity privacy [@user]` — privacy setting for one or all users
- `/admin gippity history [@user]` — whether a user has stored chat history
- `/admin info` — delegates to existing `buildBotStatsMessage` (same as `/status`)
- New `internal/admin` package; exported admin query fns added to `coffee` and `gippity` packages
- All endpoints are read-only; no mutations

## Test plan

- [ ] `make test` passes (all packages green)
- [ ] Non-owner receives ephemeral "Access denied." for any `/admin` subcommand
- [ ] Owner sees correct beverage data via `/admin coffee beverages`
- [ ] Owner sees correct privacy setting via `/admin gippity privacy`
- [ ] Owner sees correct history flag via `/admin gippity history`
- [ ] Owner sees bot stats via `/admin info`
- [ ] All responses are ephemeral (not visible to other users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)