### PR TITLE
feat(coffee): add tea and mate support to /brew

### DIFF
--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -13,6 +13,34 @@ import (
 
 const fallbackBeverage = "☕"
 
+type beverage struct {
+	name     string
+	response string
+}
+
+var beverages = []beverage{
+	{"tea", "🍵 Tea. Yeah, this counts too."},
+	{"mate", "🧉 Mate. For those who haven't fallen asleep yet."},
+}
+
+func findBeverage(name string) (beverage, bool) {
+	for _, bev := range beverages {
+		if bev.name == name {
+			return bev, true
+		}
+	}
+	return beverage{}, false
+}
+
+func availableBeverageNames() string {
+	names := make([]string, 0, len(beverages)+1)
+	names = append(names, "coffee")
+	for _, bev := range beverages {
+		names = append(names, bev.name)
+	}
+	return strings.Join(names, ", ")
+}
+
 var (
 	isSpecialDay         = util.IsSpecial
 	reactOnMessage       = util.ReactOnMessage
@@ -100,7 +128,15 @@ func Commands() []*discordgo.ApplicationCommand {
 		},
 		{
 			Name:        "brew",
-			Description: "Start brewing a pot of coffee (~3 minutes until ready)",
+			Description: "Brew something: coffee (timer + grab buttons), or tea/mate (instant)",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "beverage",
+					Description: "What to brew: coffee (default), tea, mate",
+					Required:    false,
+				},
+			},
 		},
 	}
 }
@@ -238,6 +274,29 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 }
 
 func handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	name := ""
+	if opts := i.ApplicationCommandData().Options; len(opts) > 0 {
+		name = strings.ToLower(strings.TrimSpace(opts[0].StringValue()))
+	}
+
+	if name != "" && name != "coffee" {
+		if bev, ok := findBeverage(name); ok {
+			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{Content: bev.response},
+			})
+			return
+		}
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf("I don't know that one. Try: %s", availableBeverageNames()),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
 	alreadyBrewing, readyAt := startBrew(s, i.GuildID, i.ChannelID)
 	ts := fmt.Sprintf("<t:%d:R>", readyAt.Unix())
 	if alreadyBrewing {

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -18,6 +18,7 @@ type beverage struct {
 	response string
 }
 
+// coffee is intentionally absent: it goes through the 3-min timer + grab-button flow, not instant response.
 var beverages = []beverage{
 	{"tea", "🍵 Tea. Yeah, this counts too."},
 	{"mate", "🧉 Mate. For those who haven't fallen asleep yet."},

--- a/internal/coffee/coffee_test.go
+++ b/internal/coffee/coffee_test.go
@@ -3,6 +3,7 @@ package coffee
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -467,5 +468,38 @@ func TestHandleGrabCoffeeButton_DefersEphemeralWhenNotReady(t *testing.T) {
 	}
 	if len(getEdits()) != 1 {
 		t.Errorf("expected 1 edit call, got %d", len(getEdits()))
+	}
+}
+
+func TestFindBeverage_KnownBeverages(t *testing.T) {
+	tests := []struct {
+		name     string
+		wantOK   bool
+		wantResp string
+	}{
+		{"tea", true, "🍵 Tea. Yeah, this counts too."},
+		{"mate", true, "🧉 Mate. For those who haven't fallen asleep yet."},
+		{"coffee", false, ""},
+		{"unknown", false, ""},
+		{"", false, ""},
+		{"TEA", false, ""},
+	}
+	for _, tt := range tests {
+		bev, ok := findBeverage(tt.name)
+		if ok != tt.wantOK {
+			t.Errorf("findBeverage(%q) ok = %v, want %v", tt.name, ok, tt.wantOK)
+		}
+		if ok && bev.response != tt.wantResp {
+			t.Errorf("findBeverage(%q) response = %q, want %q", tt.name, bev.response, tt.wantResp)
+		}
+	}
+}
+
+func TestAvailableBeverageNames(t *testing.T) {
+	names := availableBeverageNames()
+	for _, want := range []string{"coffee", "tea", "mate"} {
+		if !strings.Contains(names, want) {
+			t.Errorf("availableBeverageNames() = %q, want to contain %q", names, want)
+		}
 	}
 }

--- a/internal/coffee/coffee_test.go
+++ b/internal/coffee/coffee_test.go
@@ -3,7 +3,6 @@ package coffee
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -496,10 +495,8 @@ func TestFindBeverage_KnownBeverages(t *testing.T) {
 }
 
 func TestAvailableBeverageNames(t *testing.T) {
-	names := availableBeverageNames()
-	for _, want := range []string{"coffee", "tea", "mate"} {
-		if !strings.Contains(names, want) {
-			t.Errorf("availableBeverageNames() = %q, want to contain %q", names, want)
-		}
+	want := "coffee, tea, mate"
+	if got := availableBeverageNames(); got != want {
+		t.Errorf("availableBeverageNames() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `tea` and `mate` to `/brew` per ADR-001 rev 2 (toksikk's comment on #186)
- Simple `beverage` struct + `beverages` slice in `internal/coffee` — no interface, no registry
- `/brew tea` / `/brew mate` → immediate public response
- `/brew` / `/brew coffee` → existing 3-min timer + grab-button flow (unchanged)
- Unknown beverage → ephemeral error listing valid options

## Test plan

- [x] `TestFindBeverage_KnownBeverages` — tea/mate found, coffee/unknown/empty not found, case-sensitive
- [x] `TestAvailableBeverageNames` — list includes coffee, tea, mate
- [x] All existing coffee package tests still pass

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)