### PR TITLE
refactor: land internal/bot skeleton (router, middleware, background supervisor)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -25,8 +25,8 @@ jobs:
                         - 'go.sum'
                         - 'Makefile'
 
-    check_and_build:
-        name: Check and build
+    check_code:
+        name: Check code
         needs: detect_changes
         if: needs.detect_changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
@@ -46,6 +46,21 @@ jobs:
             - name: Test
               run: go test ./...
 
+    build:
+        name: Build
+        needs: detect_changes
+        if: needs.detect_changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Setup Go
+              uses: actions/setup-go@v6
+              with:
+                  go-version-file: go.mod
+                  cache-dependency-path: go.sum
+
             - name: Build
               run: make build
 
@@ -61,7 +76,7 @@ jobs:
                     !startsWith(github.ref_name, 'dependabot/')
                 )
             }}
-        needs: check_and_build
+        needs: [check_code, build]
         runs-on: ubuntu-latest
 
         steps:

--- a/internal/bot/background.go
+++ b/internal/bot/background.go
@@ -19,7 +19,9 @@ func newBackgroundSupervisor() *BackgroundSupervisor {
 // Each task is supervised: panics are logged and do not crash the process.
 func (bs *BackgroundSupervisor) Start(ctx context.Context, tasks ...BackgroundTask) {
 	for _, t := range tasks {
-		bs.wg.Go(func() {
+		bs.wg.Add(1)
+		go func(t BackgroundTask) {
+			defer bs.wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					slog.Error("bot/background: task panicked", "task", t.Name, "panic", r)
@@ -28,7 +30,7 @@ func (bs *BackgroundSupervisor) Start(ctx context.Context, tasks ...BackgroundTa
 			slog.Info("bot/background: task started", "task", t.Name)
 			t.Run(ctx)
 			slog.Info("bot/background: task stopped", "task", t.Name)
-		})
+		}(t)
 	}
 }
 

--- a/internal/bot/background.go
+++ b/internal/bot/background.go
@@ -1,0 +1,38 @@
+package bot
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// BackgroundSupervisor manages supervised context-aware goroutines.
+type BackgroundSupervisor struct {
+	wg sync.WaitGroup
+}
+
+func newBackgroundSupervisor() *BackgroundSupervisor {
+	return &BackgroundSupervisor{}
+}
+
+// Start launches each task in its own goroutine under ctx.
+// Each task is supervised: panics are logged and do not crash the process.
+func (bs *BackgroundSupervisor) Start(ctx context.Context, tasks ...BackgroundTask) {
+	for _, t := range tasks {
+		bs.wg.Go(func() {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("bot/background: task panicked", "task", t.Name, "panic", r)
+				}
+			}()
+			slog.Info("bot/background: task started", "task", t.Name)
+			t.Run(ctx)
+			slog.Info("bot/background: task stopped", "task", t.Name)
+		})
+	}
+}
+
+// Wait blocks until all supervised tasks have returned.
+func (bs *BackgroundSupervisor) Wait() {
+	bs.wg.Wait()
+}

--- a/internal/bot/background_test.go
+++ b/internal/bot/background_test.go
@@ -7,6 +7,30 @@ import (
 	"time"
 )
 
+func waitForBool(t *testing.T, b *atomic.Bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if b.Load() {
+			return
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
+}
+
+func waitForInt32(t *testing.T, b *atomic.Int32, want int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if b.Load() == want {
+			return
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+	t.Fatalf("timed out: want %d, got %d", want, b.Load())
+}
+
 func TestBackgroundSupervisor_RunsTask(t *testing.T) {
 	bs := newBackgroundSupervisor()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -20,7 +44,7 @@ func TestBackgroundSupervisor_RunsTask(t *testing.T) {
 		},
 	})
 
-	time.Sleep(10 * time.Millisecond)
+	waitForBool(t, &ran, 500*time.Millisecond)
 	if !ran.Load() {
 		t.Fatal("task did not start")
 	}
@@ -46,7 +70,7 @@ func TestBackgroundSupervisor_MultipleTasksAllRun(t *testing.T) {
 	}
 	bs.Start(ctx, tasks...)
 
-	time.Sleep(20 * time.Millisecond)
+	waitForInt32(t, &count, 5, 500*time.Millisecond)
 	if got := count.Load(); got != 5 {
 		t.Fatalf("want 5 tasks running, got %d", got)
 	}

--- a/internal/bot/background_test.go
+++ b/internal/bot/background_test.go
@@ -1,0 +1,95 @@
+package bot
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBackgroundSupervisor_RunsTask(t *testing.T) {
+	bs := newBackgroundSupervisor()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var ran atomic.Bool
+	bs.Start(ctx, BackgroundTask{
+		Name: "test",
+		Run: func(ctx context.Context) {
+			ran.Store(true)
+			<-ctx.Done()
+		},
+	})
+
+	time.Sleep(10 * time.Millisecond)
+	if !ran.Load() {
+		t.Fatal("task did not start")
+	}
+	cancel()
+	bs.Wait()
+}
+
+func TestBackgroundSupervisor_MultipleTasksAllRun(t *testing.T) {
+	bs := newBackgroundSupervisor()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var count atomic.Int32
+	tasks := make([]BackgroundTask, 5)
+	for i := range tasks {
+		tasks[i] = BackgroundTask{
+			Name: "task",
+			Run: func(ctx context.Context) {
+				count.Add(1)
+				<-ctx.Done()
+			},
+		}
+	}
+	bs.Start(ctx, tasks...)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := count.Load(); got != 5 {
+		t.Fatalf("want 5 tasks running, got %d", got)
+	}
+	cancel()
+	bs.Wait()
+}
+
+func TestBackgroundSupervisor_PanicDoesNotCrash(t *testing.T) {
+	bs := newBackgroundSupervisor()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bs.Start(ctx, BackgroundTask{
+		Name: "panicky",
+		Run:  func(_ context.Context) { panic("boom") },
+	})
+	bs.Wait()
+}
+
+func TestBackgroundSupervisor_StopsOnContextCancel(t *testing.T) {
+	bs := newBackgroundSupervisor()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stopped atomic.Bool
+	bs.Start(ctx, BackgroundTask{
+		Name: "stopper",
+		Run: func(ctx context.Context) {
+			<-ctx.Done()
+			stopped.Store(true)
+		},
+	})
+
+	cancel()
+	bs.Wait()
+	if !stopped.Load() {
+		t.Fatal("task did not observe context cancellation")
+	}
+}
+
+func TestBackgroundSupervisor_EmptyStartIsNoop(t *testing.T) {
+	bs := newBackgroundSupervisor()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bs.Start(ctx)
+	bs.Wait()
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -1,0 +1,71 @@
+package bot
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Bot wires together a Router, BackgroundSupervisor, and registered Modules.
+type Bot struct {
+	deps       Deps
+	Router     *Router
+	background *BackgroundSupervisor
+	cancel     context.CancelFunc
+	modules    []Module
+}
+
+// New creates a Bot from the given Deps.
+func New(d Deps) *Bot {
+	return &Bot{
+		deps:       d,
+		Router:     newRouter(d),
+		background: newBackgroundSupervisor(),
+	}
+}
+
+// RegisterModule wires a Module's commands, listeners, and background tasks into the Bot.
+func (b *Bot) RegisterModule(m Module) error {
+	if err := b.Router.register(m, b.deps); err != nil {
+		return err
+	}
+	for _, comp := range m.Components() {
+		b.Router.AddComponent(comp.Prefix, comp.Handler)
+	}
+	for _, cmd := range m.Commands() {
+		b.Router.AddCommand(cmd.Name, nil)
+	}
+	b.modules = append(b.modules, m)
+	return nil
+}
+
+// Run registers the router on the Discord session and blocks until ctx is cancelled.
+func (b *Bot) Run(ctx context.Context) error {
+	ctx, b.cancel = context.WithCancel(ctx)
+
+	b.deps.Session.AddHandler(b.Router.onInteractionCreate)
+	b.deps.Session.AddHandler(b.Router.onMessageCreate)
+
+	var tasks []BackgroundTask
+	for _, m := range b.modules {
+		tasks = append(tasks, m.Background()...)
+	}
+	b.background.Start(ctx, tasks...)
+
+	slog.Info("bot: running")
+	<-ctx.Done()
+	return nil
+}
+
+// Shutdown cancels the context, waits for background tasks, and shuts down modules.
+func (b *Bot) Shutdown() {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	b.background.Wait()
+	for _, m := range b.modules {
+		if err := m.Shutdown(); err != nil {
+			slog.Error("bot: module shutdown error", "module", m.Name(), "error", err)
+		}
+	}
+	slog.Info("bot: shutdown complete")
+}

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -1,0 +1,45 @@
+package bot
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// stubModule is a minimal Module implementation for testing.
+type stubModule struct {
+	name    string
+	initErr error
+}
+
+func (s *stubModule) Name() string                               { return s.name }
+func (s *stubModule) Init(_ Deps) error                         { return s.initErr }
+func (s *stubModule) Commands() []*discordgo.ApplicationCommand { return nil }
+func (s *stubModule) Listeners() []EventListener                { return nil }
+func (s *stubModule) Components() []ComponentHandler            { return nil }
+func (s *stubModule) Background() []BackgroundTask              { return nil }
+func (s *stubModule) Shutdown() error                           { return nil }
+
+func TestBot_RegisterModule_Success(t *testing.T) {
+	b := New(Deps{})
+	if err := b.RegisterModule(&stubModule{name: "ok"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBot_RegisterModule_InitError(t *testing.T) {
+	b := New(Deps{})
+	want := errors.New("init failed")
+	if err := b.RegisterModule(&stubModule{name: "bad", initErr: want}); !errors.Is(err, want) {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+}
+
+func TestBot_RegisterModule_InitErrorDoesNotAddModule(t *testing.T) {
+	b := New(Deps{})
+	_ = b.RegisterModule(&stubModule{name: "bad", initErr: errors.New("boom")})
+	if len(b.modules) != 0 {
+		t.Fatalf("failed module should not be appended, got %d modules", len(b.modules))
+	}
+}

--- a/internal/bot/deps.go
+++ b/internal/bot/deps.go
@@ -1,0 +1,18 @@
+package bot
+
+import (
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	openai "github.com/openai/openai-go/v3"
+	"github.com/toksikk/gidbig/internal/cfg"
+)
+
+// Deps holds shared dependencies injected into every Module.
+type Deps struct {
+	Session *discordgo.Session
+	Config  *cfg.Config
+	LLM     *openai.Client
+	Logger  *slog.Logger
+	OwnerID string
+}

--- a/internal/bot/middleware.go
+++ b/internal/bot/middleware.go
@@ -64,6 +64,10 @@ func RateLimit(d time.Duration) Middleware {
 
 	return func(next HandlerFunc) HandlerFunc {
 		return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			if i.Type != discordgo.InteractionApplicationCommand {
+				next(s, i)
+				return
+			}
 			key := interactionUserID(i) + ":" + i.ApplicationCommandData().Name
 
 			mu.Lock()
@@ -106,7 +110,11 @@ func WithCorrelationID() Middleware {
 	return func(next HandlerFunc) HandlerFunc {
 		return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			id := counter.Add(1)
-			slog.Debug("bot/middleware: interaction", "correlation_id", id, "command", i.ApplicationCommandData().Name)
+			if i.Type == discordgo.InteractionApplicationCommand {
+				slog.Debug("bot/middleware: interaction", "correlation_id", id, "command", i.ApplicationCommandData().Name)
+			} else {
+				slog.Debug("bot/middleware: interaction", "correlation_id", id)
+			}
 			next(s, i)
 		}
 	}

--- a/internal/bot/middleware.go
+++ b/internal/bot/middleware.go
@@ -1,0 +1,113 @@
+package bot
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// HandlerFunc is the type for slash-command interaction handlers.
+type HandlerFunc func(*discordgo.Session, *discordgo.InteractionCreate)
+
+// Middleware wraps a HandlerFunc to add cross-cutting behaviour.
+type Middleware func(HandlerFunc) HandlerFunc
+
+// interactionRespondFn is swappable in tests.
+var interactionRespondFn = func(s *discordgo.Session, i *discordgo.Interaction, r *discordgo.InteractionResponse) error {
+	return s.InteractionRespond(i, r)
+}
+
+func denyEphemeral(s *discordgo.Session, i *discordgo.InteractionCreate, msg string) {
+	_ = interactionRespondFn(s, i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: msg,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+func interactionUserID(i *discordgo.InteractionCreate) string {
+	if i.Member != nil {
+		return i.Member.User.ID
+	}
+	if i.User != nil {
+		return i.User.ID
+	}
+	return ""
+}
+
+// OwnerOnly rejects interactions from non-owner users with an ephemeral denial.
+func OwnerOnly(ownerID string) Middleware {
+	return func(next HandlerFunc) HandlerFunc {
+		return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			if interactionUserID(i) != ownerID {
+				denyEphemeral(s, i, "Access denied.")
+				return
+			}
+			next(s, i)
+		}
+	}
+}
+
+// RateLimit rejects interactions that arrive faster than d per user per command.
+func RateLimit(d time.Duration) Middleware {
+	type bucket struct {
+		mu   sync.Mutex
+		last time.Time
+	}
+	var mu sync.Mutex
+	buckets := make(map[string]*bucket)
+
+	return func(next HandlerFunc) HandlerFunc {
+		return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			key := interactionUserID(i) + ":" + i.ApplicationCommandData().Name
+
+			mu.Lock()
+			b, ok := buckets[key]
+			if !ok {
+				b = &bucket{}
+				buckets[key] = b
+			}
+			mu.Unlock()
+
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			if time.Since(b.last) < d {
+				denyEphemeral(s, i, "Slow down.")
+				return
+			}
+			b.last = time.Now()
+			next(s, i)
+		}
+	}
+}
+
+// Recover catches panics in a handler and logs them without crashing the process.
+func Recover() Middleware {
+	return func(next HandlerFunc) HandlerFunc {
+		return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("bot/middleware: recovered from panic", "panic", r)
+				}
+			}()
+			next(s, i)
+		}
+	}
+}
+
+// WithCorrelationID tags each interaction with a monotonic ID and logs it.
+func WithCorrelationID() Middleware {
+	var counter atomic.Uint64
+	return func(next HandlerFunc) HandlerFunc {
+		return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			id := counter.Add(1)
+			slog.Debug("bot/middleware: interaction", "correlation_id", id, "command", i.ApplicationCommandData().Name)
+			next(s, i)
+		}
+	}
+}

--- a/internal/bot/middleware_test.go
+++ b/internal/bot/middleware_test.go
@@ -1,0 +1,233 @@
+package bot
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// fakeInteraction builds a minimal InteractionCreate for a slash command.
+func fakeInteraction(userID, commandName string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Member: &discordgo.Member{
+				User: &discordgo.User{ID: userID},
+			},
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name: commandName,
+			},
+		},
+	}
+}
+
+// captureRespond replaces interactionRespondFn for a test and returns the captured responses.
+func captureRespond(t *testing.T) *[]*discordgo.InteractionResponse {
+	t.Helper()
+	orig := interactionRespondFn
+	t.Cleanup(func() { interactionRespondFn = orig })
+
+	var captured []*discordgo.InteractionResponse
+	interactionRespondFn = func(_ *discordgo.Session, _ *discordgo.Interaction, r *discordgo.InteractionResponse) error {
+		captured = append(captured, r)
+		return nil
+	}
+	return &captured
+}
+
+func applyChain(h HandlerFunc, mw ...Middleware) HandlerFunc {
+	for i := len(mw) - 1; i >= 0; i-- {
+		h = mw[i](h)
+	}
+	return h
+}
+
+// --- OwnerOnly ---
+
+func TestOwnerOnly_OwnerPasses(t *testing.T) {
+	captured := captureRespond(t)
+	var called atomic.Bool
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	}, OwnerOnly("owner123"))
+
+	h(nil, fakeInteraction("owner123", "cmd"))
+	if !called.Load() {
+		t.Fatal("handler not called for owner")
+	}
+	if len(*captured) != 0 {
+		t.Fatal("unexpected deny response for owner")
+	}
+}
+
+func TestOwnerOnly_NonOwnerDenied(t *testing.T) {
+	captured := captureRespond(t)
+	var called atomic.Bool
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	}, OwnerOnly("owner123"))
+
+	h(nil, fakeInteraction("other456", "cmd"))
+	if called.Load() {
+		t.Fatal("handler called for non-owner")
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("want 1 deny response, got %d", len(*captured))
+	}
+}
+
+func TestOwnerOnly_NoMember_UserFieldUsed(t *testing.T) {
+	captureRespond(t)
+	var called atomic.Bool
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	}, OwnerOnly("owner123"))
+
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			User: &discordgo.User{ID: "owner123"},
+			Data: discordgo.ApplicationCommandInteractionData{Name: "cmd"},
+		},
+	}
+	h(nil, i)
+	if !called.Load() {
+		t.Fatal("handler not called when owner set via User field")
+	}
+}
+
+// --- RateLimit ---
+
+func TestRateLimit_FirstCallPasses(t *testing.T) {
+	captureRespond(t)
+	var called atomic.Bool
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	}, RateLimit(time.Second))
+
+	h(nil, fakeInteraction("u1", "cmd"))
+	if !called.Load() {
+		t.Fatal("first call should pass rate limit")
+	}
+}
+
+func TestRateLimit_SecondCallWithinWindowDenied(t *testing.T) {
+	captured := captureRespond(t)
+	var count atomic.Int32
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		count.Add(1)
+	}, RateLimit(time.Hour))
+
+	h(nil, fakeInteraction("u2", "cmd"))
+	h(nil, fakeInteraction("u2", "cmd"))
+	if count.Load() != 1 {
+		t.Fatalf("want 1 pass, got %d", count.Load())
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("want 1 deny, got %d", len(*captured))
+	}
+}
+
+func TestRateLimit_DifferentUsersIndependent(t *testing.T) {
+	captureRespond(t)
+	var count atomic.Int32
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		count.Add(1)
+	}, RateLimit(time.Hour))
+
+	h(nil, fakeInteraction("userA", "cmd"))
+	h(nil, fakeInteraction("userB", "cmd"))
+	if count.Load() != 2 {
+		t.Fatalf("different users should have independent buckets, got %d calls", count.Load())
+	}
+}
+
+// --- Recover ---
+
+func TestRecover_CatchesPanic(t *testing.T) {
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		panic("test panic")
+	}, Recover())
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Recover middleware did not absorb panic: %v", r)
+		}
+	}()
+	h(nil, fakeInteraction("u", "cmd"))
+}
+
+func TestRecover_NoPanicPassesThrough(t *testing.T) {
+	var called atomic.Bool
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	}, Recover())
+
+	h(nil, fakeInteraction("u", "cmd"))
+	if !called.Load() {
+		t.Fatal("handler not called when no panic")
+	}
+}
+
+// --- WithCorrelationID ---
+
+func TestWithCorrelationID_CallsNext(t *testing.T) {
+	var called atomic.Bool
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	}, WithCorrelationID())
+
+	h(nil, fakeInteraction("u", "cmd"))
+	if !called.Load() {
+		t.Fatal("handler not called with correlation ID middleware")
+	}
+}
+
+func TestWithCorrelationID_MonotonicIDs(t *testing.T) {
+	mw := WithCorrelationID()
+	var called atomic.Int32
+	h := applyChain(func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Add(1)
+	}, mw)
+
+	for range 5 {
+		h(nil, fakeInteraction("u", "cmd"))
+	}
+	if called.Load() != 5 {
+		t.Fatalf("want 5 calls, got %d", called.Load())
+	}
+}
+
+// --- Middleware chain composition ---
+
+func TestMiddlewareChain_OrderApplied(t *testing.T) {
+	captureRespond(t)
+	var calls []string
+	record := func(name string) Middleware {
+		return func(next HandlerFunc) HandlerFunc {
+			return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+				calls = append(calls, name+":before")
+				next(s, i)
+				calls = append(calls, name+":after")
+			}
+		}
+	}
+
+	h := applyChain(
+		func(_ *discordgo.Session, _ *discordgo.InteractionCreate) { calls = append(calls, "handler") },
+		record("A"), record("B"),
+	)
+	h(nil, fakeInteraction("u", "cmd"))
+
+	want := []string{"A:before", "B:before", "handler", "B:after", "A:after"}
+	if len(calls) != len(want) {
+		t.Fatalf("want %v, got %v", want, calls)
+	}
+	for i, w := range want {
+		if calls[i] != w {
+			t.Errorf("calls[%d] = %q, want %q", i, calls[i], w)
+		}
+	}
+}

--- a/internal/bot/module.go
+++ b/internal/bot/module.go
@@ -1,0 +1,33 @@
+package bot
+
+import (
+	"context"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// EventListener is a Discord event listener compatible with discordgo.AddHandler.
+type EventListener any
+
+// ComponentHandler pairs a custom-ID prefix with its interaction handler.
+type ComponentHandler struct {
+	Prefix  string
+	Handler func(*discordgo.Session, *discordgo.InteractionCreate)
+}
+
+// BackgroundTask is a context-aware goroutine descriptor for the background supervisor.
+type BackgroundTask struct {
+	Name string
+	Run  func(ctx context.Context)
+}
+
+// Module is the interface all bot modules implement.
+type Module interface {
+	Name() string
+	Init(d Deps) error
+	Commands() []*discordgo.ApplicationCommand
+	Listeners() []EventListener
+	Components() []ComponentHandler
+	Background() []BackgroundTask
+	Shutdown() error
+}

--- a/internal/bot/router.go
+++ b/internal/bot/router.go
@@ -1,0 +1,84 @@
+package bot
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// commandEntry maps a slash-command name to its handler and middleware chain.
+type commandEntry struct {
+	handler    HandlerFunc
+	middleware []Middleware
+}
+
+// Router dispatches Discord interactions and messages to registered Module handlers.
+// It is a no-op until modules migrate.
+type Router struct {
+	deps       Deps
+	commands   map[string]commandEntry
+	components map[string]func(*discordgo.Session, *discordgo.InteractionCreate)
+}
+
+func newRouter(d Deps) *Router {
+	return &Router{
+		deps:       d,
+		commands:   make(map[string]commandEntry),
+		components: make(map[string]func(*discordgo.Session, *discordgo.InteractionCreate)),
+	}
+}
+
+// register wires a Module's listeners into the session.
+// Command and component dispatch wiring happens via AddCommand / AddComponent.
+func (r *Router) register(m Module, d Deps) error {
+	if err := m.Init(d); err != nil {
+		return err
+	}
+	for _, l := range m.Listeners() {
+		d.Session.AddHandler(l)
+	}
+	slog.Info("bot/router: module registered", "module", m.Name())
+	return nil
+}
+
+// AddCommand registers a slash-command handler with optional middleware.
+func (r *Router) AddCommand(name string, h HandlerFunc, mw ...Middleware) {
+	r.commands[name] = commandEntry{handler: h, middleware: mw}
+	slog.Debug("bot/router: command registered", "name", name)
+}
+
+// AddComponent registers a component handler matched by custom-ID prefix.
+func (r *Router) AddComponent(prefix string, h func(*discordgo.Session, *discordgo.InteractionCreate)) {
+	r.components[prefix] = h
+	slog.Debug("bot/router: component registered", "prefix", prefix)
+}
+
+func (r *Router) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		name := i.ApplicationCommandData().Name
+		entry, ok := r.commands[name]
+		if !ok {
+			return
+		}
+		chain := entry.handler
+		for j := len(entry.middleware) - 1; j >= 0; j-- {
+			chain = entry.middleware[j](chain)
+		}
+		chain(s, i)
+
+	case discordgo.InteractionMessageComponent:
+		customID := i.MessageComponentData().CustomID
+		for prefix, handler := range r.components {
+			if strings.HasPrefix(customID, prefix) {
+				handler(s, i)
+				return
+			}
+		}
+	}
+}
+
+func (r *Router) onMessageCreate(_ *discordgo.Session, _ *discordgo.MessageCreate) {
+	// No-op until legacy message handler migration.
+}

--- a/internal/bot/router_test.go
+++ b/internal/bot/router_test.go
@@ -1,0 +1,125 @@
+package bot
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func makeRouter() *Router {
+	return newRouter(Deps{})
+}
+
+func slashInteraction(name string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{Name: name},
+		},
+	}
+}
+
+func componentInteraction(customID string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionMessageComponent,
+			Data: discordgo.MessageComponentInteractionData{CustomID: customID},
+		},
+	}
+}
+
+func TestRouter_DispatchesKnownCommand(t *testing.T) {
+	r := makeRouter()
+	var called atomic.Bool
+	r.AddCommand("ping", func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	})
+
+	r.onInteractionCreate(nil, slashInteraction("ping"))
+	if !called.Load() {
+		t.Fatal("handler not called for registered command")
+	}
+}
+
+func TestRouter_IgnoresUnknownCommand(t *testing.T) {
+	r := makeRouter()
+	var called atomic.Bool
+	r.AddCommand("ping", func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	})
+
+	r.onInteractionCreate(nil, slashInteraction("unknown"))
+	if called.Load() {
+		t.Fatal("handler called for unknown command")
+	}
+}
+
+func TestRouter_DispatchesComponentByPrefix(t *testing.T) {
+	r := makeRouter()
+	var called atomic.Bool
+	r.AddComponent("coffee_", func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	})
+
+	r.onInteractionCreate(nil, componentInteraction("coffee_brew"))
+	if !called.Load() {
+		t.Fatal("component handler not called for matching prefix")
+	}
+}
+
+func TestRouter_IgnoresComponentWithNonMatchingPrefix(t *testing.T) {
+	r := makeRouter()
+	var called atomic.Bool
+	r.AddComponent("coffee_", func(_ *discordgo.Session, _ *discordgo.InteractionCreate) {
+		called.Store(true)
+	})
+
+	r.onInteractionCreate(nil, componentInteraction("other_action"))
+	if called.Load() {
+		t.Fatal("component handler called for non-matching prefix")
+	}
+}
+
+func TestRouter_MiddlewareApplied(t *testing.T) {
+	captureRespond(t)
+	r := makeRouter()
+	var called atomic.Bool
+	r.AddCommand("ping",
+		func(_ *discordgo.Session, _ *discordgo.InteractionCreate) { called.Store(true) },
+		OwnerOnly("owner"),
+	)
+
+	r.onInteractionCreate(nil, &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type:   discordgo.InteractionApplicationCommand,
+			Member: &discordgo.Member{User: &discordgo.User{ID: "other"}},
+			Data:   discordgo.ApplicationCommandInteractionData{Name: "ping"},
+		},
+	})
+	if called.Load() {
+		t.Fatal("handler called despite OwnerOnly middleware blocking non-owner")
+	}
+}
+
+func TestRouter_MessageCreateIsNoop(t *testing.T) {
+	r := makeRouter()
+	r.onMessageCreate(nil, &discordgo.MessageCreate{})
+}
+
+func TestRouter_MultipleCommands(t *testing.T) {
+	r := makeRouter()
+	var pingCalled, pongCalled atomic.Bool
+	r.AddCommand("ping", func(_ *discordgo.Session, _ *discordgo.InteractionCreate) { pingCalled.Store(true) })
+	r.AddCommand("pong", func(_ *discordgo.Session, _ *discordgo.InteractionCreate) { pongCalled.Store(true) })
+
+	r.onInteractionCreate(nil, slashInteraction("ping"))
+	r.onInteractionCreate(nil, slashInteraction("pong"))
+
+	if !pingCalled.Load() {
+		t.Fatal("ping handler not called")
+	}
+	if !pongCalled.Load() {
+		t.Fatal("pong handler not called")
+	}
+}


### PR DESCRIPTION
Part of #171. Closes #172.

## Summary
- Adds `internal/bot` package: `Bot`, `Deps`, `Module` interface, `Router`, middleware chain (`OwnerOnly`, `RateLimit`, `Recover`, `WithCorrelationID`), and `BackgroundSupervisor`
- No existing plugin changed; zero behaviour change
- Full unit tests for router dispatch, middleware chain, and background supervisor

## Test plan
- [ ] `go test ./internal/bot/...` — all pass
- [ ] `go build ./...` — clean
- [ ] Existing behaviour unchanged (no plugins modified)