### PR TITLE
feat(eso,stoll): slash commands + AI-generated responses

### DIFF
--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -383,7 +383,9 @@ func StartGidbig() {
 	}
 	cmds = append(cmds, admin.Commands()...)
 	cmds = append(cmds, coffee.Commands()...)
+	cmds = append(cmds, esoMod.Commands()...)
 	cmds = append(cmds, gippity.Commands()...)
+	cmds = append(cmds, stollMod.Commands()...)
 	if _, err := discord.ApplicationCommandBulkOverwrite(discord.State.User.ID, "", cmds); err != nil {
 		slog.Error("Failed to register slash commands", "error", err)
 	}

--- a/internal/eso/eso.go
+++ b/internal/eso/eso.go
@@ -1,69 +1,100 @@
 package eso
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
-	"math/rand"
-	"strings"
+	"math/rand/v2"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/toksikk/gidbig/internal/bot"
+	"github.com/toksikk/gidbig/internal/llm"
 	"github.com/toksikk/gidbig/internal/util"
 )
 
+const systemPromptTemplate = `Du bist ein esoterischer Unsinn-Generator. Produziere genau einen Satz mystischen, pseudo-tiefgründigen deutschen Unsinns. Orientiere dich an Ton und Struktur dieser Beispiele:
+{{examples}}
+Antworte ausschließlich mit dem generierten Satz auf Deutsch. Keine Erklärung, keine Begrüßung.`
+
 // Module implements bot.Module for the eso conspiracy-text plugin.
 type Module struct {
-	session *discordgo.Session
+	session   *discordgo.Session
+	responder *util.AIResponder
 }
 
 // New returns a new eso Module.
-func New() *Module {
-	return &Module{}
-}
+func New() *Module { return &Module{} }
 
 func (m *Module) Name() string { return "eso" }
 
 func (m *Module) Init(d bot.Deps) error {
 	m.session = d.Session
+
+	pool := make([]string, 20)
+	for i := range pool {
+		pool[i] = buildMessage()
+	}
+	m.responder = &util.AIResponder{
+		SystemPromptTemplate: systemPromptTemplate,
+		ExamplePool:          pool,
+		ExampleCount:         5,
+		Fallback:             buildMessage,
+		GenerateFn:           llm.GenerateMessage,
+	}
+
 	slog.Info("eso: initialized")
 	return nil
 }
 
-func (m *Module) Commands() []*discordgo.ApplicationCommand { return nil }
+func (m *Module) Commands() []*discordgo.ApplicationCommand {
+	return []*discordgo.ApplicationCommand{
+		{Name: "eso", Description: "Erhalte esoterischen Unsinn"},
+	}
+}
 
 func (m *Module) Listeners() []bot.EventListener {
-	return []bot.EventListener{m.onMessageCreate}
+	return []bot.EventListener{m.onInteractionCreate}
 }
 
 func (m *Module) Components() []bot.ComponentHandler { return nil }
+func (m *Module) Background() []bot.BackgroundTask   { return nil }
+func (m *Module) Shutdown() error                    { return nil }
 
-func (m *Module) Background() []bot.BackgroundTask { return nil }
-
-func (m *Module) Shutdown() error { return nil }
-
-func (m *Module) onMessageCreate(s *discordgo.Session, msg *discordgo.MessageCreate) {
-	tok := strings.Split(msg.Content, " ")
-	if len(tok) < 1 {
+func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type != discordgo.InteractionApplicationCommand {
 		return
 	}
-	if strings.ToLower(tok[0]) != "!eso" {
+	if i.ApplicationCommandData().Name != "eso" {
 		return
 	}
-	text := buildMessage()
-	reply, err := s.ChannelMessageSend(msg.ChannelID, text)
-	if err == nil {
-		util.ReactOnMessage(s, reply.ChannelID, reply.ID, "🧠", "add")
+
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+	}); err != nil {
+		slog.Error("eso: failed to defer interaction", "error", err)
+		return
 	}
+
+	go func() {
+		text := m.responder.Generate(context.Background())
+		if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &text}); err != nil {
+			slog.Error("eso: failed to edit interaction response", "error", err)
+			return
+		}
+		if msg, err := s.InteractionResponse(i.Interaction); err == nil && msg != nil {
+			util.ReactOnMessage(s, msg.ChannelID, msg.ID, "🧠", "add")
+		}
+	}()
 }
 
 func buildMessage() string {
 	return fmt.Sprintf(
 		"%s%s%s%s%s",
-		ohai[rand.Intn(len(ohai))],
-		buty[rand.Intn(len(buty))],
-		wat[rand.Intn(len(wat))],
-		dointings[rand.Intn(len(dointings))],
-		todotings[rand.Intn(len(todotings))],
+		ohai[rand.IntN(len(ohai))],
+		buty[rand.IntN(len(buty))],
+		wat[rand.IntN(len(wat))],
+		dointings[rand.IntN(len(dointings))],
+		todotings[rand.IntN(len(todotings))],
 	)
 }
 

--- a/internal/eso/eso_test.go
+++ b/internal/eso/eso_test.go
@@ -1,6 +1,8 @@
 package eso
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -30,11 +32,18 @@ func TestModule_Init(t *testing.T) {
 	if m.session != s {
 		t.Fatal("Init did not store session")
 	}
+	if m.responder == nil {
+		t.Fatal("Init did not create responder")
+	}
 }
 
-func TestModule_Commands_Empty(t *testing.T) {
-	if cmds := New().Commands(); len(cmds) != 0 {
-		t.Fatalf("expected 0 commands, got %d", len(cmds))
+func TestModule_Commands_HasEso(t *testing.T) {
+	cmds := New().Commands()
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	if cmds[0].Name != "eso" {
+		t.Fatalf("expected command name 'eso', got %q", cmds[0].Name)
 	}
 }
 
@@ -63,42 +72,89 @@ func TestModule_Listeners_Count(t *testing.T) {
 	}
 }
 
-func TestModule_OnMessageCreate_IgnoresNonEso(t *testing.T) {
-	m := New()
-	m.onMessageCreate(nil, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "hello world"},
-	})
-}
-
-func TestModule_OnMessageCreate_IgnoresEmptyContent(t *testing.T) {
-	m := New()
-	m.onMessageCreate(nil, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: ""},
-	})
-}
-
-func TestModule_OnMessageCreate_IgnoresOtherCommands(t *testing.T) {
-	m := New()
-	m.onMessageCreate(nil, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "!other"},
-	})
-}
-
-func TestModule_OnMessageCreate_EsoCommand(t *testing.T) {
+func TestModule_OnInteractionCreate_IgnoresNonApplicationCommand(t *testing.T) {
 	m := New()
 	s, _ := discordgo.New("Bot fake-token")
-	// HTTP send fails but must not panic; err != nil path is handled gracefully.
-	m.onMessageCreate(s, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "!eso", ChannelID: "123"},
-	})
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionMessageComponent,
+		},
+	}
+	m.onInteractionCreate(s, i)
 }
 
-func TestModule_OnMessageCreate_EsoCommandCaseInsensitive(t *testing.T) {
+func TestModule_OnInteractionCreate_IgnoresOtherCommand(t *testing.T) {
 	m := New()
 	s, _ := discordgo.New("Bot fake-token")
-	m.onMessageCreate(s, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "!ESO", ChannelID: "123"},
-	})
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{Name: "other"},
+		},
+	}
+	m.onInteractionCreate(s, i)
+}
+
+func TestModule_OnInteractionCreate_EsoCommand(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{Name: "eso"},
+		},
+	}
+	// InteractionRespond fails (no real connection) → handler returns early, no panic.
+	m.onInteractionCreate(s, i)
+}
+
+func TestModule_Responder_AIPath(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	m.responder.GenerateFn = func(_ context.Context, _, _ string) (string, error) {
+		return "AI generated eso text", nil
+	}
+	got := m.responder.Generate(context.Background())
+	if got != "AI generated eso text" {
+		t.Fatalf("expected AI text, got %q", got)
+	}
+}
+
+func TestModule_Responder_FallbackOnError(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	m.responder.GenerateFn = func(_ context.Context, _, _ string) (string, error) {
+		return "", errors.New("simulated LLM failure")
+	}
+	got := m.responder.Generate(context.Background())
+	if got == "" {
+		t.Fatal("fallback returned empty string")
+	}
+	hasOhai := false
+	for _, o := range ohai {
+		if strings.HasPrefix(got, o) {
+			hasOhai = true
+			break
+		}
+	}
+	if !hasOhai {
+		t.Fatalf("fallback output not a valid eso message: %q", got)
+	}
 }
 
 func TestBuildMessage_NonEmpty(t *testing.T) {
@@ -113,7 +169,6 @@ func TestBuildMessage_NonEmpty(t *testing.T) {
 func TestBuildMessage_ContainsAllParts(t *testing.T) {
 	for range 100 {
 		msg := buildMessage()
-		// Must start with one of the ohai entries (all end with ", ")
 		hasOhai := false
 		for _, o := range ohai {
 			if strings.HasPrefix(msg, o) {
@@ -124,7 +179,6 @@ func TestBuildMessage_ContainsAllParts(t *testing.T) {
 		if !hasOhai {
 			t.Fatalf("buildMessage output missing ohai prefix: %q", msg)
 		}
-		// Must end with one of the todotings entries
 		hasTodo := false
 		for _, td := range todotings {
 			if strings.HasSuffix(msg, td) {

--- a/internal/stoll/stoll.go
+++ b/internal/stoll/stoll.go
@@ -1,64 +1,95 @@
 package stoll
 
 import (
+	"context"
 	"log/slog"
-	"math/rand"
-	"strings"
+	"math/rand/v2"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/toksikk/gidbig/internal/bot"
+	"github.com/toksikk/gidbig/internal/llm"
 	"github.com/toksikk/gidbig/internal/util"
 )
 
+const systemPromptTemplate = `Du generierst Zitate, die Dr. Axel Stoll, einem selbsternannten deutschen Naturwissenschaftler und Verschwörungstheoretiker, zugeschrieben werden. Orientiere dich an Stimme, Inhalt und Kadenz dieser Beispiele:
+{{examples}}
+Antworte ausschließlich mit dem formatierten Zitat, genau wie in den Beispielen (beginnend mit "> " und endend mit "\n - Dr. Axel Stoll, promovierter Naturwissenschaftler"). Keine Erklärung.`
+
 // Module implements bot.Module for the stoll quote plugin.
 type Module struct {
-	session *discordgo.Session
+	session   *discordgo.Session
+	responder *util.AIResponder
 }
 
 // New returns a new stoll Module.
-func New() *Module {
-	return &Module{}
-}
+func New() *Module { return &Module{} }
 
 func (m *Module) Name() string { return "stoll" }
 
 func (m *Module) Init(d bot.Deps) error {
 	m.session = d.Session
+
+	pool := make([]string, 20)
+	for i := range pool {
+		pool[i] = buildQuote()
+	}
+	m.responder = &util.AIResponder{
+		SystemPromptTemplate: systemPromptTemplate,
+		ExamplePool:          pool,
+		ExampleCount:         5,
+		Fallback:             buildQuote,
+		GenerateFn:           llm.GenerateMessage,
+	}
+
 	slog.Info("stoll: initialized")
 	return nil
 }
 
-func (m *Module) Commands() []*discordgo.ApplicationCommand { return nil }
+func (m *Module) Commands() []*discordgo.ApplicationCommand {
+	return []*discordgo.ApplicationCommand{
+		{Name: "stoll", Description: "Erhalte ein Zitat von Dr. Axel Stoll"},
+	}
+}
 
 func (m *Module) Listeners() []bot.EventListener {
-	return []bot.EventListener{m.onMessageCreate}
+	return []bot.EventListener{m.onInteractionCreate}
 }
 
 func (m *Module) Components() []bot.ComponentHandler { return nil }
+func (m *Module) Background() []bot.BackgroundTask   { return nil }
+func (m *Module) Shutdown() error                    { return nil }
 
-func (m *Module) Background() []bot.BackgroundTask { return nil }
-
-func (m *Module) Shutdown() error { return nil }
-
-func (m *Module) onMessageCreate(s *discordgo.Session, msg *discordgo.MessageCreate) {
-	tok := strings.Split(msg.Content, " ")
-	if len(tok) < 1 {
+func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type != discordgo.InteractionApplicationCommand {
 		return
 	}
-	if strings.ToLower(tok[0]) != "!stoll" {
+	if i.ApplicationCommandData().Name != "stoll" {
 		return
 	}
-	line := buildQuote()
-	reply, err := s.ChannelMessageSend(msg.ChannelID, line)
-	if err == nil {
-		util.ReactOnMessage(s, reply.ChannelID, reply.ID, ":stoll:747387878916751421", "add")
+
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+	}); err != nil {
+		slog.Error("stoll: failed to defer interaction", "error", err)
+		return
 	}
+
+	go func() {
+		text := m.responder.Generate(context.Background())
+		if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &text}); err != nil {
+			slog.Error("stoll: failed to edit interaction response", "error", err)
+			return
+		}
+		if msg, err := s.InteractionResponse(i.Interaction); err == nil && msg != nil {
+			util.ReactOnMessage(s, msg.ChannelID, msg.ID, ":stoll:747387878916751421", "add")
+		}
+	}()
 }
 
 func buildQuote() string {
 	line := "> "
 	for i := 0; i < 3; i++ {
-		line += quotes[i][rand.Intn(len(quotes[i]))]
+		line += quotes[i][rand.IntN(len(quotes[i]))]
 		line += " "
 	}
 	line += "\n - Dr. Axel Stoll, promovierter Naturwissenschaftler"

--- a/internal/stoll/stoll.go
+++ b/internal/stoll/stoll.go
@@ -11,9 +11,16 @@ import (
 	"github.com/toksikk/gidbig/internal/util"
 )
 
-const systemPromptTemplate = `Du generierst Zitate, die Dr. Axel Stoll, einem selbsternannten deutschen Naturwissenschaftler und Verschwörungstheoretiker, zugeschrieben werden. Orientiere dich an Stimme, Inhalt und Kadenz dieser Beispiele:
+const systemPromptTemplate = `Du generierst GENAU EIN einzelnes Zitat von Dr. Axel Stoll, einem selbsternannten deutschen Naturwissenschaftler und Verschwörungstheoretiker.
+
+Ausgabeformat (exakt einhalten, kein weiterer Text):
+> [ein oder mehrere kurze Aussagen im Stoll-Stil]
+ - Dr. Axel Stoll, promovierter Naturwissenschaftler
+
+Referenzbeispiele für Ton und Stil:
 {{examples}}
-Antworte ausschließlich mit dem formatierten Zitat, genau wie in den Beispielen (beginnend mit "> " und endend mit "\n - Dr. Axel Stoll, promovierter Naturwissenschaftler"). Keine Erklärung.`
+
+Wichtig: Gib ausschließlich EIN Zitat im obigen Format aus. Kein zweites Zitat, keine Erklärung, keine Einleitung.`
 
 // Module implements bot.Module for the stoll quote plugin.
 type Module struct {
@@ -36,7 +43,7 @@ func (m *Module) Init(d bot.Deps) error {
 	m.responder = &util.AIResponder{
 		SystemPromptTemplate: systemPromptTemplate,
 		ExamplePool:          pool,
-		ExampleCount:         5,
+		ExampleCount:         3,
 		Fallback:             buildQuote,
 		GenerateFn:           llm.GenerateMessage,
 	}

--- a/internal/stoll/stoll_test.go
+++ b/internal/stoll/stoll_test.go
@@ -1,6 +1,8 @@
 package stoll
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -30,11 +32,18 @@ func TestModule_Init(t *testing.T) {
 	if m.session != s {
 		t.Fatal("Init did not store session")
 	}
+	if m.responder == nil {
+		t.Fatal("Init did not create responder")
+	}
 }
 
-func TestModule_Commands_Empty(t *testing.T) {
-	if cmds := New().Commands(); len(cmds) != 0 {
-		t.Fatalf("expected 0 commands, got %d", len(cmds))
+func TestModule_Commands_HasStoll(t *testing.T) {
+	cmds := New().Commands()
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	if cmds[0].Name != "stoll" {
+		t.Fatalf("expected command name 'stoll', got %q", cmds[0].Name)
 	}
 }
 
@@ -63,43 +72,85 @@ func TestModule_Listeners_Count(t *testing.T) {
 	}
 }
 
-func TestModule_OnMessageCreate_IgnoresNonStoll(t *testing.T) {
-	m := New()
-	// non-stoll message with nil session should not panic
-	m.onMessageCreate(nil, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "hello world"},
-	})
-}
-
-func TestModule_OnMessageCreate_IgnoresEmptyContent(t *testing.T) {
-	m := New()
-	m.onMessageCreate(nil, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: ""},
-	})
-}
-
-func TestModule_OnMessageCreate_IgnoresOtherCommands(t *testing.T) {
-	m := New()
-	m.onMessageCreate(nil, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "!other"},
-	})
-}
-
-func TestModule_OnMessageCreate_StollCommand(t *testing.T) {
+func TestModule_OnInteractionCreate_IgnoresNonApplicationCommand(t *testing.T) {
 	m := New()
 	s, _ := discordgo.New("Bot fake-token")
-	// HTTP send fails but must not panic; err != nil path is handled gracefully.
-	m.onMessageCreate(s, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "!stoll", ChannelID: "123"},
-	})
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionMessageComponent,
+		},
+	}
+	m.onInteractionCreate(s, i)
 }
 
-func TestModule_OnMessageCreate_StollCommandCaseInsensitive(t *testing.T) {
+func TestModule_OnInteractionCreate_IgnoresOtherCommand(t *testing.T) {
 	m := New()
 	s, _ := discordgo.New("Bot fake-token")
-	m.onMessageCreate(s, &discordgo.MessageCreate{
-		Message: &discordgo.Message{Content: "!STOLL", ChannelID: "123"},
-	})
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{Name: "other"},
+		},
+	}
+	m.onInteractionCreate(s, i)
+}
+
+func TestModule_OnInteractionCreate_StollCommand(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{Name: "stoll"},
+		},
+	}
+	// InteractionRespond fails (no real connection) → handler returns early, no panic.
+	m.onInteractionCreate(s, i)
+}
+
+func TestModule_Responder_AIPath(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	m.responder.GenerateFn = func(_ context.Context, _, _ string) (string, error) {
+		return "> Die Sonne ist kalt!\n - Dr. Axel Stoll, promovierter Naturwissenschaftler", nil
+	}
+	got := m.responder.Generate(context.Background())
+	if !strings.HasPrefix(got, "> ") {
+		t.Fatalf("expected AI quote to start with '> ', got %q", got)
+	}
+}
+
+func TestModule_Responder_FallbackOnError(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	m.responder.GenerateFn = func(_ context.Context, _, _ string) (string, error) {
+		return "", errors.New("simulated LLM failure")
+	}
+	got := m.responder.Generate(context.Background())
+	if got == "" {
+		t.Fatal("fallback returned empty string")
+	}
+	if !strings.HasPrefix(got, "> ") {
+		t.Fatalf("fallback output not a valid stoll quote: %q", got)
+	}
+	if !strings.HasSuffix(got, "Dr. Axel Stoll, promovierter Naturwissenschaftler") {
+		t.Fatalf("fallback output missing attribution suffix: %q", got)
+	}
 }
 
 func TestBuildQuote_Format(t *testing.T) {
@@ -115,8 +166,6 @@ func TestBuildQuote_Format(t *testing.T) {
 }
 
 func TestBuildQuote_UsesAllThreeLists(t *testing.T) {
-	// Run many times; with 3 lists each with many entries the chance of a single
-	// list not contributing is astronomically small over 100 runs.
 	for range 100 {
 		q := buildQuote()
 		if q == "" {

--- a/internal/util/airesponder.go
+++ b/internal/util/airesponder.go
@@ -33,7 +33,7 @@ func (r *AIResponder) Generate(ctx context.Context) string {
 }
 
 func pickExamples(pool []string, n int) []string {
-	if len(pool) == 0 {
+	if len(pool) == 0 || n <= 0 {
 		return nil
 	}
 	if n >= len(pool) {

--- a/internal/util/airesponder.go
+++ b/internal/util/airesponder.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"context"
+	"math/rand/v2"
+	"strings"
+)
+
+// AIResponder generates text via an LLM with few-shot examples and falls back to a
+// deterministic function when the AI call fails or returns an empty result.
+type AIResponder struct {
+	SystemPromptTemplate string
+	ExamplePool          []string
+	ExampleCount         int
+	Fallback             func() string
+	GenerateFn           func(ctx context.Context, system, user string) (string, error)
+}
+
+// Generate selects ExampleCount entries from ExamplePool, injects them into
+// SystemPromptTemplate replacing "{{examples}}", calls GenerateFn, and returns the
+// trimmed response. Falls back to Fallback() on any error or empty result.
+func (r *AIResponder) Generate(ctx context.Context) string {
+	if r.GenerateFn == nil {
+		return r.Fallback()
+	}
+	examples := pickExamples(r.ExamplePool, r.ExampleCount)
+	sys := strings.ReplaceAll(r.SystemPromptTemplate, "{{examples}}", strings.Join(examples, "\n\n"))
+	text, err := r.GenerateFn(ctx, sys, "Generate a response.")
+	if err != nil || strings.TrimSpace(text) == "" {
+		return r.Fallback()
+	}
+	return strings.TrimSpace(text)
+}
+
+func pickExamples(pool []string, n int) []string {
+	if len(pool) == 0 {
+		return nil
+	}
+	if n >= len(pool) {
+		cp := make([]string, len(pool))
+		copy(cp, pool)
+		return cp
+	}
+	perm := rand.Perm(len(pool))
+	result := make([]string, n)
+	for i := range n {
+		result[i] = pool[perm[i]]
+	}
+	return result
+}

--- a/internal/util/airesponder_test.go
+++ b/internal/util/airesponder_test.go
@@ -105,6 +105,20 @@ func TestPickExamples_EmptyPool(t *testing.T) {
 	}
 }
 
+func TestPickExamples_ZeroN(t *testing.T) {
+	got := pickExamples([]string{"a", "b"}, 0)
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for n=0, got %v", got)
+	}
+}
+
+func TestPickExamples_NegativeN(t *testing.T) {
+	got := pickExamples([]string{"a", "b"}, -1)
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for negative n, got %v", got)
+	}
+}
+
 func TestPickExamples_NLargerThanPool(t *testing.T) {
 	pool := []string{"a", "b"}
 	got := pickExamples(pool, 10)

--- a/internal/util/airesponder_test.go
+++ b/internal/util/airesponder_test.go
@@ -1,0 +1,129 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestAIResponder_Generate_AIPath(t *testing.T) {
+	r := &AIResponder{
+		SystemPromptTemplate: "Match these examples: {{examples}}",
+		ExamplePool:          []string{"a", "b", "c"},
+		ExampleCount:         2,
+		Fallback:             func() string { return "fallback" },
+		GenerateFn: func(_ context.Context, _, _ string) (string, error) {
+			return "AI result", nil
+		},
+	}
+	got := r.Generate(context.Background())
+	if got != "AI result" {
+		t.Fatalf("expected 'AI result', got %q", got)
+	}
+}
+
+func TestAIResponder_Generate_FallbackOnError(t *testing.T) {
+	r := &AIResponder{
+		SystemPromptTemplate: "{{examples}}",
+		ExamplePool:          []string{"a"},
+		ExampleCount:         1,
+		Fallback:             func() string { return "fallback" },
+		GenerateFn: func(_ context.Context, _, _ string) (string, error) {
+			return "", errors.New("simulated failure")
+		},
+	}
+	got := r.Generate(context.Background())
+	if got != "fallback" {
+		t.Fatalf("expected 'fallback', got %q", got)
+	}
+}
+
+func TestAIResponder_Generate_FallbackOnEmptyResponse(t *testing.T) {
+	r := &AIResponder{
+		SystemPromptTemplate: "{{examples}}",
+		ExamplePool:          []string{"a"},
+		ExampleCount:         1,
+		Fallback:             func() string { return "fallback" },
+		GenerateFn: func(_ context.Context, _, _ string) (string, error) {
+			return "   ", nil
+		},
+	}
+	got := r.Generate(context.Background())
+	if got != "fallback" {
+		t.Fatalf("expected 'fallback' on whitespace-only response, got %q", got)
+	}
+}
+
+func TestAIResponder_Generate_FallbackWhenGenerateFnNil(t *testing.T) {
+	r := &AIResponder{
+		Fallback: func() string { return "nil-fn fallback" },
+	}
+	got := r.Generate(context.Background())
+	if got != "nil-fn fallback" {
+		t.Fatalf("expected 'nil-fn fallback', got %q", got)
+	}
+}
+
+func TestAIResponder_Generate_InjectsExamplesIntoPrompt(t *testing.T) {
+	var capturedSys string
+	r := &AIResponder{
+		SystemPromptTemplate: "Examples: {{examples}}",
+		ExamplePool:          []string{"foo"},
+		ExampleCount:         1,
+		Fallback:             func() string { return "x" },
+		GenerateFn: func(_ context.Context, sys, _ string) (string, error) {
+			capturedSys = sys
+			return "ok", nil
+		},
+	}
+	r.Generate(context.Background())
+	if capturedSys != "Examples: foo" {
+		t.Fatalf("unexpected system prompt: %q", capturedSys)
+	}
+}
+
+func TestAIResponder_Generate_TrimsResponse(t *testing.T) {
+	r := &AIResponder{
+		SystemPromptTemplate: "{{examples}}",
+		ExamplePool:          []string{"a"},
+		ExampleCount:         1,
+		Fallback:             func() string { return "x" },
+		GenerateFn: func(_ context.Context, _, _ string) (string, error) {
+			return "  trimmed  ", nil
+		},
+	}
+	got := r.Generate(context.Background())
+	if got != "trimmed" {
+		t.Fatalf("expected trimmed output, got %q", got)
+	}
+}
+
+func TestPickExamples_EmptyPool(t *testing.T) {
+	got := pickExamples(nil, 3)
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for nil pool, got %v", got)
+	}
+}
+
+func TestPickExamples_NLargerThanPool(t *testing.T) {
+	pool := []string{"a", "b"}
+	got := pickExamples(pool, 10)
+	if len(got) != len(pool) {
+		t.Fatalf("expected %d items, got %d", len(pool), len(got))
+	}
+}
+
+func TestPickExamples_ExactCount(t *testing.T) {
+	pool := []string{"a", "b", "c", "d", "e"}
+	got := pickExamples(pool, 3)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(got))
+	}
+	seen := make(map[string]bool)
+	for _, v := range got {
+		if seen[v] {
+			t.Fatalf("duplicate entry in pickExamples result: %q", v)
+		}
+		seen[v] = true
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts `util.AIResponder`: shared LLM few-shot helper; `Generate(ctx)` picks N random examples from a pool, injects them into a system prompt, calls `llm.GenerateMessage`, and falls back to a deterministic function on error or empty response
- Migrates `/eso` and `/stoll` from legacy `!`-prefix `onMessageCreate` handlers to Discord slash commands with deferred interaction responses
- Existing string arrays become few-shot examples for GPT-4o-mini; fallback to random array pick when AI call fails
- Registers `/eso` and `/stoll` in `ApplicationCommandBulkOverwrite`

## Test plan

- [x] `util.AIResponder`: AI path, fallback on error, fallback on empty response, nil GenerateFn guard, example injection, response trimming, `pickExamples` edge cases
- [x] `eso`: module lifecycle, command registration, interaction handler dispatches correctly (ignores wrong type/name), AI path, fallback path
- [x] `stoll`: same coverage as eso
- [x] Full test suite green (`make test`)
- [x] Binary builds clean (`make build`)

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)