### PR TITLE
refactor(eso): migrate to bot.Module

### DIFF
--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -357,7 +357,14 @@ func StartGidbig() {
 	llm.Initialize()
 	admin.Start(discord, conf.Discord.OwnerID, buildBotStatsMessage)
 	coffee.Start(discord)
-	eso.Start(discord)
+	esoMod := eso.New()
+	if err := esoMod.Init(bot.Deps{Session: discord, OwnerID: conf.Discord.OwnerID}); err != nil {
+		slog.Error("eso: init failed", "error", err)
+	} else {
+		for _, l := range esoMod.Listeners() {
+			discord.AddHandler(l)
+		}
+	}
 	gamerstatus.Start(discord)
 	gippity.Start(discord)
 	leetoclock.Start(discord)

--- a/internal/eso/eso.go
+++ b/internal/eso/eso.go
@@ -7,34 +7,64 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/toksikk/gidbig/internal/bot"
 	"github.com/toksikk/gidbig/internal/util"
 )
 
-// Start the plugin
-func Start(discord *discordgo.Session) {
-	discord.AddHandler(onMessageCreate)
-	slog.Info("eso function registered")
+// Module implements bot.Module for the eso conspiracy-text plugin.
+type Module struct {
+	session *discordgo.Session
 }
 
-func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
-	tok := strings.Split(m.Content, " ")
+// New returns a new eso Module.
+func New() *Module {
+	return &Module{}
+}
+
+func (m *Module) Name() string { return "eso" }
+
+func (m *Module) Init(d bot.Deps) error {
+	m.session = d.Session
+	slog.Info("eso: initialized")
+	return nil
+}
+
+func (m *Module) Commands() []*discordgo.ApplicationCommand { return nil }
+
+func (m *Module) Listeners() []bot.EventListener {
+	return []bot.EventListener{m.onMessageCreate}
+}
+
+func (m *Module) Components() []bot.ComponentHandler { return nil }
+
+func (m *Module) Background() []bot.BackgroundTask { return nil }
+
+func (m *Module) Shutdown() error { return nil }
+
+func (m *Module) onMessageCreate(s *discordgo.Session, msg *discordgo.MessageCreate) {
+	tok := strings.Split(msg.Content, " ")
 	if len(tok) < 1 {
 		return
 	}
-	if strings.ToLower(tok[0]) == "!eso" {
-		eso := fmt.Sprintf(
-			"%s%s%s%s%s",
-			ohai[rand.Intn(len(ohai))],
-			buty[rand.Intn(len(buty))],
-			wat[rand.Intn(len(wat))],
-			dointings[rand.Intn(len(dointings))],
-			todotings[rand.Intn(len(todotings))],
-		)
-		msg, err := s.ChannelMessageSend(m.ChannelID, eso)
-		if err == nil {
-			util.ReactOnMessage(s, msg.ChannelID, msg.ID, "🧠", "add")
-		}
+	if strings.ToLower(tok[0]) != "!eso" {
+		return
 	}
+	text := buildMessage()
+	reply, err := s.ChannelMessageSend(msg.ChannelID, text)
+	if err == nil {
+		util.ReactOnMessage(s, reply.ChannelID, reply.ID, "🧠", "add")
+	}
+}
+
+func buildMessage() string {
+	return fmt.Sprintf(
+		"%s%s%s%s%s",
+		ohai[rand.Intn(len(ohai))],
+		buty[rand.Intn(len(buty))],
+		wat[rand.Intn(len(wat))],
+		dointings[rand.Intn(len(dointings))],
+		todotings[rand.Intn(len(todotings))],
+	)
 }
 
 var ohai = []string{

--- a/internal/eso/eso_test.go
+++ b/internal/eso/eso_test.go
@@ -1,0 +1,139 @@
+package eso
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/toksikk/gidbig/internal/bot"
+)
+
+func TestNew_ReturnsModule(t *testing.T) {
+	m := New()
+	if m == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+func TestModule_Name(t *testing.T) {
+	if New().Name() != "eso" {
+		t.Fatalf("expected name 'eso', got %q", New().Name())
+	}
+}
+
+func TestModule_Init(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if m.session != s {
+		t.Fatal("Init did not store session")
+	}
+}
+
+func TestModule_Commands_Empty(t *testing.T) {
+	if cmds := New().Commands(); len(cmds) != 0 {
+		t.Fatalf("expected 0 commands, got %d", len(cmds))
+	}
+}
+
+func TestModule_Components_Empty(t *testing.T) {
+	if comps := New().Components(); len(comps) != 0 {
+		t.Fatalf("expected 0 components, got %d", len(comps))
+	}
+}
+
+func TestModule_Background_Empty(t *testing.T) {
+	if tasks := New().Background(); len(tasks) != 0 {
+		t.Fatalf("expected 0 background tasks, got %d", len(tasks))
+	}
+}
+
+func TestModule_Shutdown_NoError(t *testing.T) {
+	if err := New().Shutdown(); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+}
+
+func TestModule_Listeners_Count(t *testing.T) {
+	listeners := New().Listeners()
+	if len(listeners) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(listeners))
+	}
+}
+
+func TestModule_OnMessageCreate_IgnoresNonEso(t *testing.T) {
+	m := New()
+	m.onMessageCreate(nil, &discordgo.MessageCreate{
+		Message: &discordgo.Message{Content: "hello world"},
+	})
+}
+
+func TestModule_OnMessageCreate_IgnoresEmptyContent(t *testing.T) {
+	m := New()
+	m.onMessageCreate(nil, &discordgo.MessageCreate{
+		Message: &discordgo.Message{Content: ""},
+	})
+}
+
+func TestModule_OnMessageCreate_IgnoresOtherCommands(t *testing.T) {
+	m := New()
+	m.onMessageCreate(nil, &discordgo.MessageCreate{
+		Message: &discordgo.Message{Content: "!other"},
+	})
+}
+
+func TestModule_OnMessageCreate_EsoCommand(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	// HTTP send fails but must not panic; err != nil path is handled gracefully.
+	m.onMessageCreate(s, &discordgo.MessageCreate{
+		Message: &discordgo.Message{Content: "!eso", ChannelID: "123"},
+	})
+}
+
+func TestModule_OnMessageCreate_EsoCommandCaseInsensitive(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	m.onMessageCreate(s, &discordgo.MessageCreate{
+		Message: &discordgo.Message{Content: "!ESO", ChannelID: "123"},
+	})
+}
+
+func TestBuildMessage_NonEmpty(t *testing.T) {
+	for range 20 {
+		msg := buildMessage()
+		if msg == "" {
+			t.Fatal("buildMessage returned empty string")
+		}
+	}
+}
+
+func TestBuildMessage_ContainsAllParts(t *testing.T) {
+	for range 100 {
+		msg := buildMessage()
+		// Must start with one of the ohai entries (all end with ", ")
+		hasOhai := false
+		for _, o := range ohai {
+			if strings.HasPrefix(msg, o) {
+				hasOhai = true
+				break
+			}
+		}
+		if !hasOhai {
+			t.Fatalf("buildMessage output missing ohai prefix: %q", msg)
+		}
+		// Must end with one of the todotings entries
+		hasTodo := false
+		for _, td := range todotings {
+			if strings.HasSuffix(msg, td) {
+				hasTodo = true
+				break
+			}
+		}
+		if !hasTodo {
+			t.Fatalf("buildMessage output missing todotings suffix: %q", msg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Ports `internal/eso` to `bot.Module` interface following the stoll reference pattern (#173)
- Replaces package-level `Start()` with `New()` / `Init()` / `Listeners()` / `Shutdown()`
- Extracts `buildMessage()` for unit test coverage
- Updates `cmd.go` to initialise via `esoMod` instead of `eso.Start()`
- 15 new tests; all packages green

Closes #174. Part of #171.

## Test plan

- [x] `go test ./internal/eso/...` — all 15 tests pass
- [x] `make test` — full suite green (13 packages, 0 failures)
- [x] `make build` — binary compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)