### PR TITLE
refactor(wttrin): migrate to bot.Module

### DIFF
--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -376,7 +376,14 @@ func StartGidbig() {
 			discord.AddHandler(l)
 		}
 	}
-	wttrin.Start(discord)
+	wttrinMod := wttrin.New()
+	if err := wttrinMod.Init(bot.Deps{Session: discord, OwnerID: conf.Discord.OwnerID, LLM: llm.GetClient()}); err != nil {
+		slog.Error("wttrin: init failed", "error", err)
+	} else {
+		for _, l := range wttrinMod.Listeners() {
+			discord.AddHandler(l)
+		}
+	}
 
 	cmds := []*discordgo.ApplicationCommand{
 		{Name: "status", Description: "Show bot runtime status (owner only)"},

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -17,6 +17,8 @@ const Personality = "You have very dry humor. Keep every response as short as po
 
 const llmTimeout = 30 * time.Second
 const langCacheTTL = 1 * time.Hour
+const llmModel = openai.ChatModelGPT4oMini
+const llmMaxTokens = int64(150)
 
 var client openai.Client
 
@@ -27,9 +29,9 @@ var generateMessageFn = func(ctx context.Context, systemPrompt, userPrompt strin
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(userPrompt),
 		},
-		Model:     openai.ChatModelGPT4oMini,
+		Model:     llmModel,
 		N:         openai.Int(1),
-		MaxTokens: openai.Int(150),
+		MaxTokens: openai.Int(llmMaxTokens),
 	})
 	if err != nil {
 		return "", err
@@ -73,9 +75,9 @@ func GenerateMessageWith(ctx context.Context, c *openai.Client, systemPrompt, us
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(userPrompt),
 		},
-		Model:     openai.ChatModelGPT4oMini,
+		Model:     llmModel,
 		N:         openai.Int(1),
-		MaxTokens: openai.Int(150),
+		MaxTokens: openai.Int(llmMaxTokens),
 	})
 	if err != nil {
 		return "", err

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -63,6 +63,26 @@ func GenerateMessage(ctx context.Context, systemPrompt, userPrompt string) (stri
 	return generateMessageFn(ctx, systemPrompt, userPrompt)
 }
 
+// GenerateMessageWith is like GenerateMessage but uses an explicit client instead of the global.
+// Use this when the client arrives via dependency injection rather than llm.Initialize().
+func GenerateMessageWith(ctx context.Context, c *openai.Client, systemPrompt, userPrompt string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, llmTimeout)
+	defer cancel()
+	completion, err := c.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(systemPrompt),
+			openai.UserMessage(userPrompt),
+		},
+		Model:     openai.ChatModelGPT4oMini,
+		N:         openai.Int(1),
+		MaxTokens: openai.Int(150),
+	})
+	if err != nil {
+		return "", err
+	}
+	return completion.Choices[0].Message.Content, nil
+}
+
 // DetectChannelLanguage fetches recent messages from a Discord channel and asks the LLM
 // to identify the primary language. Results are cached per channel for 1 hour.
 // Returns "English" on any error or empty channel.

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	openai "github.com/openai/openai-go/v3"
 )
 
 func TestDetectChannelLanguage_EmptyMessages(t *testing.T) {
@@ -88,4 +90,10 @@ func TestGenerateMessage_DelegatesToFn(t *testing.T) {
 	if got != "sys|usr" {
 		t.Errorf("got %q, want sys|usr", got)
 	}
+}
+
+func TestGenerateMessageWith_Signature(t *testing.T) {
+	// Compile-time check: GenerateMessageWith must accept the types expected by
+	// module Init functions that receive a *openai.Client via bot.Deps.
+	var _ func(context.Context, *openai.Client, string, string) (string, error) = GenerateMessageWith
 }

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-
-	openai "github.com/openai/openai-go/v3"
 )
 
 func TestDetectChannelLanguage_EmptyMessages(t *testing.T) {
@@ -92,8 +90,3 @@ func TestGenerateMessage_DelegatesToFn(t *testing.T) {
 	}
 }
 
-func TestGenerateMessageWith_Signature(t *testing.T) {
-	// Compile-time check: GenerateMessageWith must accept the types expected by
-	// module Init functions that receive a *openai.Client via bot.Deps.
-	var _ func(context.Context, *openai.Client, string, string) (string, error) = GenerateMessageWith
-}

--- a/internal/wttrin/wttrin.go
+++ b/internal/wttrin/wttrin.go
@@ -306,6 +306,7 @@ func (m *Module) onMessageCreate(s *discordgo.Session, mc *discordgo.MessageCrea
 }
 
 func (m *Module) sendMessage(s *discordgo.Session, mc *discordgo.MessageCreate, message string) {
+	// Empty string means the caller already handled the error (logged + notified user).
 	if message == "" {
 		return
 	}

--- a/internal/wttrin/wttrin.go
+++ b/internal/wttrin/wttrin.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/toksikk/gidbig/internal/bot"
 	"github.com/toksikk/gidbig/internal/llm"
 )
 
@@ -242,89 +243,112 @@ type wttrinResponse struct {
 	} `json:"weather"`
 }
 
-var (
-	detectLanguage   = llm.DetectChannelLanguage
-	generateLLMIntro = llm.GenerateMessage
-	getWeatherFn     = getWeather
-)
-
-// Start the plugin
-func Start(discord *discordgo.Session) {
-	discord.AddHandler(onMessageCreate)
-	slog.Info("wttrin function registered")
+// Module implements bot.Module for the wttrin weather plugin.
+type Module struct {
+	session      *discordgo.Session
+	detectLang   func(*discordgo.Session, string) (string, error)
+	generateFn   func(context.Context, string, string) (string, error)
+	getWeatherFn func(string) (wttrinResponse, error)
 }
 
-func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
-	msg := strings.Replace(m.ContentWithMentionsReplaced(), s.State.User.Username, "username", 1)
+// New returns a new wttrin Module with default LLM functions.
+func New() *Module {
+	return &Module{
+		detectLang:   llm.DetectChannelLanguage,
+		generateFn:   llm.GenerateMessage,
+		getWeatherFn: getWeather,
+	}
+}
+
+func (m *Module) Name() string { return "wttrin" }
+
+func (m *Module) Init(d bot.Deps) error {
+	m.session = d.Session
+	if d.LLM != nil {
+		llmClient := d.LLM
+		m.generateFn = func(ctx context.Context, system, user string) (string, error) {
+			return llm.GenerateMessageWith(ctx, llmClient, system, user)
+		}
+	}
+	slog.Info("wttrin: initialized")
+	return nil
+}
+
+func (m *Module) Commands() []*discordgo.ApplicationCommand { return nil }
+
+func (m *Module) Listeners() []bot.EventListener {
+	return []bot.EventListener{m.onMessageCreate}
+}
+
+func (m *Module) Components() []bot.ComponentHandler { return nil }
+func (m *Module) Background() []bot.BackgroundTask   { return nil }
+func (m *Module) Shutdown() error                    { return nil }
+
+func (m *Module) onMessageCreate(s *discordgo.Session, mc *discordgo.MessageCreate) {
+	msg := strings.Replace(mc.ContentWithMentionsReplaced(), s.State.User.Username, "username", 1)
 	parts := strings.Split(msg, " ")
-	channel, err := s.State.Channel(m.ChannelID)
+	channel, err := s.State.Channel(mc.ChannelID)
 	if channel == nil {
-		slog.Error("Failed to grab channel", "MessageID", m.ID, "ChannelID", m.ChannelID, "Error", err)
+		slog.Error("Failed to grab channel", "MessageID", mc.ID, "ChannelID", mc.ChannelID, "Error", err)
 		return
 	}
-
 	guild, err := s.State.Guild(channel.GuildID)
 	if guild == nil {
-		slog.Error("Failed to grab guild", "MessageID", m.ID, "Channel", channel, "GuildID", channel.GuildID, "Error", err)
+		slog.Error("Failed to grab guild", "MessageID", mc.ID, "Channel", channel, "GuildID", channel.GuildID, "Error", err)
 		return
 	}
-
 	switch strings.ToLower(parts[0]) {
 	case "!wttr":
-		sendMessage(s, m, constructDiscordMessage(s, m, parts, guild, false))
+		m.sendMessage(s, mc, m.constructDiscordMessage(s, mc, parts, guild, false))
 	case "!wttrf":
-		sendMessage(s, m, constructDiscordMessage(s, m, parts, guild, true))
+		m.sendMessage(s, mc, m.constructDiscordMessage(s, mc, parts, guild, true))
 	}
 }
 
-func sendMessage(s *discordgo.Session, m *discordgo.MessageCreate, message string) {
-	resultDiscordMessage, err := s.ChannelMessageSend(m.ChannelID, message)
-	if err != nil {
-		slog.Error("Failed to send message", "MessageID", resultDiscordMessage.ID, "ChannelID", resultDiscordMessage.ChannelID, "Error", err)
+func (m *Module) sendMessage(s *discordgo.Session, mc *discordgo.MessageCreate, message string) {
+	if message == "" {
+		return
+	}
+	if _, err := s.ChannelMessageSend(mc.ChannelID, message); err != nil {
+		slog.Error("Failed to send message", "ChannelID", mc.ChannelID, "Error", err)
 	}
 }
 
-func constructDiscordMessage(s *discordgo.Session, m *discordgo.MessageCreate, parts []string, g *discordgo.Guild, forecast bool) string {
+func (m *Module) constructDiscordMessage(s *discordgo.Session, mc *discordgo.MessageCreate, parts []string, g *discordgo.Guild, forecast bool) string {
 	if len(parts) <= 1 {
 		return ""
 	}
-
 	location := strings.Join(parts[1:], "+")
-	weatherResult, err := getWeatherFn(location)
+	weatherResult, err := m.getWeatherFn(location)
 	if err != nil {
-		slog.Error("Failed to get weather", "MessageID", m.ID, "Location", location, "Error", err)
-		discordErrorMessage, err := s.ChannelMessageSend(m.ChannelID, "Failed to get weather for "+location+": "+err.Error())
-		if err != nil {
-			slog.Error("Failed to send message", "MessageID", discordErrorMessage.ID, "ChannelID", discordErrorMessage.ChannelID, "Error", err)
+		slog.Error("Failed to get weather", "MessageID", mc.ID, "Location", location, "Error", err)
+		if _, err2 := s.ChannelMessageSend(mc.ChannelID, "Failed to get weather for "+location+": "+err.Error()); err2 != nil {
+			slog.Error("Failed to send error message", "ChannelID", mc.ChannelID, "Error", err2)
 		}
 		return ""
 	}
-
 	var structured string
 	if forecast {
 		structured = buildForecastString(weatherResult)
 	} else {
 		structured = buildWeatherString(weatherResult)
 	}
-
-	outro := buildLLMWeatherOutro(s, m, location, structured)
+	outro := m.buildLLMWeatherOutro(s, mc, location, structured)
 	if outro != "" {
 		return structured + "\n" + outro
 	}
 	return structured
 }
 
-func buildLLMWeatherOutro(s *discordgo.Session, m *discordgo.MessageCreate, location, weatherData string) string {
-	lang, err := detectLanguage(s, m.ChannelID)
+func (m *Module) buildLLMWeatherOutro(s *discordgo.Session, mc *discordgo.MessageCreate, location, weatherData string) string {
+	lang, err := m.detectLang(s, mc.ChannelID)
 	if err != nil {
 		slog.Warn("wttrin: language detection failed", "error", err)
 		lang = "English"
 	}
-
 	systemPrompt := "You are a Discord bot. Write one sentence describing the current weather for the given location — set the mood without repeating the raw numbers. " + llm.Personality + " Respond in " + lang + "."
 	userPrompt := "Location: " + location + "\n" + weatherData
-
-	outro, err := generateLLMIntro(context.Background(), systemPrompt, userPrompt)
+	outro, err := m.generateFn(context.Background(), systemPrompt, userPrompt)
 	if err != nil {
 		slog.Warn("wttrin: LLM outro generation failed", "error", err)
 		return ""
@@ -361,7 +385,6 @@ func getWeatherConditionEmoji(weatherCode string) (weatherConditionEmoji string)
 			break
 		}
 	}
-
 	if weatherConditionEmoji == "🌈" {
 		slog.Warn("Unknown weather code", "Code", weatherCode)
 	}
@@ -400,12 +423,10 @@ func mostOccurringWeatherCodeForDay(hours []hourly) string {
 	if len(hours) == 0 {
 		return ""
 	}
-
 	weatherCodeCounts := make(map[string]int)
 	for _, hour := range hours {
 		weatherCodeCounts[hour.WeatherCode]++
 	}
-
 	maxCount := 0
 	mostOccurringCode := ""
 	for code, count := range weatherCodeCounts {
@@ -414,7 +435,6 @@ func mostOccurringWeatherCodeForDay(hours []hourly) string {
 			maxCount = count
 		}
 	}
-
 	return mostOccurringCode
 }
 
@@ -506,11 +526,9 @@ func checkForHighChances(hourly []hourly) (highChances string) {
 	if highestChanceOfWindy > 0 {
 		highChances += "💨 " + strconv.Itoa(highestChanceOfWindy) + "% "
 	}
-
 	if highChances != "" {
 		highChances = "⚠️ " + highChances
 	}
-
 	return
 }
 
@@ -579,7 +597,7 @@ func buildForecastString(weatherResult wttrinResponse) (result string) {
 				}
 				result += fmt.Sprintf("🌧️ %.2fmm\n", averageRain)
 			} else {
-				result += "\n" // Add newline if no rain but snow
+				result += "\n"
 			}
 		}
 

--- a/internal/wttrin/wttrin_test.go
+++ b/internal/wttrin/wttrin_test.go
@@ -7,41 +7,24 @@ import (
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/toksikk/gidbig/internal/llm"
 )
 
-func stubLLM(t *testing.T, reply string, err error) {
-	t.Helper()
-	prev := generateLLMIntro
-	t.Cleanup(func() { generateLLMIntro = prev })
-	generateLLMIntro = func(_ context.Context, _, _ string) (string, error) {
-		return reply, err
-	}
-}
-
-func stubDetectLanguage(t *testing.T, lang string) {
-	t.Helper()
-	prev := detectLanguage
-	t.Cleanup(func() { detectLanguage = prev })
-	detectLanguage = func(_ *discordgo.Session, _ string) (string, error) {
-		return lang, nil
-	}
-}
-
-func stubGetWeather(t *testing.T, result wttrinResponse, err error) {
-	t.Helper()
-	prev := getWeatherFn
-	t.Cleanup(func() { getWeatherFn = prev })
-	getWeatherFn = func(_ string) (wttrinResponse, error) {
-		return result, err
+func newTestModule() *Module {
+	return &Module{
+		detectLang:   func(_ *discordgo.Session, _ string) (string, error) { return "English", nil },
+		generateFn:   func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		getWeatherFn: func(_ string) (wttrinResponse, error) { return wttrinResponse{}, nil },
 	}
 }
 
 func TestBuildLLMWeatherOutro_ReturnsOnSuccess(t *testing.T) {
-	stubDetectLanguage(t, "German")
-	stubLLM(t, "Das Wetter heute ist angenehm.", nil)
+	m := newTestModule()
+	m.detectLang = func(_ *discordgo.Session, _ string) (string, error) { return "German", nil }
+	m.generateFn = func(_ context.Context, _, _ string) (string, error) {
+		return "Das Wetter heute ist angenehm.", nil
+	}
 
-	outro := buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
+	outro := m.buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, "Berlin", "15°C sunny")
 
@@ -51,10 +34,12 @@ func TestBuildLLMWeatherOutro_ReturnsOnSuccess(t *testing.T) {
 }
 
 func TestBuildLLMWeatherOutro_EmptyOnLLMError(t *testing.T) {
-	stubDetectLanguage(t, "English")
-	stubLLM(t, "", errors.New("api error"))
+	m := newTestModule()
+	m.generateFn = func(_ context.Context, _, _ string) (string, error) {
+		return "", errors.New("api error")
+	}
 
-	outro := buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
+	outro := m.buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, "London", "10°C rain")
 
@@ -64,10 +49,12 @@ func TestBuildLLMWeatherOutro_EmptyOnLLMError(t *testing.T) {
 }
 
 func TestBuildLLMWeatherOutro_TrimsWhitespace(t *testing.T) {
-	stubDetectLanguage(t, "English")
-	stubLLM(t, "  Nice weather!  ", nil)
+	m := newTestModule()
+	m.generateFn = func(_ context.Context, _, _ string) (string, error) {
+		return "  Nice weather!  ", nil
+	}
 
-	outro := buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
+	outro := m.buildLLMWeatherOutro(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, "London", "data")
 
@@ -76,12 +63,17 @@ func TestBuildLLMWeatherOutro_TrimsWhitespace(t *testing.T) {
 	}
 }
 
-// Verify the package-level vars are wired to the llm package.
-func TestDefaultsWiredToLLMPackage(t *testing.T) {
-	if generateLLMIntro == nil {
-		t.Error("generateLLMIntro must not be nil")
+func TestDefaultsWiredCorrectly(t *testing.T) {
+	m := New()
+	if m.generateFn == nil {
+		t.Error("generateFn must not be nil")
 	}
-	_ = llm.GenerateMessage // ensure llm package is referenced
+	if m.detectLang == nil {
+		t.Error("detectLang must not be nil")
+	}
+	if m.getWeatherFn == nil {
+		t.Error("getWeatherFn must not be nil")
+	}
 }
 
 func minimalWeatherResponse() wttrinResponse {
@@ -244,11 +236,11 @@ func TestMostOccurringWeatherCodeForDay_ReturnsDominantCode(t *testing.T) {
 }
 
 func TestConstructDiscordMessage_StructuredBeforeLLMOutro(t *testing.T) {
-	stubDetectLanguage(t, "English")
-	stubLLM(t, "Lovely day ahead!", nil)
-	stubGetWeather(t, minimalWeatherResponse(), nil)
+	m := newTestModule()
+	m.generateFn = func(_ context.Context, _, _ string) (string, error) { return "Lovely day ahead!", nil }
+	m.getWeatherFn = func(_ string) (wttrinResponse, error) { return minimalWeatherResponse(), nil }
 
-	msg := constructDiscordMessage(nil, &discordgo.MessageCreate{
+	msg := m.constructDiscordMessage(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, []string{"!wttr", "Berlin"}, &discordgo.Guild{}, false)
 
@@ -266,11 +258,11 @@ func TestConstructDiscordMessage_StructuredBeforeLLMOutro(t *testing.T) {
 }
 
 func TestConstructDiscordMessage_ForecastStructuredBeforeLLMOutro(t *testing.T) {
-	stubDetectLanguage(t, "English")
-	stubLLM(t, "Pack an umbrella!", nil)
-	stubGetWeather(t, minimalWeatherResponse(), nil)
+	m := newTestModule()
+	m.generateFn = func(_ context.Context, _, _ string) (string, error) { return "Pack an umbrella!", nil }
+	m.getWeatherFn = func(_ string) (wttrinResponse, error) { return minimalWeatherResponse(), nil }
 
-	msg := constructDiscordMessage(nil, &discordgo.MessageCreate{
+	msg := m.constructDiscordMessage(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, []string{"!wttrf", "Berlin"}, &discordgo.Guild{}, true)
 
@@ -288,11 +280,11 @@ func TestConstructDiscordMessage_ForecastStructuredBeforeLLMOutro(t *testing.T) 
 }
 
 func TestConstructDiscordMessage_LLMFailureReturnsOnlyStructured(t *testing.T) {
-	stubDetectLanguage(t, "English")
-	stubLLM(t, "", errors.New("llm down"))
-	stubGetWeather(t, minimalWeatherResponse(), nil)
+	m := newTestModule()
+	m.generateFn = func(_ context.Context, _, _ string) (string, error) { return "", errors.New("llm down") }
+	m.getWeatherFn = func(_ string) (wttrinResponse, error) { return minimalWeatherResponse(), nil }
 
-	msg := constructDiscordMessage(nil, &discordgo.MessageCreate{
+	msg := m.constructDiscordMessage(nil, &discordgo.MessageCreate{
 		Message: &discordgo.Message{ChannelID: "ch1"},
 	}, []string{"!wttr", "Berlin"}, &discordgo.Guild{}, false)
 


### PR DESCRIPTION
Closes #175. Part of #171.

## Summary

- `wttrin.New()` returns a `*Module` implementing `bot.Module`
- `detectLang`, `generateFn`, `getWeatherFn` moved from package-level mutable vars to `Module` fields — no more global monkey-patch state
- `Init(bot.Deps)` wires `d.LLM` via `llm.GenerateMessageWith` closure; falls back to `llm.GenerateMessage` for zero-value Deps (backward-compatible)
- `buildLLMWeatherOutro` / `constructDiscordMessage` / `sendMessage` become methods on `Module`
- Fix: `sendMessage` previously dereferenced `*discordgo.Message` on error return (nil ptr)
- `llm.GenerateMessageWith(ctx, *openai.Client, system, user)` added for explicit-client callers
- `cmd.go` updated to `wttrin.New()+Init+Listeners()` pattern, passing `LLM: llm.GetClient()`
- Tests updated: module field injection replaces package-level var stubs

## Test plan

- [ ] `make test` passes
- [ ] `make build` succeeds
- [ ] `!wttr Berlin` and `!wttrf Berlin` still work in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)