### PR TITLE
fix(coffee,leetoclock): cap coffee cup to remaining pot volume; fix leap year

### DIFF
--- a/internal/coffee/brew.go
+++ b/internal/coffee/brew.go
@@ -173,11 +173,11 @@ func grabCoffee(guildID, channelID, userID string) grabResult {
 		return grabResult{notReady: true}
 	}
 	cup := CupTaken{ml: randCupSize()}
+	if cup.ml > st.coffeeLiters {
+		cup.ml = st.coffeeLiters
+	}
 	st.grabs = append(st.grabs, grabRecord{userID: userID, cup: cup})
 	st.coffeeLiters -= cup.ml
-	if st.coffeeLiters < 0 {
-		st.coffeeLiters = 0
-	}
 	labels := st.buttonLabels
 	isEmpty := st.coffeeLiters < emptyThreshold
 	updatedMsg := buildBrewMessage(st)

--- a/internal/coffee/brew.go
+++ b/internal/coffee/brew.go
@@ -18,9 +18,9 @@ const (
 
 // CupTaken records the details of a single cup of coffee taken by a user.
 type CupTaken struct {
-	ml    float64
-	milk  bool
-	sugar bool
+	liters float64
+	milk   bool
+	sugar  bool
 }
 
 type grabRecord struct {
@@ -41,7 +41,7 @@ type grabResult struct {
 	notReady     bool
 	noCup        bool // tried to add milk/sugar but user has no cup in this brew
 	isEmpty      bool
-	cupML        float64
+	cupLiters    float64
 	updatedMsg   string
 	buttonLabels [3]string
 }
@@ -172,12 +172,12 @@ func grabCoffee(guildID, channelID, userID string) grabResult {
 	if !ok || !st.isReady || st.coffeeLiters < emptyThreshold {
 		return grabResult{notReady: true}
 	}
-	cup := CupTaken{ml: randCupSize()}
-	if cup.ml > st.coffeeLiters {
-		cup.ml = st.coffeeLiters
+	cup := CupTaken{liters: randCupSize()}
+	if cup.liters > st.coffeeLiters {
+		cup.liters = st.coffeeLiters
 	}
 	st.grabs = append(st.grabs, grabRecord{userID: userID, cup: cup})
-	st.coffeeLiters -= cup.ml
+	st.coffeeLiters -= cup.liters
 	labels := st.buttonLabels
 	isEmpty := st.coffeeLiters < emptyThreshold
 	updatedMsg := buildBrewMessage(st)
@@ -185,7 +185,7 @@ func grabCoffee(guildID, channelID, userID string) grabResult {
 		delete(brewStates, key)
 	}
 	return grabResult{
-		cupML:        cup.ml,
+		cupLiters:    cup.liters,
 		isEmpty:      isEmpty,
 		updatedMsg:   updatedMsg,
 		buttonLabels: labels,
@@ -246,10 +246,10 @@ func buildBrewMessage(st *brewState) string {
 
 	for _, uid := range userOrder {
 		cups := userGrabs[uid]
-		var totalML float64
+		var totalLiters float64
 		cupDescs := make([]string, 0, len(cups))
 		for _, c := range cups {
-			totalML += c.ml
+			totalLiters += c.liters
 			emoji := "☕"
 			if c.milk {
 				emoji += "🥛"
@@ -257,14 +257,14 @@ func buildBrewMessage(st *brewState) string {
 			if c.sugar {
 				emoji += "🍬"
 			}
-			cupDescs = append(cupDescs, fmt.Sprintf("%s ~%.0fml", emoji, c.ml*1000))
+			cupDescs = append(cupDescs, fmt.Sprintf("%s ~%.0fml", emoji, c.liters*1000))
 		}
 		cupsWord := "cup"
 		if len(cups) > 1 {
 			cupsWord = "cups"
 		}
 		fmt.Fprintf(&sb, "\n<@%s>: %d %s (~%.0fml) — %s",
-			uid, len(cups), cupsWord, totalML*1000, strings.Join(cupDescs, ", "))
+			uid, len(cups), cupsWord, totalLiters*1000, strings.Join(cupDescs, ", "))
 	}
 
 	if st.coffeeLiters < emptyThreshold {

--- a/internal/coffee/brew_test.go
+++ b/internal/coffee/brew_test.go
@@ -205,12 +205,12 @@ func TestGrabCoffee_RandomCupSize(t *testing.T) {
 	if result.notReady {
 		t.Fatal("expected successful grab")
 	}
-	if result.cupML < 0.15 || result.cupML > 0.35 {
-		t.Errorf("cupML = %.3f, want between 0.150 and 0.350", result.cupML)
+	if result.cupLiters < 0.15 || result.cupLiters > 0.35 {
+		t.Errorf("cupLiters = %.3f, want between 0.150 and 0.350", result.cupLiters)
 	}
-	ml := int(result.cupML * 1000)
+	ml := int(result.cupLiters * 1000)
 	if ml%10 != 0 {
-		t.Errorf("cupML should be in 10ml increments, got %dml", ml)
+		t.Errorf("cupLiters should be in 10ml increments, got %dml", ml)
 	}
 }
 
@@ -295,7 +295,7 @@ func TestGrabCoffee_PotEmpties(t *testing.T) {
 	}
 }
 
-func TestGrabCoffee_CupsCapToRemainingML(t *testing.T) {
+func TestGrabCoffee_CupsCappedToRemainingLiters(t *testing.T) {
 	resetBrewStates(t)
 	useFixedCupSize(t, 0.30) // cup wants 300ml but only 50ml left
 	brewMu.Lock()
@@ -309,8 +309,8 @@ func TestGrabCoffee_CupsCapToRemainingML(t *testing.T) {
 	if result.notReady {
 		t.Fatal("expected successful grab")
 	}
-	if result.cupML > 0.05+1e-9 {
-		t.Errorf("cupML = %.4f, want <= 0.05 (capped to remaining)", result.cupML)
+	if result.cupLiters > 0.05+1e-9 {
+		t.Errorf("cupLiters = %.4f, want <= 0.05 (capped to remaining)", result.cupLiters)
 	}
 	if !result.isEmpty {
 		t.Error("expected isEmpty=true after draining last drop")
@@ -353,7 +353,7 @@ func TestAddToLastCup_AddsMilk(t *testing.T) {
 	brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
-		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{ml: 0.25}}},
+		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
 	brewMu.Unlock()
 
@@ -380,7 +380,7 @@ func TestAddToLastCup_AddsSugar(t *testing.T) {
 	brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
-		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{ml: 0.25}}},
+		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
 	brewMu.Unlock()
 
@@ -401,7 +401,7 @@ func TestAddToLastCup_CombinesMilkAndSugar(t *testing.T) {
 	brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
-		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{ml: 0.25}}},
+		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
 	brewMu.Unlock()
 
@@ -424,8 +424,8 @@ func TestAddToLastCup_ModifiesLastCupOnly(t *testing.T) {
 		isReady:      true,
 		coffeeLiters: potCapacity,
 		grabs: []grabRecord{
-			{userID: "user1", cup: CupTaken{ml: 0.25}},
-			{userID: "user1", cup: CupTaken{ml: 0.20}},
+			{userID: "user1", cup: CupTaken{liters: 0.25}},
+			{userID: "user1", cup: CupTaken{liters: 0.20}},
 		},
 	}
 	brewMu.Unlock()
@@ -451,7 +451,7 @@ func TestAddToLastCup_DoesNotAffectPotLevel(t *testing.T) {
 	brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
-		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{ml: 0.25}}},
+		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
 	brewMu.Unlock()
 
@@ -498,9 +498,9 @@ func TestBuildBrewMessage_WithCups(t *testing.T) {
 		readyAnnouncement: "Coffee is ready!",
 		coffeeLiters:      1.25,
 		grabs: []grabRecord{
-			{userID: "alice", cup: CupTaken{ml: 0.25, milk: false, sugar: false}},
-			{userID: "bob", cup: CupTaken{ml: 0.25, milk: true, sugar: false}},
-			{userID: "alice", cup: CupTaken{ml: 0.25, milk: false, sugar: true}},
+			{userID: "alice", cup: CupTaken{liters: 0.25, milk: false, sugar: false}},
+			{userID: "bob", cup: CupTaken{liters: 0.25, milk: true, sugar: false}},
+			{userID: "alice", cup: CupTaken{liters: 0.25, milk: false, sugar: true}},
 		},
 	}
 	got := buildBrewMessage(st)
@@ -527,7 +527,7 @@ func TestBuildBrewMessage_EmptyPot(t *testing.T) {
 		readyAnnouncement: "Coffee is ready!",
 		coffeeLiters:      0.0,
 		grabs: []grabRecord{
-			{userID: "user1", cup: CupTaken{ml: 0.25}},
+			{userID: "user1", cup: CupTaken{liters: 0.25}},
 		},
 	}
 	got := buildBrewMessage(st)

--- a/internal/coffee/brew_test.go
+++ b/internal/coffee/brew_test.go
@@ -295,6 +295,35 @@ func TestGrabCoffee_PotEmpties(t *testing.T) {
 	}
 }
 
+func TestGrabCoffee_CupsCapToRemainingML(t *testing.T) {
+	resetBrewStates(t)
+	useFixedCupSize(t, 0.30) // cup wants 300ml but only 50ml left
+	brewMu.Lock()
+	brewStates["guild1:channel1"] = &brewState{
+		isReady:      true,
+		coffeeLiters: 0.05,
+	}
+	brewMu.Unlock()
+
+	result := grabCoffee("guild1", "channel1", "user1")
+	if result.notReady {
+		t.Fatal("expected successful grab")
+	}
+	if result.cupML > 0.05+1e-9 {
+		t.Errorf("cupML = %.4f, want <= 0.05 (capped to remaining)", result.cupML)
+	}
+	if !result.isEmpty {
+		t.Error("expected isEmpty=true after draining last drop")
+	}
+
+	brewMu.Lock()
+	_, exists := brewStates["guild1:channel1"]
+	brewMu.Unlock()
+	if exists {
+		t.Error("expected brew state deleted after pot is empty")
+	}
+}
+
 func TestAddToLastCup_NoBrew(t *testing.T) {
 	resetBrewStates(t)
 	result := addToLastCup("guild1", "channel1", "user1", true, false)

--- a/internal/leetoclock/util/datastore/datastore.go
+++ b/internal/leetoclock/util/datastore/datastore.go
@@ -101,21 +101,7 @@ func getSeasonStartDateForDate(date time.Time) time.Time {
 }
 
 func getSeasonEndDateForDate(date time.Time) time.Time {
-	var lastDayOfMonth int
-	switch date.Month() {
-	case time.January, time.March, time.May, time.July, time.August, time.October, time.December:
-		lastDayOfMonth = 31
-	case time.April, time.June, time.September, time.November:
-		lastDayOfMonth = 30
-	case time.February:
-		if date.Year()%4 == 0 {
-			lastDayOfMonth = 29
-		} else {
-			lastDayOfMonth = 28
-		}
-	}
-
-	return time.Date(date.Year(), date.Month(), lastDayOfMonth, 23, 59, 59, 999999999, date.Location())
+	return time.Date(date.Year(), date.Month()+1, 0, 23, 59, 59, 999999999, date.Location())
 }
 
 // SEASON

--- a/internal/leetoclock/util/datastore/datastore_test.go
+++ b/internal/leetoclock/util/datastore/datastore_test.go
@@ -44,6 +44,11 @@ func TestGetSeasonEndDateForDate(t *testing.T) {
 			date: time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC),
 			want: time.Date(2000, time.February, 29, 23, 59, 59, 999999999, time.UTC),
 		},
+		{
+			name: "December month overflow (month+1=13 normalises to January next year)",
+			date: time.Date(2023, time.December, 15, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2023, time.December, 31, 23, 59, 59, 999999999, time.UTC),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/leetoclock/util/datastore/datastore_test.go
+++ b/internal/leetoclock/util/datastore/datastore_test.go
@@ -8,6 +8,53 @@ import (
 	"gorm.io/gorm"
 )
 
+func TestGetSeasonEndDateForDate(t *testing.T) {
+	tests := []struct {
+		name string
+		date time.Time
+		want time.Time
+	}{
+		{
+			name: "31-day month",
+			date: time.Date(2023, time.July, 8, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2023, time.July, 31, 23, 59, 59, 999999999, time.UTC),
+		},
+		{
+			name: "30-day month",
+			date: time.Date(2023, time.April, 15, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2023, time.April, 30, 23, 59, 59, 999999999, time.UTC),
+		},
+		{
+			name: "February non-leap",
+			date: time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2023, time.February, 28, 23, 59, 59, 999999999, time.UTC),
+		},
+		{
+			name: "February leap year divisible by 4",
+			date: time.Date(2024, time.February, 10, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2024, time.February, 29, 23, 59, 59, 999999999, time.UTC),
+		},
+		{
+			name: "February century year (not leap)",
+			date: time.Date(2100, time.February, 5, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2100, time.February, 28, 23, 59, 59, 999999999, time.UTC),
+		},
+		{
+			name: "February 400-year cycle (leap)",
+			date: time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2000, time.February, 29, 23, 59, 59, 999999999, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getSeasonEndDateForDate(tt.date)
+			if !got.Equal(tt.want) {
+				t.Errorf("getSeasonEndDateForDate(%v) = %v, want %v", tt.date, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStore_EnsureSeason(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
 	if err != nil {


### PR DESCRIPTION
## Summary

- **#169** `grabCoffee` now caps `cup.ml` to the remaining liters in the pot before recording the grab, so the message can never report more coffee poured than was available.
- **#112** `getSeasonEndDateForDate` replaced hand-rolled month-length switch (which also had a broken century-year leap check — year%4 is wrong for 2100) with the stdlib day-0-of-next-month idiom.

## Test plan

- [ ] `TestGrabCoffee_CupsCapToRemainingML` — verifies cup is capped to 50ml when 300ml cup requested but only 50ml left
- [ ] `TestGetSeasonEndDateForDate` — covers 31-day, 30-day, Feb non-leap, Feb÷4 leap, Feb century non-leap (2100), Feb 400-year leap (2000)
- [ ] `go test ./internal/coffee/... ./internal/leetoclock/...` all green

Closes #169
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)