### PR TITLE
fix(coffee): defer interactions before LLM calls to prevent Discord timeout

### DIFF
--- a/internal/coffee/brew.go
+++ b/internal/coffee/brew.go
@@ -137,7 +137,7 @@ func startBrew(s *discordgo.Session, guildID, channelID string) (alreadyBrewing 
 	brewMu.Unlock()
 
 	go func() {
-		time.Sleep(time.Until(readyAt))
+		time.Sleep(brewDuration)
 		markBrewReady(s, guildID, channelID)
 	}()
 

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -21,6 +21,24 @@ var (
 	generateLLMMessage = llm.GenerateMessage
 )
 
+// deferInteraction sends an immediate deferred acknowledgement so Discord doesn't
+// time out while the bot performs slow work (e.g. LLM calls).
+func deferInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, ephemeral bool) error {
+	var flags discordgo.MessageFlags
+	if ephemeral {
+		flags = discordgo.MessageFlagsEphemeral
+	}
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{Flags: flags},
+	})
+}
+
+// editDeferredResponse updates the deferred reply with the final content.
+func editDeferredResponse(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content})
+}
+
 // generateInteractionMessage detects the channel language and uses the LLM to generate
 // a response for the given scenario. Returns fallback on any error.
 func generateInteractionMessage(s *discordgo.Session, channelID, scenario, fallback string) string {
@@ -204,16 +222,11 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
+	_ = deferInteraction(s, i, true)
 	confirmMsg := generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("Confirm to the user that their morning beverage is now set to %s.", emoji),
 		fmt.Sprintf("Your morning beverage is now %s ☑️", emoji))
-	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: confirmMsg,
-			Flags:   discordgo.MessageFlagsEphemeral,
-		},
-	})
+	editDeferredResponse(s, i, confirmMsg)
 
 	if !introducedBefore {
 		sendIntroDM(s, userID, emoji)
@@ -224,27 +237,18 @@ func handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate)
 	alreadyBrewing, readyAt := startBrew(s, i.GuildID, i.ChannelID)
 	ts := fmt.Sprintf("<t:%d:R>", readyAt.Unix())
 	if alreadyBrewing {
+		_ = deferInteraction(s, i, true)
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"Coffee is already brewing. Tell the user in one short sentence.",
 			"☕ Coffee is already brewing!") + " " + ts
-		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: msg,
-				Flags:   discordgo.MessageFlagsEphemeral,
-			},
-		})
+		editDeferredResponse(s, i, msg)
 		return
 	}
+	_ = deferInteraction(s, i, false)
 	msg := generateInteractionMessage(s, i.ChannelID,
 		"A user just started brewing coffee. It will be ready in about 3 minutes. Announce this in one short sentence.",
 		"☕ Brewing coffee... Ready") + " " + ts
-	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: msg,
-		},
-	})
+	editDeferredResponse(s, i, msg)
 }
 
 func handleGrabCoffeeButton(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -258,16 +262,11 @@ func handleGrabCoffeeButton(s *discordgo.Session, i *discordgo.InteractionCreate
 	result := grabCoffee(i.GuildID, i.ChannelID, userID)
 
 	if result.notReady {
+		_ = deferInteraction(s, i, true)
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"A user tried to grab coffee but the pot is empty or not ready. Tell them in one short sentence.",
 			"Too late — the coffee pot is empty! ☕")
-		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: msg,
-				Flags:   discordgo.MessageFlagsEphemeral,
-			},
-		})
+		editDeferredResponse(s, i, msg)
 		return
 	}
 
@@ -293,29 +292,19 @@ func handleModifyLastCupButton(s *discordgo.Session, i *discordgo.InteractionCre
 	result := addToLastCup(i.GuildID, i.ChannelID, userID, milk, sugar)
 
 	if result.notReady {
+		_ = deferInteraction(s, i, true)
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"A user tried to add milk or sugar but the coffee pot is no longer available. Tell them in one short sentence.",
 			"No coffee available! ☕")
-		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: msg,
-				Flags:   discordgo.MessageFlagsEphemeral,
-			},
-		})
+		editDeferredResponse(s, i, msg)
 		return
 	}
 	if result.noCup {
+		_ = deferInteraction(s, i, true)
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"A user tried to add milk or sugar but hasn't grabbed a cup yet. Tell them to grab a cup first, in one short sentence.",
 			"Grab a cup first! ☕")
-		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: msg,
-				Flags:   discordgo.MessageFlagsEphemeral,
-			},
-		})
+		editDeferredResponse(s, i, msg)
 		return
 	}
 

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -14,16 +14,16 @@ import (
 const fallbackBeverage = "☕"
 
 var (
-	isSpecialDay       = util.IsSpecial
-	reactOnMessage     = util.ReactOnMessage
-	sendIntroDM        = sendIntroDMFunc
-	detectLanguage     = llm.DetectChannelLanguage
-	generateLLMMessage = llm.GenerateMessage
+	isSpecialDay         = util.IsSpecial
+	reactOnMessage       = util.ReactOnMessage
+	sendIntroDM          = sendIntroDMFunc
+	detectLanguage       = llm.DetectChannelLanguage
+	generateLLMMessage   = llm.GenerateMessage
+	deferInteraction     = deferInteractionImpl
+	editDeferredResponse = editDeferredResponseImpl
 )
 
-// deferInteraction sends an immediate deferred acknowledgement so Discord doesn't
-// time out while the bot performs slow work (e.g. LLM calls).
-func deferInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, ephemeral bool) error {
+func deferInteractionImpl(s *discordgo.Session, i *discordgo.InteractionCreate, ephemeral bool) error {
 	var flags discordgo.MessageFlags
 	if ephemeral {
 		flags = discordgo.MessageFlagsEphemeral
@@ -34,9 +34,10 @@ func deferInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, ephe
 	})
 }
 
-// editDeferredResponse updates the deferred reply with the final content.
-func editDeferredResponse(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
-	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content})
+func editDeferredResponseImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content}); err != nil {
+		slog.Error("coffee: failed to edit deferred response", "error", err)
+	}
 }
 
 // generateInteractionMessage detects the channel language and uses the LLM to generate
@@ -222,7 +223,10 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	_ = deferInteraction(s, i, true)
+	if err := deferInteraction(s, i, true); err != nil {
+		slog.Error("coffee: failed to defer interaction", "error", err)
+		return
+	}
 	confirmMsg := generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("Confirm to the user that their morning beverage is now set to %s.", emoji),
 		fmt.Sprintf("Your morning beverage is now %s ☑️", emoji))
@@ -237,14 +241,20 @@ func handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate)
 	alreadyBrewing, readyAt := startBrew(s, i.GuildID, i.ChannelID)
 	ts := fmt.Sprintf("<t:%d:R>", readyAt.Unix())
 	if alreadyBrewing {
-		_ = deferInteraction(s, i, true)
+		if err := deferInteraction(s, i, true); err != nil {
+			slog.Error("coffee: failed to defer interaction", "error", err)
+			return
+		}
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"Coffee is already brewing. Tell the user in one short sentence.",
 			"☕ Coffee is already brewing!") + " " + ts
 		editDeferredResponse(s, i, msg)
 		return
 	}
-	_ = deferInteraction(s, i, false)
+	if err := deferInteraction(s, i, false); err != nil {
+		slog.Error("coffee: failed to defer interaction", "error", err)
+		return
+	}
 	msg := generateInteractionMessage(s, i.ChannelID,
 		"A user just started brewing coffee. It will be ready in about 3 minutes. Announce this in one short sentence.",
 		"☕ Brewing coffee... Ready") + " " + ts
@@ -262,7 +272,10 @@ func handleGrabCoffeeButton(s *discordgo.Session, i *discordgo.InteractionCreate
 	result := grabCoffee(i.GuildID, i.ChannelID, userID)
 
 	if result.notReady {
-		_ = deferInteraction(s, i, true)
+		if err := deferInteraction(s, i, true); err != nil {
+			slog.Error("coffee: failed to defer interaction", "error", err)
+			return
+		}
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"A user tried to grab coffee but the pot is empty or not ready. Tell them in one short sentence.",
 			"Too late — the coffee pot is empty! ☕")
@@ -292,7 +305,10 @@ func handleModifyLastCupButton(s *discordgo.Session, i *discordgo.InteractionCre
 	result := addToLastCup(i.GuildID, i.ChannelID, userID, milk, sugar)
 
 	if result.notReady {
-		_ = deferInteraction(s, i, true)
+		if err := deferInteraction(s, i, true); err != nil {
+			slog.Error("coffee: failed to defer interaction", "error", err)
+			return
+		}
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"A user tried to add milk or sugar but the coffee pot is no longer available. Tell them in one short sentence.",
 			"No coffee available! ☕")
@@ -300,7 +316,10 @@ func handleModifyLastCupButton(s *discordgo.Session, i *discordgo.InteractionCre
 		return
 	}
 	if result.noCup {
-		_ = deferInteraction(s, i, true)
+		if err := deferInteraction(s, i, true); err != nil {
+			slog.Error("coffee: failed to defer interaction", "error", err)
+			return
+		}
 		msg := generateInteractionMessage(s, i.ChannelID,
 			"A user tried to add milk or sugar but hasn't grabbed a cup yet. Tell them to grab a cup first, in one short sentence.",
 			"Grab a cup first! ☕")

--- a/internal/coffee/coffee_test.go
+++ b/internal/coffee/coffee_test.go
@@ -333,3 +333,139 @@ func TestGenerateInteractionMessage_FallsBackOnEmptyReply(t *testing.T) {
 		t.Errorf("got %q, want fallback on empty LLM reply", got)
 	}
 }
+
+type deferCall struct {
+	ephemeral bool
+}
+
+type editCall struct {
+	content string
+}
+
+func stubInteractionHelpers(t *testing.T, deferErr error) (func() []deferCall, func() []editCall) {
+	t.Helper()
+
+	prevDefer := deferInteraction
+	prevEdit := editDeferredResponse
+	defers := []deferCall{}
+	edits := []editCall{}
+
+	deferInteraction = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, ephemeral bool) error {
+		defers = append(defers, deferCall{ephemeral: ephemeral})
+		return deferErr
+	}
+	editDeferredResponse = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string) {
+		edits = append(edits, editCall{content: content})
+	}
+
+	t.Cleanup(func() {
+		deferInteraction = prevDefer
+		editDeferredResponse = prevEdit
+	})
+
+	return func() []deferCall { return defers }, func() []editCall { return edits }
+}
+
+func makeBrewInteraction(guildID, channelID string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   guildID,
+			ChannelID: channelID,
+			Type:      discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name: "brew",
+			},
+		},
+	}
+}
+
+func makeComponentInteraction(guildID, channelID, customID, userID string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   guildID,
+			ChannelID: channelID,
+			Type:      discordgo.InteractionMessageComponent,
+			Member:    &discordgo.Member{User: &discordgo.User{ID: userID}},
+			Data:      discordgo.MessageComponentInteractionData{CustomID: customID},
+		},
+	}
+}
+
+func TestHandleBrewInteraction_DefersEphemeralWhenAlreadyBrewing(t *testing.T) {
+	openInMemoryStore(t)
+	resetBrewStates(t)
+	getDefers, getEdits := stubInteractionHelpers(t, nil)
+	stubLLM(t, "Already brewing!", nil)
+	captureBrewReadyMessages(t)
+
+	i := makeBrewInteraction("g1", "ch1")
+	handleBrewInteraction(nil, i)
+	handleBrewInteraction(nil, i)
+
+	defers := getDefers()
+	edits := getEdits()
+	if len(defers) < 2 {
+		t.Fatalf("expected at least 2 defer calls, got %d", len(defers))
+	}
+	if !defers[1].ephemeral {
+		t.Error("second /brew (already brewing) should defer as ephemeral")
+	}
+	if len(edits) < 2 {
+		t.Fatalf("expected at least 2 edit calls, got %d", len(edits))
+	}
+}
+
+func TestHandleBrewInteraction_DefersPublicOnNewBrew(t *testing.T) {
+	openInMemoryStore(t)
+	resetBrewStates(t)
+	getDefers, getEdits := stubInteractionHelpers(t, nil)
+	stubLLM(t, "Coffee brewing!", nil)
+	captureBrewReadyMessages(t)
+
+	handleBrewInteraction(nil, makeBrewInteraction("g2", "ch2"))
+
+	defers := getDefers()
+	if len(defers) != 1 {
+		t.Fatalf("expected 1 defer call, got %d", len(defers))
+	}
+	if defers[0].ephemeral {
+		t.Error("new brew should defer as public (not ephemeral)")
+	}
+	if len(getEdits()) != 1 {
+		t.Errorf("expected 1 edit call, got %d", len(getEdits()))
+	}
+}
+
+func TestHandleBrewInteraction_AbortsOnDeferError(t *testing.T) {
+	openInMemoryStore(t)
+	resetBrewStates(t)
+	_, getEdits := stubInteractionHelpers(t, fmt.Errorf("discord unavailable"))
+	stubLLM(t, "Coffee!", nil)
+	captureBrewReadyMessages(t)
+
+	handleBrewInteraction(nil, makeBrewInteraction("g3", "ch3"))
+
+	if len(getEdits()) != 0 {
+		t.Error("edit should not be called when defer fails")
+	}
+}
+
+func TestHandleGrabCoffeeButton_DefersEphemeralWhenNotReady(t *testing.T) {
+	openInMemoryStore(t)
+	resetBrewStates(t)
+	getDefers, getEdits := stubInteractionHelpers(t, nil)
+	stubLLM(t, "Pot is empty!", nil)
+
+	handleGrabCoffeeButton(nil, makeComponentInteraction("g4", "ch4", "grab_coffee", "user1"))
+
+	defers := getDefers()
+	if len(defers) != 1 {
+		t.Fatalf("expected 1 defer call, got %d", len(defers))
+	}
+	if !defers[0].ephemeral {
+		t.Error("grab when not ready should defer as ephemeral")
+	}
+	if len(getEdits()) != 1 {
+		t.Errorf("expected 1 edit call, got %d", len(getEdits()))
+	}
+}


### PR DESCRIPTION
## Summary
- All coffee slash command and button handlers called `generateInteractionMessage` (LLM API call) before `InteractionRespond`, routinely exceeding Discord's 3-second response deadline → "The application did not respond" error
- Fix: respond immediately with `InteractionResponseDeferredChannelMessageWithSource`, then call LLM, then edit the deferred response via `InteractionResponseEdit`
- Success paths for `grab_coffee` / `grab_milk` / `grab_sugar` that update the original message (no LLM involved) are left as `InteractionResponseUpdateMessage` — they're already fast

## Test plan
- [x] `go test ./internal/coffee/...` — all 50 tests pass
- [ ] Manual: `/brew` → bot shows "thinking…" then sends brew announcement without timeout
- [ ] Manual: `/brew` again → ephemeral "already brewing" message appears
- [ ] Manual: grab coffee button → pot message updates immediately
- [ ] Manual: `grab_coffee` when pot empty → ephemeral error without timeout

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)