### PR TITLE
refactor(stoll): remove LLM, use classic random quotes only

### DIFF
--- a/internal/stoll/stoll.go
+++ b/internal/stoll/stoll.go
@@ -1,31 +1,17 @@
 package stoll
 
 import (
-	"context"
 	"log/slog"
 	"math/rand/v2"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/toksikk/gidbig/internal/bot"
-	"github.com/toksikk/gidbig/internal/llm"
 	"github.com/toksikk/gidbig/internal/util"
 )
 
-const systemPromptTemplate = `Du generierst GENAU EIN einzelnes Zitat von Dr. Axel Stoll, einem selbsternannten deutschen Naturwissenschaftler und Verschwörungstheoretiker.
-
-Ausgabeformat (exakt einhalten, kein weiterer Text):
-> [ein oder mehrere kurze Aussagen im Stoll-Stil]
- - Dr. Axel Stoll, promovierter Naturwissenschaftler
-
-Referenzbeispiele für Ton und Stil:
-{{examples}}
-
-Wichtig: Gib ausschließlich EIN Zitat im obigen Format aus. Kein zweites Zitat, keine Erklärung, keine Einleitung.`
-
 // Module implements bot.Module for the stoll quote plugin.
 type Module struct {
-	session   *discordgo.Session
-	responder *util.AIResponder
+	session *discordgo.Session
 }
 
 // New returns a new stoll Module.
@@ -35,19 +21,6 @@ func (m *Module) Name() string { return "stoll" }
 
 func (m *Module) Init(d bot.Deps) error {
 	m.session = d.Session
-
-	pool := make([]string, 20)
-	for i := range pool {
-		pool[i] = buildQuote()
-	}
-	m.responder = &util.AIResponder{
-		SystemPromptTemplate: systemPromptTemplate,
-		ExamplePool:          pool,
-		ExampleCount:         3,
-		Fallback:             buildQuote,
-		GenerateFn:           llm.GenerateMessage,
-	}
-
 	slog.Info("stoll: initialized")
 	return nil
 }
@@ -74,23 +47,17 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 		return
 	}
 
+	text := buildQuote()
 	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{Content: text},
 	}); err != nil {
-		slog.Error("stoll: failed to defer interaction", "error", err)
+		slog.Error("stoll: failed to respond to interaction", "error", err)
 		return
 	}
-
-	go func() {
-		text := m.responder.Generate(context.Background())
-		if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &text}); err != nil {
-			slog.Error("stoll: failed to edit interaction response", "error", err)
-			return
-		}
-		if msg, err := s.InteractionResponse(i.Interaction); err == nil && msg != nil {
-			util.ReactOnMessage(s, msg.ChannelID, msg.ID, ":stoll:747387878916751421", "add")
-		}
-	}()
+	if msg, err := s.InteractionResponse(i.Interaction); err == nil && msg != nil {
+		util.ReactOnMessage(s, msg.ChannelID, msg.ID, ":stoll:747387878916751421", "add")
+	}
 }
 
 func buildQuote() string {

--- a/internal/stoll/stoll_test.go
+++ b/internal/stoll/stoll_test.go
@@ -1,8 +1,6 @@
 package stoll
 
 import (
-	"context"
-	"errors"
 	"strings"
 	"testing"
 
@@ -31,9 +29,6 @@ func TestModule_Init(t *testing.T) {
 	}
 	if m.session != s {
 		t.Fatal("Init did not store session")
-	}
-	if m.responder == nil {
-		t.Fatal("Init did not create responder")
 	}
 }
 
@@ -115,42 +110,6 @@ func TestModule_OnInteractionCreate_StollCommand(t *testing.T) {
 	}
 	// InteractionRespond fails (no real connection) → handler returns early, no panic.
 	m.onInteractionCreate(s, i)
-}
-
-func TestModule_Responder_AIPath(t *testing.T) {
-	m := New()
-	s, _ := discordgo.New("Bot fake-token")
-	if err := m.Init(bot.Deps{Session: s}); err != nil {
-		t.Fatalf("Init failed: %v", err)
-	}
-	m.responder.GenerateFn = func(_ context.Context, _, _ string) (string, error) {
-		return "> Die Sonne ist kalt!\n - Dr. Axel Stoll, promovierter Naturwissenschaftler", nil
-	}
-	got := m.responder.Generate(context.Background())
-	if !strings.HasPrefix(got, "> ") {
-		t.Fatalf("expected AI quote to start with '> ', got %q", got)
-	}
-}
-
-func TestModule_Responder_FallbackOnError(t *testing.T) {
-	m := New()
-	s, _ := discordgo.New("Bot fake-token")
-	if err := m.Init(bot.Deps{Session: s}); err != nil {
-		t.Fatalf("Init failed: %v", err)
-	}
-	m.responder.GenerateFn = func(_ context.Context, _, _ string) (string, error) {
-		return "", errors.New("simulated LLM failure")
-	}
-	got := m.responder.Generate(context.Background())
-	if got == "" {
-		t.Fatal("fallback returned empty string")
-	}
-	if !strings.HasPrefix(got, "> ") {
-		t.Fatalf("fallback output not a valid stoll quote: %q", got)
-	}
-	if !strings.HasSuffix(got, "Dr. Axel Stoll, promovierter Naturwissenschaftler") {
-		t.Fatalf("fallback output missing attribution suffix: %q", got)
-	}
 }
 
 func TestBuildQuote_Format(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove `util.AIResponder` from stoll — the OG quotes are better than AI-generated ones
- Switch from deferred+goroutine interaction pattern to direct `InteractionResponseChannelMessageWithSource` (no async work needed without LLM)
- Drop `context` and `llm` imports from stoll package
- Remove AI/fallback path tests; all remaining tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)