### PR TITLE
refactor(coffee): migrate to bot.Module with AdminProvider

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -6,14 +6,21 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/toksikk/gidbig/internal/coffee"
+	"github.com/toksikk/gidbig/internal/bot"
 	"github.com/toksikk/gidbig/internal/gippity"
 )
 
 var (
-	ownerID string
-	infoFn  func(s *discordgo.Session) string
+	ownerID   string
+	infoFn    func(s *discordgo.Session) string
+	providers []bot.AdminProvider
 )
+
+// RegisterProvider registers a module as an admin subcommand provider.
+// Must be called before Start.
+func RegisterProvider(p bot.AdminProvider) {
+	providers = append(providers, p)
+}
 
 // Start registers the /admin interaction handler.
 func Start(s *discordgo.Session, oid string, info func(s *discordgo.Session) string) {
@@ -33,49 +40,43 @@ func Commands() []*discordgo.ApplicationCommand {
 			Required:    false,
 		}
 	}
+
+	opts := make([]*discordgo.ApplicationCommandOption, 0, len(providers)+2)
+	for _, p := range providers {
+		opts = append(opts, p.AdminSubcommandGroup())
+	}
+	opts = append(opts,
+		&discordgo.ApplicationCommandOption{
+			Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+			Name:        "gippity",
+			Description: "Gippity admin queries",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "privacy",
+					Description: "Show gippity privacy setting for a user or all users",
+					Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "history",
+					Description: "Show whether a user has stored conversation history",
+					Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
+				},
+			},
+		},
+		&discordgo.ApplicationCommandOption{
+			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			Name:        "info",
+			Description: "General bot info: uptime, guild count, loaded plugins",
+		},
+	)
+
 	return []*discordgo.ApplicationCommand{
 		{
 			Name:        "admin",
 			Description: "Admin commands (owner only)",
-			Options: []*discordgo.ApplicationCommandOption{
-				{
-					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
-					Name:        "coffee",
-					Description: "Coffee admin queries",
-					Options: []*discordgo.ApplicationCommandOption{
-						{
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Name:        "beverages",
-							Description: "Show beverage settings for a user or all users",
-							Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
-						},
-					},
-				},
-				{
-					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
-					Name:        "gippity",
-					Description: "Gippity admin queries",
-					Options: []*discordgo.ApplicationCommandOption{
-						{
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Name:        "privacy",
-							Description: "Show gippity privacy setting for a user or all users",
-							Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
-						},
-						{
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Name:        "history",
-							Description: "Show whether a user has stored conversation history",
-							Options:     []*discordgo.ApplicationCommandOption{userOpt("Target user (omit for all)")},
-						},
-					},
-				},
-				{
-					Type:        discordgo.ApplicationCommandOptionSubCommand,
-					Name:        "info",
-					Description: "General bot info: uptime, guild count, loaded plugins",
-				},
-			},
+			Options:     opts,
 		},
 	}
 }
@@ -121,13 +122,18 @@ func onAdminInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCrea
 	switch top.Name {
 	case "info":
 		ephemeral(s, i, "```"+infoFn(s)+"```")
-	case "coffee":
-		if len(top.Options) > 0 {
-			handleCoffeeAdmin(s, i, top.Options[0])
-		}
 	case "gippity":
 		if len(top.Options) > 0 {
 			handleGippityAdmin(s, i, top.Options[0])
+		}
+	default:
+		for _, p := range providers {
+			if p.AdminSubcommandGroup().Name == top.Name {
+				if len(top.Options) > 0 {
+					p.HandleAdminSubcommand(s, i, top.Options[0])
+				}
+				return
+			}
 		}
 	}
 }
@@ -143,36 +149,6 @@ func optUserID(s *discordgo.Session, opts []*discordgo.ApplicationCommandInterac
 		}
 	}
 	return ""
-}
-
-func handleCoffeeAdmin(s *discordgo.Session, i *discordgo.InteractionCreate, sub *discordgo.ApplicationCommandInteractionDataOption) {
-	if sub.Name != "beverages" {
-		return
-	}
-	targetID := optUserID(s, sub.Options)
-	if targetID != "" {
-		pref, found := coffee.AdminGetBeveragePreference(targetID)
-		if !found {
-			ephemeral(s, i, fmt.Sprintf("No beverage preference found for <@%s>.", targetID))
-			return
-		}
-		ephemeral(s, i, fmt.Sprintf("<@%s>: %s (introduced: %v)", targetID, pref.BeverageEmoji, pref.HasSeenIntro))
-		return
-	}
-	prefs, err := coffee.AdminGetAllBeveragePreferences()
-	if err != nil {
-		ephemeral(s, i, fmt.Sprintf("Error querying beverage preferences: %v", err))
-		return
-	}
-	if len(prefs) == 0 {
-		ephemeral(s, i, "No beverage preferences stored.")
-		return
-	}
-	var sb strings.Builder
-	for _, p := range prefs {
-		fmt.Fprintf(&sb, "<@%s>: %s (introduced: %v)\n", p.UserID, p.BeverageEmoji, p.HasSeenIntro)
-	}
-	ephemeral(s, i, sb.String())
 }
 
 func handleGippityAdmin(s *discordgo.Session, i *discordgo.InteractionCreate, sub *discordgo.ApplicationCommandInteractionDataOption) {

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -1,10 +1,40 @@
 package admin
 
 import (
+	"os"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/toksikk/gidbig/internal/bot"
 )
+
+// stubCoffeeProvider is a minimal bot.AdminProvider used in tests.
+type stubCoffeeProvider struct{}
+
+func (stubCoffeeProvider) AdminSubcommandGroup() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+		Name:        "coffee",
+		Description: "Coffee admin queries",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Name:        "beverages",
+				Description: "Show beverage settings for a user or all users",
+			},
+		},
+	}
+}
+
+func (stubCoffeeProvider) HandleAdminSubcommand(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ *discordgo.ApplicationCommandInteractionDataOption) {
+}
+
+var _ bot.AdminProvider = stubCoffeeProvider{}
+
+func TestMain(m *testing.M) {
+	RegisterProvider(stubCoffeeProvider{})
+	os.Exit(m.Run())
+}
 
 func TestCommands_Structure(t *testing.T) {
 	cmds := Commands()

--- a/internal/bot/module.go
+++ b/internal/bot/module.go
@@ -31,3 +31,9 @@ type Module interface {
 	Background() []BackgroundTask
 	Shutdown() error
 }
+
+// AdminProvider allows a Module to expose a subcommand group under /admin.
+type AdminProvider interface {
+	AdminSubcommandGroup() *discordgo.ApplicationCommandOption
+	HandleAdminSubcommand(s *discordgo.Session, i *discordgo.InteractionCreate, sub *discordgo.ApplicationCommandInteractionDataOption)
+}

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -26,6 +26,9 @@ type Config struct {
 		SessionSecret string `yaml:"session_secret"`
 		Port          int    `yaml:"port,omitempty" default:"8080"`
 	} `yaml:"web"`
+	Database struct {
+		Path string `yaml:"path,omitempty"`
+	} `yaml:"database,omitempty"`
 	Gippity struct {
 		AllowedGuilds []string `yaml:"allowed_guilds"`
 		IgnoredUsers  []string `yaml:"ignored_users"`

--- a/internal/coffee/admin.go
+++ b/internal/coffee/admin.go
@@ -1,10 +1,71 @@
 package coffee
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
 
-// AdminGetBeveragePreference returns the stored beverage preference for one user.
-func AdminGetBeveragePreference(userID string) (*UserBeveragePreference, bool) {
-	d := getDB()
+	"github.com/bwmarrin/discordgo"
+)
+
+// AdminSubcommandGroup returns the /admin coffee subcommand group definition.
+func (m *Module) AdminSubcommandGroup() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+		Name:        "coffee",
+		Description: "Coffee admin queries",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Name:        "beverages",
+				Description: "Show beverage settings for a user or all users",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionUser,
+						Name:        "user",
+						Description: "Target user (omit for all)",
+						Required:    false,
+					},
+				},
+			},
+		},
+	}
+}
+
+// HandleAdminSubcommand handles /admin coffee subcommands.
+func (m *Module) HandleAdminSubcommand(s *discordgo.Session, i *discordgo.InteractionCreate, sub *discordgo.ApplicationCommandInteractionDataOption) {
+	if sub.Name != "beverages" {
+		return
+	}
+	targetID := adminOptUserID(s, sub.Options)
+	if targetID != "" {
+		pref, found := m.adminGetBeveragePreference(targetID)
+		if !found {
+			adminEphemeral(s, i, fmt.Sprintf("No beverage preference found for <@%s>.", targetID))
+			return
+		}
+		adminEphemeral(s, i, fmt.Sprintf("<@%s>: %s (introduced: %v)", targetID, pref.BeverageEmoji, pref.HasSeenIntro))
+		return
+	}
+	prefs, err := m.adminGetAllBeveragePreferences()
+	if err != nil {
+		adminEphemeral(s, i, fmt.Sprintf("Error querying beverage preferences: %v", err))
+		return
+	}
+	if len(prefs) == 0 {
+		adminEphemeral(s, i, "No beverage preferences stored.")
+		return
+	}
+	var sb strings.Builder
+	for _, p := range prefs {
+		fmt.Fprintf(&sb, "<@%s>: %s (introduced: %v)\n", p.UserID, p.BeverageEmoji, p.HasSeenIntro)
+	}
+	adminEphemeral(s, i, sb.String())
+}
+
+func (m *Module) adminGetBeveragePreference(userID string) (*UserBeveragePreference, bool) {
+	d := m.getDB()
 	if d == nil {
 		return nil, false
 	}
@@ -15,13 +76,37 @@ func AdminGetBeveragePreference(userID string) (*UserBeveragePreference, bool) {
 	return &pref, true
 }
 
-// AdminGetAllBeveragePreferences returns all stored beverage preferences.
-func AdminGetAllBeveragePreferences() ([]UserBeveragePreference, error) {
-	d := getDB()
+func (m *Module) adminGetAllBeveragePreferences() ([]UserBeveragePreference, error) {
+	d := m.getDB()
 	if d == nil {
 		return nil, errors.New("store not initialized")
 	}
 	var prefs []UserBeveragePreference
 	result := d.Find(&prefs)
 	return prefs, result.Error
+}
+
+func adminOptUserID(s *discordgo.Session, opts []*discordgo.ApplicationCommandInteractionDataOption) string {
+	for _, o := range opts {
+		if o.Name == "user" {
+			u := o.UserValue(s)
+			if u == nil {
+				return ""
+			}
+			return u.ID
+		}
+	}
+	return ""
+}
+
+func adminEphemeral(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: content,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	}); err != nil {
+		slog.Error("coffee: admin respond failed", "error", err)
+	}
 }

--- a/internal/coffee/admin_test.go
+++ b/internal/coffee/admin_test.go
@@ -5,22 +5,22 @@ import (
 )
 
 func TestAdminGetBeveragePreference_NotFound(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
-	pref, found := AdminGetBeveragePreference("unknown-user")
+	pref, found := m.adminGetBeveragePreference("unknown-user")
 	if found {
 		t.Errorf("expected found=false for unknown user, got pref=%v", pref)
 	}
 }
 
 func TestAdminGetBeveragePreference_Found(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
-	if err := setBeverageEmoji("user1", "🍵"); err != nil {
+	if err := m.setBeverageEmoji("user1", "🍵"); err != nil {
 		t.Fatalf("setBeverageEmoji: %v", err)
 	}
 
-	pref, found := AdminGetBeveragePreference("user1")
+	pref, found := m.adminGetBeveragePreference("user1")
 	if !found {
 		t.Fatal("expected found=true")
 	}
@@ -33,9 +33,9 @@ func TestAdminGetBeveragePreference_Found(t *testing.T) {
 }
 
 func TestAdminGetAllBeveragePreferences_Empty(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
-	prefs, err := AdminGetAllBeveragePreferences()
+	prefs, err := m.adminGetAllBeveragePreferences()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestAdminGetAllBeveragePreferences_Empty(t *testing.T) {
 }
 
 func TestAdminGetAllBeveragePreferences_Multiple(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
 	users := []struct {
 		id    string
@@ -56,12 +56,12 @@ func TestAdminGetAllBeveragePreferences_Multiple(t *testing.T) {
 		{"user-c", "🧃"},
 	}
 	for _, u := range users {
-		if err := setBeverageEmoji(u.id, u.emoji); err != nil {
+		if err := m.setBeverageEmoji(u.id, u.emoji); err != nil {
 			t.Fatalf("setBeverageEmoji(%q): %v", u.id, err)
 		}
 	}
 
-	prefs, err := AdminGetAllBeveragePreferences()
+	prefs, err := m.adminGetAllBeveragePreferences()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,34 +71,24 @@ func TestAdminGetAllBeveragePreferences_Multiple(t *testing.T) {
 }
 
 func TestAdminGetBeveragePreference_NilDB(t *testing.T) {
-	dbMu.Lock()
-	prev := db
-	db = nil
-	dbMu.Unlock()
-	t.Cleanup(func() {
-		dbMu.Lock()
-		db = prev
-		dbMu.Unlock()
-	})
+	m := newTestModule(t)
+	m.dbMu.Lock()
+	m.db = nil
+	m.dbMu.Unlock()
 
-	_, found := AdminGetBeveragePreference("user1")
+	_, found := m.adminGetBeveragePreference("user1")
 	if found {
 		t.Error("expected found=false when DB is nil")
 	}
 }
 
 func TestAdminGetAllBeveragePreferences_NilDB(t *testing.T) {
-	dbMu.Lock()
-	prev := db
-	db = nil
-	dbMu.Unlock()
-	t.Cleanup(func() {
-		dbMu.Lock()
-		db = prev
-		dbMu.Unlock()
-	})
+	m := newTestModule(t)
+	m.dbMu.Lock()
+	m.db = nil
+	m.dbMu.Unlock()
 
-	_, err := AdminGetAllBeveragePreferences()
+	_, err := m.adminGetAllBeveragePreferences()
 	if err == nil {
 		t.Error("expected error when DB is nil")
 	}

--- a/internal/coffee/brew.go
+++ b/internal/coffee/brew.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -39,45 +38,34 @@ type brewState struct {
 
 type grabResult struct {
 	notReady     bool
-	noCup        bool // tried to add milk/sugar but user has no cup in this brew
+	noCup        bool
 	isEmpty      bool
 	cupLiters    float64
 	updatedMsg   string
 	buttonLabels [3]string
 }
 
-var (
-	brewMu     sync.RWMutex
-	brewStates = map[string]*brewState{}
-
-	sendBrewReadyMessage     = defaultSendBrewReadyMessage
-	randCupSize              = defaultRandCupSize
-	generateBrewButtonLabels = func(_ *discordgo.Session, _ string) [3]string {
-		return [3]string{"☕ Grab a cup", "🥛 With milk", "🍬 With sugar"}
-	}
-)
-
 func defaultRandCupSize() float64 {
 	ml := 150 + rand.Intn(21)*10
 	return float64(ml) / 1000.0
 }
 
-func defaultSendBrewReadyMessage(s *discordgo.Session, guildID, channelID string) {
+func (m *Module) defaultSendBrewReadyMessage(s *discordgo.Session, guildID, channelID string) {
 	if s == nil {
 		return
 	}
-	announcement := generateInteractionMessage(s, channelID,
+	announcement := m.generateInteractionMessage(s, channelID,
 		"The coffee is ready. Announce it to the channel in one short, inviting sentence.",
 		"☕ Coffee is ready! Grab your cup!")
-	labels := generateBrewButtonLabels(s, channelID)
+	labels := m.generateBrewButtonLabels(s, channelID)
 
-	brewMu.Lock()
+	m.brewMu.Lock()
 	key := brewStateKey(guildID, channelID)
-	if st, ok := brewStates[key]; ok {
+	if st, ok := m.brewStates[key]; ok {
 		st.readyAnnouncement = announcement
 		st.buttonLabels = labels
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
 	_, _ = s.ChannelMessageSendComplex(channelID, &discordgo.MessageSend{
 		Content: announcement,
@@ -87,17 +75,17 @@ func defaultSendBrewReadyMessage(s *discordgo.Session, guildID, channelID string
 					discordgo.Button{
 						Label:    labels[0],
 						Style:    discordgo.PrimaryButton,
-						CustomID: "grab_coffee",
+						CustomID: "coffee:grab_coffee",
 					},
 					discordgo.Button{
 						Label:    labels[1],
 						Style:    discordgo.SecondaryButton,
-						CustomID: "grab_milk",
+						CustomID: "coffee:grab_milk",
 					},
 					discordgo.Button{
 						Label:    labels[2],
 						Style:    discordgo.SecondaryButton,
-						CustomID: "grab_sugar",
+						CustomID: "coffee:grab_sugar",
 					},
 				},
 			},
@@ -112,67 +100,64 @@ func brewStateKey(guildID, channelID string) string {
 	return guildID + ":" + channelID
 }
 
-func hasActiveBrew(guildID, channelID string) bool {
-	brewMu.RLock()
-	defer brewMu.RUnlock()
-	_, exists := brewStates[brewStateKey(guildID, channelID)]
+func (m *Module) hasActiveBrew(guildID, channelID string) bool {
+	m.brewMu.RLock()
+	defer m.brewMu.RUnlock()
+	_, exists := m.brewStates[brewStateKey(guildID, channelID)]
 	return exists
 }
 
 // startBrew attempts to start a new brew in the given channel.
 // Returns (true, readyAt) if a brew is already in progress, (false, readyAt) if newly started.
-func startBrew(s *discordgo.Session, guildID, channelID string) (alreadyBrewing bool, readyAt time.Time) {
-	brewMu.Lock()
+func (m *Module) startBrew(s *discordgo.Session, guildID, channelID string) (alreadyBrewing bool, readyAt time.Time) {
+	m.brewMu.Lock()
 	key := brewStateKey(guildID, channelID)
-	if st, exists := brewStates[key]; exists && !st.isReady {
-		brewMu.Unlock()
+	if st, exists := m.brewStates[key]; exists && !st.isReady {
+		m.brewMu.Unlock()
 		return true, st.readyAt
 	}
-	readyAt = nowFunc().Add(brewDuration)
-	brewStates[key] = &brewState{
+	readyAt = m.nowFunc().Add(brewDuration)
+	m.brewStates[key] = &brewState{
 		readyAt:      readyAt,
 		isReady:      false,
 		coffeeLiters: potCapacity,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
 	go func() {
 		time.Sleep(brewDuration)
-		markBrewReady(s, guildID, channelID)
+		m.markBrewReady(s, guildID, channelID)
 	}()
 
 	return false, readyAt
 }
 
-func markBrewReady(s *discordgo.Session, guildID, channelID string) {
-	brewMu.Lock()
+func (m *Module) markBrewReady(s *discordgo.Session, guildID, channelID string) {
+	m.brewMu.Lock()
 	key := brewStateKey(guildID, channelID)
-	st, ok := brewStates[key]
+	st, ok := m.brewStates[key]
 	if ok && !st.isReady {
 		st.isReady = true
 	} else {
 		ok = false
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
 	if ok {
-		sendBrewReadyMessage(s, guildID, channelID)
+		m.sendBrewReadyMessage(s, guildID, channelID)
 	}
 }
 
-// grabCoffee handles the state mutation for a user grabbing a plain cup of coffee.
-// Multiple grabs by the same user are allowed. Milk/sugar can be added afterwards
-// via addToLastCup.
-func grabCoffee(guildID, channelID, userID string) grabResult {
-	brewMu.Lock()
-	defer brewMu.Unlock()
+func (m *Module) grabCoffee(guildID, channelID, userID string) grabResult {
+	m.brewMu.Lock()
+	defer m.brewMu.Unlock()
 
 	key := brewStateKey(guildID, channelID)
-	st, ok := brewStates[key]
+	st, ok := m.brewStates[key]
 	if !ok || !st.isReady || st.coffeeLiters < emptyThreshold {
 		return grabResult{notReady: true}
 	}
-	cup := CupTaken{liters: randCupSize()}
+	cup := CupTaken{liters: m.randCupSize()}
 	if cup.liters > st.coffeeLiters {
 		cup.liters = st.coffeeLiters
 	}
@@ -182,7 +167,7 @@ func grabCoffee(guildID, channelID, userID string) grabResult {
 	isEmpty := st.coffeeLiters < emptyThreshold
 	updatedMsg := buildBrewMessage(st)
 	if isEmpty {
-		delete(brewStates, key)
+		delete(m.brewStates, key)
 	}
 	return grabResult{
 		cupLiters:    cup.liters,
@@ -192,14 +177,12 @@ func grabCoffee(guildID, channelID, userID string) grabResult {
 	}
 }
 
-// addToLastCup adds milk and/or sugar to the most recent cup grabbed by userID in
-// this brew. Returns noCup=true if the user has not grabbed a cup yet.
-func addToLastCup(guildID, channelID, userID string, milk, sugar bool) grabResult {
-	brewMu.Lock()
-	defer brewMu.Unlock()
+func (m *Module) addToLastCup(guildID, channelID, userID string, milk, sugar bool) grabResult {
+	m.brewMu.Lock()
+	defer m.brewMu.Unlock()
 
 	key := brewStateKey(guildID, channelID)
-	st, ok := brewStates[key]
+	st, ok := m.brewStates[key]
 	if !ok || !st.isReady {
 		return grabResult{notReady: true}
 	}
@@ -234,7 +217,6 @@ func buildBrewMessage(st *brewState) string {
 	var sb strings.Builder
 	sb.WriteString(header)
 
-	// Group by user, maintaining first-grab order for deterministic output.
 	userOrder := []string{}
 	userGrabs := map[string][]CupTaken{}
 	for _, gr := range st.grabs {

--- a/internal/coffee/brew_test.go
+++ b/internal/coffee/brew_test.go
@@ -13,50 +13,51 @@ type capturedBrewReadyCall struct {
 	channelID string
 }
 
-func captureBrewReadyMessages(t *testing.T) func() []capturedBrewReadyCall {
+func captureBrewReadyMessages(m *Module, t *testing.T) func() []capturedBrewReadyCall {
 	t.Helper()
-	previous := sendBrewReadyMessage
+	previous := m.sendBrewReadyMessage
 	calls := []capturedBrewReadyCall{}
-	sendBrewReadyMessage = func(_ *discordgo.Session, guildID, channelID string) {
+	m.sendBrewReadyMessage = func(_ *discordgo.Session, guildID, channelID string) {
 		calls = append(calls, capturedBrewReadyCall{guildID: guildID, channelID: channelID})
 	}
-	t.Cleanup(func() { sendBrewReadyMessage = previous })
+	t.Cleanup(func() { m.sendBrewReadyMessage = previous })
 	return func() []capturedBrewReadyCall { return calls }
 }
 
-func useFixedCupSize(t *testing.T, size float64) {
+func useFixedCupSize(m *Module, t *testing.T, size float64) {
 	t.Helper()
-	previous := randCupSize
-	randCupSize = func() float64 { return size }
-	t.Cleanup(func() { randCupSize = previous })
+	previous := m.randCupSize
+	m.randCupSize = func() float64 { return size }
+	t.Cleanup(func() { m.randCupSize = previous })
 }
 
-func resetBrewStates(t *testing.T) {
+func resetBrewStates(m *Module, t *testing.T) {
 	t.Helper()
-	brewMu.Lock()
-	brewStates = map[string]*brewState{}
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	m.brewStates = map[string]*brewState{}
+	m.brewMu.Unlock()
 	t.Cleanup(func() {
-		brewMu.Lock()
-		brewStates = map[string]*brewState{}
-		brewMu.Unlock()
+		m.brewMu.Lock()
+		m.brewStates = map[string]*brewState{}
+		m.brewMu.Unlock()
 	})
 }
 
-func setBrewReady(guildID, channelID string) {
-	brewMu.Lock()
-	defer brewMu.Unlock()
+func setBrewReady(m *Module, guildID, channelID string) {
+	m.brewMu.Lock()
+	defer m.brewMu.Unlock()
 	key := brewStateKey(guildID, channelID)
-	if st, ok := brewStates[key]; ok {
+	if st, ok := m.brewStates[key]; ok {
 		st.isReady = true
 	}
 }
 
 func TestStartBrew_NewBrew(t *testing.T) {
-	resetBrewStates(t)
-	useNow(t, time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC))
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	useNow(m, t, time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC))
 
-	alreadyBrewing, readyAt := startBrew(nil, "guild1", "channel1")
+	alreadyBrewing, readyAt := m.startBrew(nil, "guild1", "channel1")
 
 	if alreadyBrewing {
 		t.Fatal("expected new brew, got alreadyBrewing=true")
@@ -66,9 +67,9 @@ func TestStartBrew_NewBrew(t *testing.T) {
 		t.Errorf("readyAt = %v, want %v", readyAt, expected)
 	}
 
-	brewMu.Lock()
-	st := brewStates[brewStateKey("guild1", "channel1")]
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	st := m.brewStates[brewStateKey("guild1", "channel1")]
+	m.brewMu.Unlock()
 
 	if st == nil {
 		t.Fatal("expected brew state to be created")
@@ -82,11 +83,12 @@ func TestStartBrew_NewBrew(t *testing.T) {
 }
 
 func TestStartBrew_AlreadyBrewing(t *testing.T) {
-	resetBrewStates(t)
-	useNow(t, time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC))
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	useNow(m, t, time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC))
 
-	startBrew(nil, "guild1", "channel1")
-	alreadyBrewing, readyAt := startBrew(nil, "guild1", "channel1")
+	m.startBrew(nil, "guild1", "channel1")
+	alreadyBrewing, readyAt := m.startBrew(nil, "guild1", "channel1")
 
 	if !alreadyBrewing {
 		t.Fatal("expected alreadyBrewing=true for second /brew")
@@ -98,35 +100,37 @@ func TestStartBrew_AlreadyBrewing(t *testing.T) {
 }
 
 func TestStartBrew_AllowsNewBrewAfterReady(t *testing.T) {
-	resetBrewStates(t)
-	useNow(t, time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC))
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	useNow(m, t, time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC))
 
-	startBrew(nil, "guild1", "channel1")
-	setBrewReady("guild1", "channel1")
+	m.startBrew(nil, "guild1", "channel1")
+	setBrewReady(m, "guild1", "channel1")
 
-	alreadyBrewing, _ := startBrew(nil, "guild1", "channel1")
+	alreadyBrewing, _ := m.startBrew(nil, "guild1", "channel1")
 	if alreadyBrewing {
 		t.Error("expected to allow new brew after previous brew is ready")
 	}
 }
 
 func TestMarkBrewReady_SendsMessage(t *testing.T) {
-	resetBrewStates(t)
-	getReadyCalls := captureBrewReadyMessages(t)
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	getReadyCalls := captureBrewReadyMessages(m, t)
 
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		readyAt:      time.Now(),
 		isReady:      false,
 		coffeeLiters: potCapacity,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	markBrewReady(nil, "guild1", "channel1")
+	m.markBrewReady(nil, "guild1", "channel1")
 
-	brewMu.Lock()
-	st := brewStates["guild1:channel1"]
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	st := m.brewStates["guild1:channel1"]
+	m.brewMu.Unlock()
 
 	if st == nil || !st.isReady {
 		t.Error("expected brew to be marked ready")
@@ -142,10 +146,11 @@ func TestMarkBrewReady_SendsMessage(t *testing.T) {
 }
 
 func TestMarkBrewReady_NoStateDoesNothing(t *testing.T) {
-	resetBrewStates(t)
-	getReadyCalls := captureBrewReadyMessages(t)
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	getReadyCalls := captureBrewReadyMessages(m, t)
 
-	markBrewReady(nil, "guild1", "channel1")
+	m.markBrewReady(nil, "guild1", "channel1")
 
 	if len(getReadyCalls()) != 0 {
 		t.Error("expected no ready message when no brew state exists")
@@ -167,41 +172,45 @@ func TestBrewStateKey_WithoutGuild(t *testing.T) {
 }
 
 func TestHasActiveBrew_NoState(t *testing.T) {
-	resetBrewStates(t)
-	if hasActiveBrew("guild1", "channel1") {
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	if m.hasActiveBrew("guild1", "channel1") {
 		t.Error("expected false with no brew state")
 	}
 }
 
 func TestHasActiveBrew_WithState(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{coffeeLiters: potCapacity}
-	brewMu.Unlock()
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{coffeeLiters: potCapacity}
+	m.brewMu.Unlock()
 
-	if !hasActiveBrew("guild1", "channel1") {
+	if !m.hasActiveBrew("guild1", "channel1") {
 		t.Error("expected true with active brew state")
 	}
 }
 
 func TestGrabCoffee_NotReady(t *testing.T) {
-	resetBrewStates(t)
-	result := grabCoffee("guild1", "channel1", "user1")
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	result := m.grabCoffee("guild1", "channel1", "user1")
 	if !result.notReady {
 		t.Error("expected notReady=true with no brew state")
 	}
 }
 
 func TestGrabCoffee_RandomCupSize(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	result := grabCoffee("guild1", "channel1", "user1")
+	result := m.grabCoffee("guild1", "channel1", "user1")
 	if result.notReady {
 		t.Fatal("expected successful grab")
 	}
@@ -215,27 +224,28 @@ func TestGrabCoffee_RandomCupSize(t *testing.T) {
 }
 
 func TestGrabCoffee_MultipleCupsAllowed(t *testing.T) {
-	resetBrewStates(t)
-	useFixedCupSize(t, 0.25)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	useFixedCupSize(m, t, 0.25)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	r1 := grabCoffee("guild1", "channel1", "user1")
+	r1 := m.grabCoffee("guild1", "channel1", "user1")
 	if r1.notReady {
 		t.Fatal("first grab should succeed")
 	}
-	r2 := grabCoffee("guild1", "channel1", "user1")
+	r2 := m.grabCoffee("guild1", "channel1", "user1")
 	if r2.notReady {
 		t.Fatal("second grab by same user should also succeed (no alreadyTaken restriction)")
 	}
 
-	brewMu.Lock()
-	st := brewStates["guild1:channel1"]
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	st := m.brewStates["guild1:channel1"]
+	m.brewMu.Unlock()
 
 	if st == nil {
 		t.Fatal("expected brew state to still exist after two 0.25L grabs from 2L")
@@ -250,19 +260,20 @@ func TestGrabCoffee_MultipleCupsAllowed(t *testing.T) {
 }
 
 func TestGrabCoffee_AlwaysPlain(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	grabCoffee("guild1", "channel1", "user1")
+	m.grabCoffee("guild1", "channel1", "user1")
 
-	brewMu.Lock()
-	st := brewStates["guild1:channel1"]
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	st := m.brewStates["guild1:channel1"]
+	m.brewMu.Unlock()
 
 	if st.grabs[0].cup.milk || st.grabs[0].cup.sugar {
 		t.Error("grabCoffee should always produce a plain cup; milk/sugar are added separately")
@@ -270,16 +281,17 @@ func TestGrabCoffee_AlwaysPlain(t *testing.T) {
 }
 
 func TestGrabCoffee_PotEmpties(t *testing.T) {
-	resetBrewStates(t)
-	useFixedCupSize(t, 0.25)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	useFixedCupSize(m, t, 0.25)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: 0.25,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	result := grabCoffee("guild1", "channel1", "user1")
+	result := m.grabCoffee("guild1", "channel1", "user1")
 	if result.notReady {
 		t.Fatal("expected successful grab")
 	}
@@ -287,25 +299,26 @@ func TestGrabCoffee_PotEmpties(t *testing.T) {
 		t.Error("expected isEmpty=true after draining the pot")
 	}
 
-	brewMu.Lock()
-	_, exists := brewStates["guild1:channel1"]
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	_, exists := m.brewStates["guild1:channel1"]
+	m.brewMu.Unlock()
 	if exists {
 		t.Error("expected brew state deleted after pot is empty")
 	}
 }
 
 func TestGrabCoffee_CupsCappedToRemainingLiters(t *testing.T) {
-	resetBrewStates(t)
-	useFixedCupSize(t, 0.30) // cup wants 300ml but only 50ml left
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	useFixedCupSize(m, t, 0.30)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: 0.05,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	result := grabCoffee("guild1", "channel1", "user1")
+	result := m.grabCoffee("guild1", "channel1", "user1")
 	if result.notReady {
 		t.Fatal("expected successful grab")
 	}
@@ -316,55 +329,58 @@ func TestGrabCoffee_CupsCappedToRemainingLiters(t *testing.T) {
 		t.Error("expected isEmpty=true after draining last drop")
 	}
 
-	brewMu.Lock()
-	_, exists := brewStates["guild1:channel1"]
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	_, exists := m.brewStates["guild1:channel1"]
+	m.brewMu.Unlock()
 	if exists {
 		t.Error("expected brew state deleted after pot is empty")
 	}
 }
 
 func TestAddToLastCup_NoBrew(t *testing.T) {
-	resetBrewStates(t)
-	result := addToLastCup("guild1", "channel1", "user1", true, false)
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	result := m.addToLastCup("guild1", "channel1", "user1", true, false)
 	if !result.notReady {
 		t.Error("expected notReady=true with no brew state")
 	}
 }
 
 func TestAddToLastCup_NoCup(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	result := addToLastCup("guild1", "channel1", "user1", true, false)
+	result := m.addToLastCup("guild1", "channel1", "user1", true, false)
 	if !result.noCup {
 		t.Error("expected noCup=true when user has not grabbed a cup")
 	}
 }
 
 func TestAddToLastCup_AddsMilk(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	result := addToLastCup("guild1", "channel1", "user1", true, false)
+	result := m.addToLastCup("guild1", "channel1", "user1", true, false)
 	if result.noCup || result.notReady {
 		t.Fatal("expected successful modification")
 	}
 
-	brewMu.Lock()
-	cup := brewStates["guild1:channel1"].grabs[0].cup
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	cup := m.brewStates["guild1:channel1"].grabs[0].cup
+	m.brewMu.Unlock()
 
 	if !cup.milk {
 		t.Error("expected milk=true after addToLastCup with milk")
@@ -375,20 +391,21 @@ func TestAddToLastCup_AddsMilk(t *testing.T) {
 }
 
 func TestAddToLastCup_AddsSugar(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	addToLastCup("guild1", "channel1", "user1", false, true)
+	m.addToLastCup("guild1", "channel1", "user1", false, true)
 
-	brewMu.Lock()
-	cup := brewStates["guild1:channel1"].grabs[0].cup
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	cup := m.brewStates["guild1:channel1"].grabs[0].cup
+	m.brewMu.Unlock()
 
 	if !cup.sugar {
 		t.Error("expected sugar=true after addToLastCup with sugar")
@@ -396,21 +413,22 @@ func TestAddToLastCup_AddsSugar(t *testing.T) {
 }
 
 func TestAddToLastCup_CombinesMilkAndSugar(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	addToLastCup("guild1", "channel1", "user1", true, false)
-	addToLastCup("guild1", "channel1", "user1", false, true)
+	m.addToLastCup("guild1", "channel1", "user1", true, false)
+	m.addToLastCup("guild1", "channel1", "user1", false, true)
 
-	brewMu.Lock()
-	cup := brewStates["guild1:channel1"].grabs[0].cup
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	cup := m.brewStates["guild1:channel1"].grabs[0].cup
+	m.brewMu.Unlock()
 
 	if !cup.milk || !cup.sugar {
 		t.Errorf("expected milk=true sugar=true after both modifications, got milk=%v sugar=%v", cup.milk, cup.sugar)
@@ -418,9 +436,10 @@ func TestAddToLastCup_CombinesMilkAndSugar(t *testing.T) {
 }
 
 func TestAddToLastCup_ModifiesLastCupOnly(t *testing.T) {
-	resetBrewStates(t)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 		grabs: []grabRecord{
@@ -428,13 +447,13 @@ func TestAddToLastCup_ModifiesLastCupOnly(t *testing.T) {
 			{userID: "user1", cup: CupTaken{liters: 0.20}},
 		},
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	addToLastCup("guild1", "channel1", "user1", true, false)
+	m.addToLastCup("guild1", "channel1", "user1", true, false)
 
-	brewMu.Lock()
-	grabs := brewStates["guild1:channel1"].grabs
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	grabs := m.brewStates["guild1:channel1"].grabs
+	m.brewMu.Unlock()
 
 	if grabs[0].cup.milk {
 		t.Error("first cup should not be modified")
@@ -445,21 +464,22 @@ func TestAddToLastCup_ModifiesLastCupOnly(t *testing.T) {
 }
 
 func TestAddToLastCup_DoesNotAffectPotLevel(t *testing.T) {
-	resetBrewStates(t)
-	useFixedCupSize(t, 0.25)
-	brewMu.Lock()
-	brewStates["guild1:channel1"] = &brewState{
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	useFixedCupSize(m, t, 0.25)
+	m.brewMu.Lock()
+	m.brewStates["guild1:channel1"] = &brewState{
 		isReady:      true,
 		coffeeLiters: potCapacity,
 		grabs:        []grabRecord{{userID: "user1", cup: CupTaken{liters: 0.25}}},
 	}
-	brewMu.Unlock()
+	m.brewMu.Unlock()
 
-	addToLastCup("guild1", "channel1", "user1", true, false)
+	m.addToLastCup("guild1", "channel1", "user1", true, false)
 
-	brewMu.Lock()
-	liters := brewStates["guild1:channel1"].coffeeLiters
-	brewMu.Unlock()
+	m.brewMu.Lock()
+	liters := m.brewStates["guild1:channel1"].coffeeLiters
+	m.brewMu.Unlock()
 
 	if liters != potCapacity {
 		t.Errorf("addToLastCup should not change pot level, got %.2fL", liters)

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -5,62 +5,17 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/toksikk/gidbig/internal/bot"
 	"github.com/toksikk/gidbig/internal/llm"
 	"github.com/toksikk/gidbig/internal/util"
+	"gorm.io/gorm"
 )
 
 const fallbackBeverage = "☕"
-
-var (
-	isSpecialDay         = util.IsSpecial
-	reactOnMessage       = util.ReactOnMessage
-	sendIntroDM          = sendIntroDMFunc
-	detectLanguage       = llm.DetectChannelLanguage
-	generateLLMMessage   = llm.GenerateMessage
-	deferInteraction     = deferInteractionImpl
-	editDeferredResponse = editDeferredResponseImpl
-)
-
-func deferInteractionImpl(s *discordgo.Session, i *discordgo.InteractionCreate, ephemeral bool) error {
-	var flags discordgo.MessageFlags
-	if ephemeral {
-		flags = discordgo.MessageFlagsEphemeral
-	}
-	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{Flags: flags},
-	})
-}
-
-func editDeferredResponseImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
-	if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content}); err != nil {
-		slog.Error("coffee: failed to edit deferred response", "error", err)
-	}
-}
-
-// generateInteractionMessage detects the channel language and uses the LLM to generate
-// a response for the given scenario. Returns fallback on any error.
-func generateInteractionMessage(s *discordgo.Session, channelID, scenario, fallback string) string {
-	lang, _ := detectLanguage(s, channelID)
-	if lang == "" {
-		lang = "English"
-	}
-	systemPrompt := "You are a Discord bot managing a coffee station in a community chat. " + llm.Personality + " Respond in " + lang + "."
-	msg, err := generateLLMMessage(context.Background(), systemPrompt, scenario)
-	if err != nil || strings.TrimSpace(msg) == "" {
-		return fallback
-	}
-	return strings.TrimSpace(msg)
-}
-
-func beverageEmojiFor(userID string) string {
-	if emoji, ok := getBeverageEmoji(userID); ok {
-		return emoji
-	}
-	return fallbackBeverage
-}
 
 var messages = []string{
 	"moin",
@@ -83,8 +38,70 @@ var messages = []string{
 	"christkindl",
 }
 
+// Module implements bot.Module and bot.AdminProvider for the coffee plugin.
+type Module struct {
+	session *discordgo.Session
+
+	// DB state
+	dbMu sync.RWMutex
+	db   *gorm.DB
+
+	// Brew state
+	brewMu     sync.RWMutex
+	brewStates map[string]*brewState
+
+	// Test hooks
+	nowFunc              func() time.Time
+	isSpecialDay         func() bool
+	reactOnMessage       func(*discordgo.Session, string, string, string, string)
+	sendIntroDM          func(*discordgo.Session, string, string)
+	detectLanguage       func(*discordgo.Session, string) (string, error)
+	generateLLMMessage   func(context.Context, string, string) (string, error)
+	deferInteraction     func(*discordgo.Session, *discordgo.InteractionCreate, bool) error
+	editDeferredResponse func(*discordgo.Session, *discordgo.InteractionCreate, string)
+
+	sendBrewReadyMessage     func(*discordgo.Session, string, string)
+	randCupSize              func() float64
+	generateBrewButtonLabels func(*discordgo.Session, string) [3]string
+}
+
+// New returns a Module with production-default hook implementations.
+func New() *Module {
+	m := &Module{
+		brewStates: make(map[string]*brewState),
+		nowFunc:    time.Now,
+	}
+	m.isSpecialDay = util.IsSpecial
+	m.reactOnMessage = util.ReactOnMessage
+	m.sendIntroDM = m.sendIntroDMImpl
+	m.detectLanguage = llm.DetectChannelLanguage
+	m.generateLLMMessage = llm.GenerateMessage
+	m.deferInteraction = m.deferInteractionImpl
+	m.editDeferredResponse = m.editDeferredResponseImpl
+	m.sendBrewReadyMessage = m.defaultSendBrewReadyMessage
+	m.randCupSize = defaultRandCupSize
+	m.generateBrewButtonLabels = m.buildBrewButtonLabels
+	return m
+}
+
+func (m *Module) Name() string { return "coffee" }
+
+// Init opens the beverage-preference store using the DB path from Deps.Config.
+func (m *Module) Init(d bot.Deps) error {
+	m.session = d.Session
+	dbPath := "gidbig.db"
+	if d.Config != nil && d.Config.Database.Path != "" {
+		dbPath = d.Config.Database.Path
+	}
+	if err := m.openStore(dbPath); err != nil {
+		return fmt.Errorf("coffee: open store: %w", err)
+	}
+	slog.Info("coffee: initialized")
+	return nil
+}
+
 // Commands returns the slash command definitions for this plugin.
-func Commands() []*discordgo.ApplicationCommand {
+func (m *Module) Commands() []*discordgo.ApplicationCommand {
 	return []*discordgo.ApplicationCommand{
 		{
 			Name:        "setbeverage",
@@ -105,74 +122,107 @@ func Commands() []*discordgo.ApplicationCommand {
 	}
 }
 
-// Start the plugin
-func Start(discord *discordgo.Session) {
-	generateBrewButtonLabels = buildBrewButtonLabels
-	discord.AddHandler(onMessageCreate)
-	discord.AddHandler(onInteractionCreate)
-	if err := openStore("coffee.db"); err != nil {
-		slog.Error("coffee: failed to open store", "error", err)
+// Listeners returns the Discord event listeners for this module.
+func (m *Module) Listeners() []bot.EventListener {
+	return []bot.EventListener{m.onMessageCreate, m.onInteractionCreate}
+}
+
+// Components returns the message-component handlers for this module.
+func (m *Module) Components() []bot.ComponentHandler {
+	return []bot.ComponentHandler{
+		{Prefix: "coffee:", Handler: m.handleComponent},
 	}
-	slog.Info("coffee function registered")
 }
 
-// Shutdown closes the beverage preference store.
-func Shutdown() {
-	closeStore()
+// Background returns no background tasks.
+func (m *Module) Background() []bot.BackgroundTask { return nil }
+
+// Shutdown closes the beverage-preference store.
+func (m *Module) Shutdown() error {
+	return m.closeStore()
 }
 
-func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
-	if m.Author == nil || m.Author.Bot {
+func (m *Module) deferInteractionImpl(s *discordgo.Session, i *discordgo.InteractionCreate, ephemeral bool) error {
+	var flags discordgo.MessageFlags
+	if ephemeral {
+		flags = discordgo.MessageFlagsEphemeral
+	}
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{Flags: flags},
+	})
+}
+
+func (m *Module) editDeferredResponseImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content}); err != nil {
+		slog.Error("coffee: failed to edit deferred response", "error", err)
+	}
+}
+
+func (m *Module) generateInteractionMessage(s *discordgo.Session, channelID, scenario, fallback string) string {
+	lang, _ := m.detectLanguage(s, channelID)
+	if lang == "" {
+		lang = "English"
+	}
+	systemPrompt := "You are a Discord bot managing a coffee station in a community chat. " + llm.Personality + " Respond in " + lang + "."
+	msg, err := m.generateLLMMessage(context.Background(), systemPrompt, scenario)
+	if err != nil || strings.TrimSpace(msg) == "" {
+		return fallback
+	}
+	return strings.TrimSpace(msg)
+}
+
+func (m *Module) beverageEmojiFor(userID string) string {
+	if emoji, ok := m.getBeverageEmoji(userID); ok {
+		return emoji
+	}
+	return fallbackBeverage
+}
+
+func (m *Module) onMessageCreate(s *discordgo.Session, mc *discordgo.MessageCreate) {
+	if mc.Author == nil || mc.Author.Bot {
 		return
 	}
 
 	for _, v := range messages {
-		if v == strings.ToLower(m.Content) {
-			if hasGreetedToday(m.Author.ID) {
+		if v == strings.ToLower(mc.Content) {
+			if m.hasGreetedToday(mc.Author.ID) {
 				return
 			}
 
-			emoji := beverageEmojiFor(m.Author.ID)
-			if isSpecialDay() {
-				reactOnMessage(s, m.ChannelID, m.ID, string(util.Ae[util.RandomRange(0, len(util.Ae))]), "add")
-				reactOnMessage(s, m.ChannelID, m.ID, string(util.Cl), "add")
+			emoji := m.beverageEmojiFor(mc.Author.ID)
+			if m.isSpecialDay() {
+				m.reactOnMessage(s, mc.ChannelID, mc.ID, string(util.Ae[util.RandomRange(0, len(util.Ae))]), "add")
+				m.reactOnMessage(s, mc.ChannelID, mc.ID, string(util.Cl), "add")
 			} else {
-				reactOnMessage(s, m.ChannelID, m.ID, emoji, "add")
-				// faces
-				if m.Author.ID == "269898849714307073" {
-					reactOnMessage(s, m.ChannelID, m.ID, ":sidus:576309032789475328", "add")
+				m.reactOnMessage(s, mc.ChannelID, mc.ID, emoji, "add")
+				if mc.Author.ID == "269898849714307073" {
+					m.reactOnMessage(s, mc.ChannelID, mc.ID, ":sidus:576309032789475328", "add")
 				}
-				if m.Author.ID == "125230846629249024" {
-					reactOnMessage(s, m.ChannelID, m.ID, ":sikk:355329009824825355", "add")
-				}
-			}
-
-			if !isUserIntroduced(m.Author.ID) {
-				sendIntroDM(s, m.Author.ID, emoji)
-				if err := markUserIntroduced(m.Author.ID); err != nil {
-					slog.Error("coffee: failed to mark user as introduced", "error", err, "userID", m.Author.ID)
+				if mc.Author.ID == "125230846629249024" {
+					m.reactOnMessage(s, mc.ChannelID, mc.ID, ":sikk:355329009824825355", "add")
 				}
 			}
 
-			if err := recordGreeting(m.Author.ID); err != nil {
-				slog.Error("coffee: failed to record daily greeting", "error", err, "userID", m.Author.ID)
+			if !m.isUserIntroduced(mc.Author.ID) {
+				m.sendIntroDM(s, mc.Author.ID, emoji)
+				if err := m.markUserIntroduced(mc.Author.ID); err != nil {
+					slog.Error("coffee: failed to mark user as introduced", "error", err, "userID", mc.Author.ID)
+				}
+			}
+
+			if err := m.recordGreeting(mc.Author.ID); err != nil {
+				slog.Error("coffee: failed to record daily greeting", "error", err, "userID", mc.Author.ID)
 			}
 			return
 		}
 	}
 }
 
-func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	switch i.Type {
 	case discordgo.InteractionMessageComponent:
-		switch i.MessageComponentData().CustomID {
-		case "grab_coffee":
-			handleGrabCoffeeButton(s, i)
-		case "grab_milk":
-			handleModifyLastCupButton(s, i, true, false)
-		case "grab_sugar":
-			handleModifyLastCupButton(s, i, false, true)
-		}
+		m.handleComponent(s, i)
 		return
 	case discordgo.InteractionApplicationCommand:
 	default:
@@ -182,7 +232,7 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	data := i.ApplicationCommandData()
 	switch data.Name {
 	case "brew":
-		handleBrewInteraction(s, i)
+		m.handleBrewInteraction(s, i)
 		return
 	case "setbeverage":
 	default:
@@ -209,9 +259,9 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		userID = i.User.ID
 	}
 
-	introducedBefore := isUserIntroduced(userID)
+	introducedBefore := m.isUserIntroduced(userID)
 
-	if err := setBeverageEmoji(userID, emoji); err != nil {
+	if err := m.setBeverageEmoji(userID, emoji); err != nil {
 		slog.Error("coffee: failed to set beverage emoji", "error", err, "userID", userID)
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -223,45 +273,57 @@ func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	if err := deferInteraction(s, i, true); err != nil {
+	if err := m.deferInteraction(s, i, true); err != nil {
 		slog.Error("coffee: failed to defer interaction", "error", err)
 		return
 	}
-	confirmMsg := generateInteractionMessage(s, i.ChannelID,
+	confirmMsg := m.generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("Confirm to the user that their morning beverage is now set to %s.", emoji),
 		fmt.Sprintf("Your morning beverage is now %s ☑️", emoji))
-	editDeferredResponse(s, i, confirmMsg)
+	m.editDeferredResponse(s, i, confirmMsg)
 
 	if !introducedBefore {
-		sendIntroDM(s, userID, emoji)
+		m.sendIntroDM(s, userID, emoji)
 	}
 }
 
-func handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	alreadyBrewing, readyAt := startBrew(s, i.GuildID, i.ChannelID)
+// handleComponent dispatches coffee:* message component interactions.
+func (m *Module) handleComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	switch i.MessageComponentData().CustomID {
+	case "coffee:grab_coffee":
+		m.handleGrabCoffeeButton(s, i)
+	case "coffee:grab_milk":
+		m.handleModifyLastCupButton(s, i, true, false)
+	case "coffee:grab_sugar":
+		m.handleModifyLastCupButton(s, i, false, true)
+	}
+}
+
+func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	alreadyBrewing, readyAt := m.startBrew(s, i.GuildID, i.ChannelID)
 	ts := fmt.Sprintf("<t:%d:R>", readyAt.Unix())
 	if alreadyBrewing {
-		if err := deferInteraction(s, i, true); err != nil {
+		if err := m.deferInteraction(s, i, true); err != nil {
 			slog.Error("coffee: failed to defer interaction", "error", err)
 			return
 		}
-		msg := generateInteractionMessage(s, i.ChannelID,
+		msg := m.generateInteractionMessage(s, i.ChannelID,
 			"Coffee is already brewing. Tell the user in one short sentence.",
 			"☕ Coffee is already brewing!") + " " + ts
-		editDeferredResponse(s, i, msg)
+		m.editDeferredResponse(s, i, msg)
 		return
 	}
-	if err := deferInteraction(s, i, false); err != nil {
+	if err := m.deferInteraction(s, i, false); err != nil {
 		slog.Error("coffee: failed to defer interaction", "error", err)
 		return
 	}
-	msg := generateInteractionMessage(s, i.ChannelID,
+	msg := m.generateInteractionMessage(s, i.ChannelID,
 		"A user just started brewing coffee. It will be ready in about 3 minutes. Announce this in one short sentence.",
 		"☕ Brewing coffee... Ready") + " " + ts
-	editDeferredResponse(s, i, msg)
+	m.editDeferredResponse(s, i, msg)
 }
 
-func handleGrabCoffeeButton(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (m *Module) handleGrabCoffeeButton(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	var userID string
 	if i.Member != nil {
 		userID = i.Member.User.ID
@@ -269,17 +331,17 @@ func handleGrabCoffeeButton(s *discordgo.Session, i *discordgo.InteractionCreate
 		userID = i.User.ID
 	}
 
-	result := grabCoffee(i.GuildID, i.ChannelID, userID)
+	result := m.grabCoffee(i.GuildID, i.ChannelID, userID)
 
 	if result.notReady {
-		if err := deferInteraction(s, i, true); err != nil {
+		if err := m.deferInteraction(s, i, true); err != nil {
 			slog.Error("coffee: failed to defer interaction", "error", err)
 			return
 		}
-		msg := generateInteractionMessage(s, i.ChannelID,
+		msg := m.generateInteractionMessage(s, i.ChannelID,
 			"A user tried to grab coffee but the pot is empty or not ready. Tell them in one short sentence.",
 			"Too late — the coffee pot is empty! ☕")
-		editDeferredResponse(s, i, msg)
+		m.editDeferredResponse(s, i, msg)
 		return
 	}
 
@@ -287,14 +349,12 @@ func handleGrabCoffeeButton(s *discordgo.Session, i *discordgo.InteractionCreate
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
 			Content:    result.updatedMsg,
-			Components: brewComponents(result.buttonLabels, result.isEmpty),
+			Components: m.brewComponents(result.buttonLabels, result.isEmpty),
 		},
 	})
 }
 
-// handleModifyLastCupButton adds milk or sugar to the user's most recent cup without
-// pouring a new one. Shows an ephemeral error if the user has no cup in this brew.
-func handleModifyLastCupButton(s *discordgo.Session, i *discordgo.InteractionCreate, milk, sugar bool) {
+func (m *Module) handleModifyLastCupButton(s *discordgo.Session, i *discordgo.InteractionCreate, milk, sugar bool) {
 	var userID string
 	if i.Member != nil {
 		userID = i.Member.User.ID
@@ -302,28 +362,28 @@ func handleModifyLastCupButton(s *discordgo.Session, i *discordgo.InteractionCre
 		userID = i.User.ID
 	}
 
-	result := addToLastCup(i.GuildID, i.ChannelID, userID, milk, sugar)
+	result := m.addToLastCup(i.GuildID, i.ChannelID, userID, milk, sugar)
 
 	if result.notReady {
-		if err := deferInteraction(s, i, true); err != nil {
+		if err := m.deferInteraction(s, i, true); err != nil {
 			slog.Error("coffee: failed to defer interaction", "error", err)
 			return
 		}
-		msg := generateInteractionMessage(s, i.ChannelID,
+		msg := m.generateInteractionMessage(s, i.ChannelID,
 			"A user tried to add milk or sugar but the coffee pot is no longer available. Tell them in one short sentence.",
 			"No coffee available! ☕")
-		editDeferredResponse(s, i, msg)
+		m.editDeferredResponse(s, i, msg)
 		return
 	}
 	if result.noCup {
-		if err := deferInteraction(s, i, true); err != nil {
+		if err := m.deferInteraction(s, i, true); err != nil {
 			slog.Error("coffee: failed to defer interaction", "error", err)
 			return
 		}
-		msg := generateInteractionMessage(s, i.ChannelID,
+		msg := m.generateInteractionMessage(s, i.ChannelID,
 			"A user tried to add milk or sugar but hasn't grabbed a cup yet. Tell them to grab a cup first, in one short sentence.",
 			"Grab a cup first! ☕")
-		editDeferredResponse(s, i, msg)
+		m.editDeferredResponse(s, i, msg)
 		return
 	}
 
@@ -331,12 +391,12 @@ func handleModifyLastCupButton(s *discordgo.Session, i *discordgo.InteractionCre
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
 			Content:    result.updatedMsg,
-			Components: brewComponents(result.buttonLabels, false),
+			Components: m.brewComponents(result.buttonLabels, false),
 		},
 	})
 }
 
-func brewComponents(labels [3]string, empty bool) []discordgo.MessageComponent {
+func (m *Module) brewComponents(labels [3]string, empty bool) []discordgo.MessageComponent {
 	if empty {
 		return nil
 	}
@@ -346,32 +406,32 @@ func brewComponents(labels [3]string, empty bool) []discordgo.MessageComponent {
 				discordgo.Button{
 					Label:    labels[0],
 					Style:    discordgo.PrimaryButton,
-					CustomID: "grab_coffee",
+					CustomID: "coffee:grab_coffee",
 				},
 				discordgo.Button{
 					Label:    labels[1],
 					Style:    discordgo.SecondaryButton,
-					CustomID: "grab_milk",
+					CustomID: "coffee:grab_milk",
 				},
 				discordgo.Button{
 					Label:    labels[2],
 					Style:    discordgo.SecondaryButton,
-					CustomID: "grab_sugar",
+					CustomID: "coffee:grab_sugar",
 				},
 			},
 		},
 	}
 }
 
-func buildBrewButtonLabels(s *discordgo.Session, channelID string) [3]string {
+func (m *Module) buildBrewButtonLabels(s *discordgo.Session, channelID string) [3]string {
 	fallback := [3]string{"☕ Grab a cup", "🥛 With milk", "🍬 With sugar"}
-	lang, _ := detectLanguage(s, channelID)
+	lang, _ := m.detectLanguage(s, channelID)
 	if lang == "" {
 		lang = "English"
 	}
 	systemPrompt := "You translate button labels for a coffee bot. " + llm.Personality +
 		" Respond in " + lang + ". Format: exactly 3 labels separated by | with no other text. Each label must be 2-4 words."
-	msg, err := generateLLMMessage(context.Background(), systemPrompt, "Grab a cup|With milk|With sugar")
+	msg, err := m.generateLLMMessage(context.Background(), systemPrompt, "Grab a cup|With milk|With sugar")
 	if err != nil || strings.TrimSpace(msg) == "" {
 		return fallback
 	}
@@ -386,7 +446,7 @@ func buildBrewButtonLabels(s *discordgo.Session, channelID string) [3]string {
 	}
 }
 
-func sendIntroDMFunc(s *discordgo.Session, userID string, emoji string) {
+func (m *Module) sendIntroDMImpl(s *discordgo.Session, userID string, emoji string) {
 	channel, err := s.UserChannelCreate(userID)
 	if err != nil {
 		slog.Error("coffee: failed to create DM channel", "error", err, "userID", userID)

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -40,8 +40,6 @@ var messages = []string{
 
 // Module implements bot.Module and bot.AdminProvider for the coffee plugin.
 type Module struct {
-	session *discordgo.Session
-
 	// DB state
 	dbMu sync.RWMutex
 	db   *gorm.DB
@@ -88,7 +86,6 @@ func (m *Module) Name() string { return "coffee" }
 
 // Init opens the beverage-preference store using the DB path from Deps.Config.
 func (m *Module) Init(d bot.Deps) error {
-	m.session = d.Session
 	dbPath := "gidbig.db"
 	if d.Config != nil && d.Config.Database.Path != "" {
 		dbPath = d.Config.Database.Path

--- a/internal/coffee/coffee_test.go
+++ b/internal/coffee/coffee_test.go
@@ -17,11 +17,11 @@ type capturedReaction struct {
 	reactionType string
 }
 
-func captureReactions(t *testing.T) func() []capturedReaction {
+func captureReactions(m *Module, t *testing.T) func() []capturedReaction {
 	t.Helper()
-	previous := reactOnMessage
+	previous := m.reactOnMessage
 	reactions := []capturedReaction{}
-	reactOnMessage = func(_ *discordgo.Session, channelID, messageID, emoji, reactionType string) {
+	m.reactOnMessage = func(_ *discordgo.Session, channelID, messageID, emoji, reactionType string) {
 		reactions = append(reactions, capturedReaction{
 			channelID:    channelID,
 			messageID:    messageID,
@@ -30,21 +30,21 @@ func captureReactions(t *testing.T) func() []capturedReaction {
 		})
 	}
 	t.Cleanup(func() {
-		reactOnMessage = previous
+		m.reactOnMessage = previous
 	})
 	return func() []capturedReaction {
 		return reactions
 	}
 }
 
-func useSpecialDay(t *testing.T, special bool) {
+func useSpecialDay(m *Module, t *testing.T, special bool) {
 	t.Helper()
-	previous := isSpecialDay
-	isSpecialDay = func() bool {
+	previous := m.isSpecialDay
+	m.isSpecialDay = func() bool {
 		return special
 	}
 	t.Cleanup(func() {
-		isSpecialDay = previous
+		m.isSpecialDay = previous
 	})
 }
 
@@ -61,9 +61,9 @@ func greetingMessage(userID, content string) *discordgo.MessageCreate {
 	}
 }
 
-func countGreetings(t *testing.T, userID string) int64 {
+func countGreetings(m *Module, t *testing.T, userID string) int64 {
 	t.Helper()
-	d := getDB()
+	d := m.getDB()
 	var count int64
 	if err := d.Model(&UserGreeting{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
 		t.Fatalf("failed to count greetings: %v", err)
@@ -76,18 +76,18 @@ type capturedDM struct {
 	emoji  string
 }
 
-func captureIntroDMs(t *testing.T) func() []capturedDM {
+func captureIntroDMs(m *Module, t *testing.T) func() []capturedDM {
 	t.Helper()
-	previous := sendIntroDM
+	previous := m.sendIntroDM
 	dms := []capturedDM{}
-	sendIntroDM = func(_ *discordgo.Session, userID string, emoji string) {
+	m.sendIntroDM = func(_ *discordgo.Session, userID string, emoji string) {
 		dms = append(dms, capturedDM{
 			userID: userID,
 			emoji:  emoji,
 		})
 	}
 	t.Cleanup(func() {
-		sendIntroDM = previous
+		m.sendIntroDM = previous
 	})
 	return func() []capturedDM {
 		return dms
@@ -95,13 +95,13 @@ func captureIntroDMs(t *testing.T) func() []capturedDM {
 }
 
 func TestOnMessageCreate_TriggersIntroDMOnFirstGreeting(t *testing.T) {
-	openInMemoryStore(t)
-	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
-	useSpecialDay(t, false)
-	_ = captureReactions(t)
-	getDMs := captureIntroDMs(t)
+	m := newTestModule(t)
+	useNow(m, t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(m, t, false)
+	_ = captureReactions(m, t)
+	getDMs := captureIntroDMs(m, t)
 
-	onMessageCreate(nil, greetingMessage("user_new", "moin"))
+	m.onMessageCreate(nil, greetingMessage("user_new", "moin"))
 
 	dms := getDMs()
 	if len(dms) != 1 {
@@ -114,21 +114,21 @@ func TestOnMessageCreate_TriggersIntroDMOnFirstGreeting(t *testing.T) {
 		t.Errorf("DM emoji = %q, want %q", dms[0].emoji, fallbackBeverage)
 	}
 
-	if !isUserIntroduced("user_new") {
+	if !m.isUserIntroduced("user_new") {
 		t.Error("expected user_new to be marked as introduced")
 	}
 }
 
 func TestOnMessageCreate_DoesNotTriggerIntroDMIfAlreadyIntroduced(t *testing.T) {
-	openInMemoryStore(t)
-	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
-	useSpecialDay(t, false)
-	_ = captureReactions(t)
-	getDMs := captureIntroDMs(t)
+	m := newTestModule(t)
+	useNow(m, t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(m, t, false)
+	_ = captureReactions(m, t)
+	getDMs := captureIntroDMs(m, t)
 
-	_ = setBeverageEmoji("user_old", "🧃") // sets introduced=true
+	_ = m.setBeverageEmoji("user_old", "🧃")
 
-	onMessageCreate(nil, greetingMessage("user_old", "moin"))
+	m.onMessageCreate(nil, greetingMessage("user_old", "moin"))
 
 	dms := getDMs()
 	if len(dms) != 0 {
@@ -150,22 +150,16 @@ func TestIsValidBeverageEmoji(t *testing.T) {
 		input string
 		valid bool
 	}{
-		// valid Unicode emoji
 		{"🫖", true},
 		{"☕", true},
 		{"🍺", true},
 		{"🧃", true},
-		// valid Discord custom emoji
 		{"<:customemoji:123456789>", true},
 		{"<a:animatedemoji:987654321>", true},
-		// invalid: plain text
 		{"hello", false},
 		{"hello world", false},
-		// invalid: empty
 		{"", false},
-		// invalid: number
 		{"42", false},
-		// invalid: mixed text
 		{"coffee", false},
 	}
 	for _, tt := range tests {
@@ -177,6 +171,7 @@ func TestIsValidBeverageEmoji(t *testing.T) {
 }
 
 func TestBeverageEmojiFor(t *testing.T) {
+	m := newTestModule(t)
 	tests := []struct {
 		userID   string
 		expected string
@@ -187,7 +182,7 @@ func TestBeverageEmojiFor(t *testing.T) {
 		{"", "☕"},
 	}
 	for _, tt := range tests {
-		got := beverageEmojiFor(tt.userID)
+		got := m.beverageEmojiFor(tt.userID)
 		if got != tt.expected {
 			t.Errorf("beverageEmojiFor(%q) = %q; want %q", tt.userID, got, tt.expected)
 		}
@@ -195,13 +190,13 @@ func TestBeverageEmojiFor(t *testing.T) {
 }
 
 func TestOnMessageCreate_FirstGreetingReactsAndRecordsGreeting(t *testing.T) {
-	openInMemoryStore(t)
-	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
-	useSpecialDay(t, false)
-	getReactions := captureReactions(t)
-	_ = captureIntroDMs(t)
+	m := newTestModule(t)
+	useNow(m, t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(m, t, false)
+	getReactions := captureReactions(m, t)
+	_ = captureIntroDMs(m, t)
 
-	onMessageCreate(nil, greetingMessage("user1", "moin"))
+	m.onMessageCreate(nil, greetingMessage("user1", "moin"))
 
 	reactions := getReactions()
 	if len(reactions) != 1 {
@@ -213,38 +208,38 @@ func TestOnMessageCreate_FirstGreetingReactsAndRecordsGreeting(t *testing.T) {
 	if reactions[0].reactionType != "add" {
 		t.Errorf("reaction type = %q, want add", reactions[0].reactionType)
 	}
-	if count := countGreetings(t, "user1"); count != 1 {
+	if count := countGreetings(m, t, "user1"); count != 1 {
 		t.Errorf("expected 1 greeting row, got %d", count)
 	}
 }
 
 func TestOnMessageCreate_DuplicateSameDayGreetingIsSuppressed(t *testing.T) {
-	openInMemoryStore(t)
-	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
-	useSpecialDay(t, false)
-	getReactions := captureReactions(t)
-	_ = captureIntroDMs(t)
+	m := newTestModule(t)
+	useNow(m, t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(m, t, false)
+	getReactions := captureReactions(m, t)
+	_ = captureIntroDMs(m, t)
 
-	onMessageCreate(nil, greetingMessage("user1", "moin"))
-	onMessageCreate(nil, greetingMessage("user1", "hi"))
+	m.onMessageCreate(nil, greetingMessage("user1", "moin"))
+	m.onMessageCreate(nil, greetingMessage("user1", "hi"))
 
 	reactions := getReactions()
 	if len(reactions) != 1 {
 		t.Fatalf("expected only the first greeting to react, got %d reactions", len(reactions))
 	}
-	if count := countGreetings(t, "user1"); count != 1 {
+	if count := countGreetings(m, t, "user1"); count != 1 {
 		t.Errorf("expected duplicate greeting to keep 1 row, got %d", count)
 	}
 }
 
 func TestOnMessageCreate_PriorDayGreetingAllowsNextDayReaction(t *testing.T) {
-	openInMemoryStore(t)
-	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
-	useSpecialDay(t, false)
-	getReactions := captureReactions(t)
-	_ = captureIntroDMs(t)
+	m := newTestModule(t)
+	useNow(m, t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(m, t, false)
+	getReactions := captureReactions(m, t)
+	_ = captureIntroDMs(m, t)
 
-	d := getDB()
+	d := m.getDB()
 	if err := d.Create(&UserGreeting{
 		UserID:    "user1",
 		GreetedAt: time.Date(2026, 5, 2, 23, 0, 0, 0, time.Local),
@@ -252,25 +247,25 @@ func TestOnMessageCreate_PriorDayGreetingAllowsNextDayReaction(t *testing.T) {
 		t.Fatalf("failed to create prior greeting: %v", err)
 	}
 
-	onMessageCreate(nil, greetingMessage("user1", "moin"))
+	m.onMessageCreate(nil, greetingMessage("user1", "moin"))
 
 	reactions := getReactions()
 	if len(reactions) != 1 {
 		t.Fatalf("expected next-day greeting to react once, got %d reactions", len(reactions))
 	}
-	if count := countGreetings(t, "user1"); count != 2 {
+	if count := countGreetings(m, t, "user1"); count != 2 {
 		t.Errorf("expected prior and new greeting rows, got %d", count)
 	}
 }
 
 func TestOnMessageCreate_SpecialDayFirstGreetingReactsAndRecordsGreeting(t *testing.T) {
-	openInMemoryStore(t)
-	useNow(t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
-	useSpecialDay(t, true)
-	getReactions := captureReactions(t)
-	_ = captureIntroDMs(t)
+	m := newTestModule(t)
+	useNow(m, t, time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local))
+	useSpecialDay(m, t, true)
+	getReactions := captureReactions(m, t)
+	_ = captureIntroDMs(m, t)
 
-	onMessageCreate(nil, greetingMessage("user1", "moin"))
+	m.onMessageCreate(nil, greetingMessage("user1", "moin"))
 
 	reactions := getReactions()
 	if len(reactions) != 2 {
@@ -282,24 +277,24 @@ func TestOnMessageCreate_SpecialDayFirstGreetingReactsAndRecordsGreeting(t *test
 	if reactions[1].emoji != string(util.Cl) {
 		t.Errorf("second special-day reaction = %q, want %q", reactions[1].emoji, string(util.Cl))
 	}
-	if count := countGreetings(t, "user1"); count != 1 {
+	if count := countGreetings(m, t, "user1"); count != 1 {
 		t.Errorf("expected 1 greeting row, got %d", count)
 	}
 }
 
-func stubLLM(t *testing.T, reply string, callErr error) func() []string {
+func stubLLM(m *Module, t *testing.T, reply string, callErr error) func() []string {
 	t.Helper()
-	prevDetect := detectLanguage
-	prevGenerate := generateLLMMessage
+	prevDetect := m.detectLanguage
+	prevGenerate := m.generateLLMMessage
 	t.Cleanup(func() {
-		detectLanguage = prevDetect
-		generateLLMMessage = prevGenerate
+		m.detectLanguage = prevDetect
+		m.generateLLMMessage = prevGenerate
 	})
-	detectLanguage = func(_ *discordgo.Session, _ string) (string, error) {
+	m.detectLanguage = func(_ *discordgo.Session, _ string) (string, error) {
 		return "English", nil
 	}
 	calls := []string{}
-	generateLLMMessage = func(_ context.Context, _, userPrompt string) (string, error) {
+	m.generateLLMMessage = func(_ context.Context, _, userPrompt string) (string, error) {
 		calls = append(calls, userPrompt)
 		return reply, callErr
 	}
@@ -307,9 +302,9 @@ func stubLLM(t *testing.T, reply string, callErr error) func() []string {
 }
 
 func TestGenerateInteractionMessage_ReturnsLLMText(t *testing.T) {
-	getCalls := stubLLM(t, "Der Kaffee ist fertig.", nil)
-	got := generateInteractionMessage(nil, "ch1", "Coffee is ready.", "fallback")
-	// nil session → detectLanguage returns "English" (stubbed), generateLLMMessage still called
+	m := newTestModule(t)
+	getCalls := stubLLM(m, t, "Der Kaffee ist fertig.", nil)
+	got := m.generateInteractionMessage(nil, "ch1", "Coffee is ready.", "fallback")
 	if got != "Der Kaffee ist fertig." {
 		t.Errorf("got %q, want LLM reply", got)
 	}
@@ -319,16 +314,18 @@ func TestGenerateInteractionMessage_ReturnsLLMText(t *testing.T) {
 }
 
 func TestGenerateInteractionMessage_FallsBackOnError(t *testing.T) {
-	stubLLM(t, "", fmt.Errorf("api failure"))
-	got := generateInteractionMessage(nil, "ch1", "scenario", "my fallback")
+	m := newTestModule(t)
+	stubLLM(m, t, "", fmt.Errorf("api failure"))
+	got := m.generateInteractionMessage(nil, "ch1", "scenario", "my fallback")
 	if got != "my fallback" {
 		t.Errorf("got %q, want fallback", got)
 	}
 }
 
 func TestGenerateInteractionMessage_FallsBackOnEmptyReply(t *testing.T) {
-	stubLLM(t, "   ", nil)
-	got := generateInteractionMessage(nil, "ch1", "scenario", "my fallback")
+	m := newTestModule(t)
+	stubLLM(m, t, "   ", nil)
+	got := m.generateInteractionMessage(nil, "ch1", "scenario", "my fallback")
 	if got != "my fallback" {
 		t.Errorf("got %q, want fallback on empty LLM reply", got)
 	}
@@ -342,25 +339,25 @@ type editCall struct {
 	content string
 }
 
-func stubInteractionHelpers(t *testing.T, deferErr error) (func() []deferCall, func() []editCall) {
+func stubInteractionHelpers(m *Module, t *testing.T, deferErr error) (func() []deferCall, func() []editCall) {
 	t.Helper()
 
-	prevDefer := deferInteraction
-	prevEdit := editDeferredResponse
+	prevDefer := m.deferInteraction
+	prevEdit := m.editDeferredResponse
 	defers := []deferCall{}
 	edits := []editCall{}
 
-	deferInteraction = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, ephemeral bool) error {
+	m.deferInteraction = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, ephemeral bool) error {
 		defers = append(defers, deferCall{ephemeral: ephemeral})
 		return deferErr
 	}
-	editDeferredResponse = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string) {
+	m.editDeferredResponse = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string) {
 		edits = append(edits, editCall{content: content})
 	}
 
 	t.Cleanup(func() {
-		deferInteraction = prevDefer
-		editDeferredResponse = prevEdit
+		m.deferInteraction = prevDefer
+		m.editDeferredResponse = prevEdit
 	})
 
 	return func() []deferCall { return defers }, func() []editCall { return edits }
@@ -392,15 +389,15 @@ func makeComponentInteraction(guildID, channelID, customID, userID string) *disc
 }
 
 func TestHandleBrewInteraction_DefersEphemeralWhenAlreadyBrewing(t *testing.T) {
-	openInMemoryStore(t)
-	resetBrewStates(t)
-	getDefers, getEdits := stubInteractionHelpers(t, nil)
-	stubLLM(t, "Already brewing!", nil)
-	captureBrewReadyMessages(t)
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	getDefers, getEdits := stubInteractionHelpers(m, t, nil)
+	stubLLM(m, t, "Already brewing!", nil)
+	captureBrewReadyMessages(m, t)
 
 	i := makeBrewInteraction("g1", "ch1")
-	handleBrewInteraction(nil, i)
-	handleBrewInteraction(nil, i)
+	m.handleBrewInteraction(nil, i)
+	m.handleBrewInteraction(nil, i)
 
 	defers := getDefers()
 	edits := getEdits()
@@ -416,13 +413,13 @@ func TestHandleBrewInteraction_DefersEphemeralWhenAlreadyBrewing(t *testing.T) {
 }
 
 func TestHandleBrewInteraction_DefersPublicOnNewBrew(t *testing.T) {
-	openInMemoryStore(t)
-	resetBrewStates(t)
-	getDefers, getEdits := stubInteractionHelpers(t, nil)
-	stubLLM(t, "Coffee brewing!", nil)
-	captureBrewReadyMessages(t)
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	getDefers, getEdits := stubInteractionHelpers(m, t, nil)
+	stubLLM(m, t, "Coffee brewing!", nil)
+	captureBrewReadyMessages(m, t)
 
-	handleBrewInteraction(nil, makeBrewInteraction("g2", "ch2"))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g2", "ch2"))
 
 	defers := getDefers()
 	if len(defers) != 1 {
@@ -437,13 +434,13 @@ func TestHandleBrewInteraction_DefersPublicOnNewBrew(t *testing.T) {
 }
 
 func TestHandleBrewInteraction_AbortsOnDeferError(t *testing.T) {
-	openInMemoryStore(t)
-	resetBrewStates(t)
-	_, getEdits := stubInteractionHelpers(t, fmt.Errorf("discord unavailable"))
-	stubLLM(t, "Coffee!", nil)
-	captureBrewReadyMessages(t)
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	_, getEdits := stubInteractionHelpers(m, t, fmt.Errorf("discord unavailable"))
+	stubLLM(m, t, "Coffee!", nil)
+	captureBrewReadyMessages(m, t)
 
-	handleBrewInteraction(nil, makeBrewInteraction("g3", "ch3"))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g3", "ch3"))
 
 	if len(getEdits()) != 0 {
 		t.Error("edit should not be called when defer fails")
@@ -451,12 +448,12 @@ func TestHandleBrewInteraction_AbortsOnDeferError(t *testing.T) {
 }
 
 func TestHandleGrabCoffeeButton_DefersEphemeralWhenNotReady(t *testing.T) {
-	openInMemoryStore(t)
-	resetBrewStates(t)
-	getDefers, getEdits := stubInteractionHelpers(t, nil)
-	stubLLM(t, "Pot is empty!", nil)
+	m := newTestModule(t)
+	resetBrewStates(m, t)
+	getDefers, getEdits := stubInteractionHelpers(m, t, nil)
+	stubLLM(m, t, "Pot is empty!", nil)
 
-	handleGrabCoffeeButton(nil, makeComponentInteraction("g4", "ch4", "grab_coffee", "user1"))
+	m.handleGrabCoffeeButton(nil, makeComponentInteraction("g4", "ch4", "coffee:grab_coffee", "user1"))
 
 	defers := getDefers()
 	if len(defers) != 1 {

--- a/internal/coffee/store.go
+++ b/internal/coffee/store.go
@@ -3,7 +3,6 @@ package coffee
 import (
 	"errors"
 	"log/slog"
-	"sync"
 	"time"
 
 	"gorm.io/driver/sqlite"
@@ -18,6 +17,8 @@ type UserBeveragePreference struct {
 	HasSeenIntro  bool   `gorm:"not null;default:false"`
 }
 
+func (UserBeveragePreference) TableName() string { return "coffee_user_beverage_preferences" }
+
 // UserGreeting records when a Discord user received their daily greeting reaction.
 type UserGreeting struct {
 	gorm.Model
@@ -25,48 +26,46 @@ type UserGreeting struct {
 	GreetedAt time.Time `gorm:"not null;index"`
 }
 
-var (
-	dbMu    sync.RWMutex
-	db      *gorm.DB
-	nowFunc = time.Now
-)
+func (UserGreeting) TableName() string { return "coffee_user_greetings" }
 
-func getDB() *gorm.DB {
-	dbMu.RLock()
-	defer dbMu.RUnlock()
-	return db
+func (m *Module) getDB() *gorm.DB {
+	m.dbMu.RLock()
+	defer m.dbMu.RUnlock()
+	return m.db
 }
 
-func openStore(path string) error {
-	dbMu.Lock()
-	defer dbMu.Unlock()
+func (m *Module) openStore(path string) error {
+	m.dbMu.Lock()
+	defer m.dbMu.Unlock()
 	var err error
-	db, err = gorm.Open(sqlite.Open(path), &gorm.Config{})
+	m.db, err = gorm.Open(sqlite.Open(path), &gorm.Config{})
 	if err != nil {
 		return err
 	}
-	return db.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{})
+	return m.db.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{})
 }
 
-func closeStore() {
-	dbMu.Lock()
-	defer dbMu.Unlock()
-	if db == nil {
-		return
+func (m *Module) closeStore() error {
+	m.dbMu.Lock()
+	defer m.dbMu.Unlock()
+	if m.db == nil {
+		return nil
 	}
-	sqlDB, err := db.DB()
+	sqlDB, err := m.db.DB()
 	if err != nil {
 		slog.Error("coffee: error getting sql.DB for close", "error", err)
-		return
+		return err
 	}
 	if err := sqlDB.Close(); err != nil {
 		slog.Error("coffee: error closing database", "error", err)
+		return err
 	}
-	db = nil
+	m.db = nil
+	return nil
 }
 
-func getBeverageEmoji(userID string) (string, bool) {
-	d := getDB()
+func (m *Module) getBeverageEmoji(userID string) (string, bool) {
+	d := m.getDB()
 	if d == nil {
 		return "", false
 	}
@@ -82,8 +81,8 @@ func getBeverageEmoji(userID string) (string, bool) {
 	return pref.BeverageEmoji, true
 }
 
-func isUserIntroduced(userID string) bool {
-	d := getDB()
+func (m *Module) isUserIntroduced(userID string) bool {
+	d := m.getDB()
 	if d == nil {
 		return false
 	}
@@ -95,21 +94,20 @@ func isUserIntroduced(userID string) bool {
 	return pref.HasSeenIntro
 }
 
-func markUserIntroduced(userID string) error {
-	d := getDB()
+func (m *Module) markUserIntroduced(userID string) error {
+	d := m.getDB()
 	if d == nil {
 		return errors.New("store not initialized")
 	}
 	var pref UserBeveragePreference
-	// If it doesn't exist, we create it with fallbackBeverage and HasSeenIntro = true
 	return d.Where(UserBeveragePreference{UserID: userID}).
 		Attrs(UserBeveragePreference{BeverageEmoji: fallbackBeverage}).
 		Assign(UserBeveragePreference{HasSeenIntro: true}).
 		FirstOrCreate(&pref).Error
 }
 
-func setBeverageEmoji(userID, emoji string) error {
-	d := getDB()
+func (m *Module) setBeverageEmoji(userID, emoji string) error {
+	d := m.getDB()
 	if d == nil {
 		return errors.New("store not initialized")
 	}
@@ -120,13 +118,13 @@ func setBeverageEmoji(userID, emoji string) error {
 	return result.Error
 }
 
-func hasGreetedToday(userID string) bool {
-	d := getDB()
+func (m *Module) hasGreetedToday(userID string) bool {
+	d := m.getDB()
 	if d == nil {
 		return false
 	}
 
-	now := nowFunc().UTC()
+	now := m.nowFunc().UTC()
 	year, month, day := now.Date()
 	startOfToday := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 	startOfTomorrow := startOfToday.AddDate(0, 0, 1)
@@ -142,14 +140,14 @@ func hasGreetedToday(userID string) bool {
 	return count > 0
 }
 
-func recordGreeting(userID string) error {
-	d := getDB()
+func (m *Module) recordGreeting(userID string) error {
+	d := m.getDB()
 	if d == nil {
 		return errors.New("store not initialized")
 	}
 
 	return d.Transaction(func(tx *gorm.DB) error {
-		now := nowFunc().UTC()
+		now := m.nowFunc().UTC()
 		year, month, day := now.Date()
 		startOfToday := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 		startOfTomorrow := startOfToday.AddDate(0, 0, 1)
@@ -161,7 +159,7 @@ func recordGreeting(userID string) error {
 			return err
 		}
 		if count > 0 {
-			return nil // already greeted, skip insert
+			return nil
 		}
 
 		return tx.Create(&UserGreeting{

--- a/internal/coffee/store_test.go
+++ b/internal/coffee/store_test.go
@@ -1,6 +1,8 @@
 package coffee
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -8,47 +10,52 @@ import (
 	"gorm.io/gorm"
 )
 
-func openInMemoryStore(t *testing.T) {
+// newTestModule creates a Module with an isolated in-memory SQLite store.
+func newTestModule(t *testing.T) *Module {
 	t.Helper()
-	gormDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	m := New()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", url.PathEscape(t.Name()))
+	gormDB, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("failed to open in-memory store: %v", err)
 	}
 	if err := gormDB.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{}); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
-	dbMu.Lock()
-	db = gormDB
-	dbMu.Unlock()
+	m.dbMu.Lock()
+	m.db = gormDB
+	m.dbMu.Unlock()
 	t.Cleanup(func() {
-		dbMu.Lock()
-		defer dbMu.Unlock()
-		sqlDB, _ := db.DB()
-		if err := sqlDB.Close(); err != nil {
-			t.Logf("warning: failed to close test DB: %v", err)
+		m.dbMu.Lock()
+		defer m.dbMu.Unlock()
+		if m.db == nil {
+			return
 		}
-		db = nil
+		sqlDB, _ := m.db.DB()
+		if sqlDB != nil {
+			if err := sqlDB.Close(); err != nil {
+				t.Logf("warning: failed to close test DB: %v", err)
+			}
+		}
+		m.db = nil
 	})
+	return m
 }
 
-func useNow(t *testing.T, now time.Time) {
+func useNow(m *Module, t *testing.T, now time.Time) {
 	t.Helper()
-	previous := nowFunc
-	nowFunc = func() time.Time {
-		return now
-	}
-	t.Cleanup(func() {
-		nowFunc = previous
-	})
+	previous := m.nowFunc
+	m.nowFunc = func() time.Time { return now }
+	t.Cleanup(func() { m.nowFunc = previous })
 }
 
 func TestSetAndGetBeverageEmoji(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
-	if err := setBeverageEmoji("user1", "🍺"); err != nil {
+	if err := m.setBeverageEmoji("user1", "🍺"); err != nil {
 		t.Fatalf("setBeverageEmoji: %v", err)
 	}
-	emoji, ok := getBeverageEmoji("user1")
+	emoji, ok := m.getBeverageEmoji("user1")
 	if !ok {
 		t.Fatal("expected ok=true, got false")
 	}
@@ -56,31 +63,30 @@ func TestSetAndGetBeverageEmoji(t *testing.T) {
 		t.Errorf("got %q, want %q", emoji, "🍺")
 	}
 
-	if !isUserIntroduced("user1") {
+	if !m.isUserIntroduced("user1") {
 		t.Error("expected user1 to be introduced after setting beverage")
 	}
 }
 
 func TestIsUserIntroduced_UnknownUser(t *testing.T) {
-	openInMemoryStore(t)
-	if isUserIntroduced("unknown") {
+	m := newTestModule(t)
+	if m.isUserIntroduced("unknown") {
 		t.Error("expected false for unknown user")
 	}
 }
 
 func TestMarkUserIntroduced(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
-	if err := markUserIntroduced("user_intro"); err != nil {
+	if err := m.markUserIntroduced("user_intro"); err != nil {
 		t.Fatalf("markUserIntroduced: %v", err)
 	}
 
-	if !isUserIntroduced("user_intro") {
+	if !m.isUserIntroduced("user_intro") {
 		t.Error("expected user_intro to be introduced")
 	}
 
-	// Verify it sets fallback beverage if it didn't exist
-	emoji, ok := getBeverageEmoji("user_intro")
+	emoji, ok := m.getBeverageEmoji("user_intro")
 	if !ok {
 		t.Fatal("expected beverage to be set (fallback)")
 	}
@@ -90,25 +96,25 @@ func TestMarkUserIntroduced(t *testing.T) {
 }
 
 func TestGetBeverageEmoji_UnknownUser(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
-	_, ok := getBeverageEmoji("unknown")
+	_, ok := m.getBeverageEmoji("unknown")
 	if ok {
 		t.Fatal("expected ok=false for unknown user, got true")
 	}
 }
 
 func TestSetBeverageEmoji_Upsert(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 
-	if err := setBeverageEmoji("user2", "🍵"); err != nil {
+	if err := m.setBeverageEmoji("user2", "🍵"); err != nil {
 		t.Fatalf("first setBeverageEmoji: %v", err)
 	}
-	if err := setBeverageEmoji("user2", "🧃"); err != nil {
+	if err := m.setBeverageEmoji("user2", "🧃"); err != nil {
 		t.Fatalf("second setBeverageEmoji: %v", err)
 	}
 
-	emoji, ok := getBeverageEmoji("user2")
+	emoji, ok := m.getBeverageEmoji("user2")
 	if !ok {
 		t.Fatal("expected ok=true after upsert")
 	}
@@ -116,7 +122,7 @@ func TestSetBeverageEmoji_Upsert(t *testing.T) {
 		t.Errorf("got %q, want %q after upsert", emoji, "🧃")
 	}
 
-	d := getDB()
+	d := m.getDB()
 	var count int64
 	d.Model(&UserBeveragePreference{}).Where("user_id = ?", "user2").Count(&count)
 	if count != 1 {
@@ -125,20 +131,20 @@ func TestSetBeverageEmoji_Upsert(t *testing.T) {
 }
 
 func TestHasGreetedToday_UnknownUser(t *testing.T) {
-	openInMemoryStore(t)
-	useNow(t, time.Date(2026, 5, 3, 10, 0, 0, 0, time.Local))
+	m := newTestModule(t)
+	useNow(m, t, time.Date(2026, 5, 3, 10, 0, 0, 0, time.Local))
 
-	if hasGreetedToday("unknown") {
+	if m.hasGreetedToday("unknown") {
 		t.Fatal("expected false for unknown user")
 	}
 }
 
 func TestHasGreetedToday_SameLocalDay(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 	now := time.Date(2026, 5, 3, 10, 0, 0, 0, time.Local)
-	useNow(t, now)
+	useNow(m, t, now)
 
-	d := getDB()
+	d := m.getDB()
 	if err := d.Create(&UserGreeting{
 		UserID:    "user1",
 		GreetedAt: time.Date(2026, 5, 3, 7, 30, 0, 0, time.Local),
@@ -146,17 +152,17 @@ func TestHasGreetedToday_SameLocalDay(t *testing.T) {
 		t.Fatalf("failed to create greeting: %v", err)
 	}
 
-	if !hasGreetedToday("user1") {
+	if !m.hasGreetedToday("user1") {
 		t.Fatal("expected true for greeting earlier on the same local day")
 	}
 }
 
 func TestHasGreetedToday_PreviousLocalDay(t *testing.T) {
-	openInMemoryStore(t)
+	m := newTestModule(t)
 	now := time.Date(2026, 5, 3, 10, 0, 0, 0, time.Local)
-	useNow(t, now)
+	useNow(m, t, now)
 
-	d := getDB()
+	d := m.getDB()
 	if err := d.Create(&UserGreeting{
 		UserID:    "user1",
 		GreetedAt: time.Date(2026, 5, 2, 23, 59, 0, 0, time.Local),
@@ -164,7 +170,7 @@ func TestHasGreetedToday_PreviousLocalDay(t *testing.T) {
 		t.Fatalf("failed to create greeting: %v", err)
 	}
 
-	if hasGreetedToday("user1") {
+	if m.hasGreetedToday("user1") {
 		t.Fatal("expected false for greeting on the previous local day")
 	}
 }

--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -356,8 +356,16 @@ func StartGidbig() {
 	}
 
 	llm.Initialize()
+	coffeeMod := coffee.New()
+	if err := coffeeMod.Init(bot.Deps{Session: discord, Config: conf}); err != nil {
+		slog.Error("coffee: init failed", "error", err)
+	} else {
+		for _, l := range coffeeMod.Listeners() {
+			discord.AddHandler(l)
+		}
+	}
+	admin.RegisterProvider(coffeeMod)
 	admin.Start(discord, conf.Discord.OwnerID, buildBotStatsMessage)
-	coffee.Start(discord)
 	esoMod := eso.New()
 	if err := esoMod.Init(bot.Deps{Session: discord, OwnerID: conf.Discord.OwnerID}); err != nil {
 		slog.Error("eso: init failed", "error", err)
@@ -397,7 +405,7 @@ func StartGidbig() {
 		{Name: "status", Description: "Show bot runtime status (owner only)"},
 	}
 	cmds = append(cmds, admin.Commands()...)
-	cmds = append(cmds, coffee.Commands()...)
+	cmds = append(cmds, coffeeMod.Commands()...)
 	cmds = append(cmds, esoMod.Commands()...)
 	cmds = append(cmds, gippity.Commands()...)
 	cmds = append(cmds, stollMod.Commands()...)
@@ -431,7 +439,9 @@ func StartGidbig() {
 		gippity.Shutdown()
 		gippity.CloseDB()
 		leetoclock.Shutdown()
-		coffee.Shutdown()
+		if err := coffeeMod.Shutdown(); err != nil {
+			slog.Error("coffee: shutdown failed", "error", err)
+		}
 	}()
 
 	select {


### PR DESCRIPTION
## Summary

- Adds `bot.AdminProvider` interface so modules can expose `/admin` subcommands without the admin package importing them
- Adds optional `cfg.Database.Path` for configurable DB path (path to single shared `gidbig.db` per #188)
- Rewrites `internal/coffee` as `bot.Module` struct — removes package-level `Start`/`Shutdown`/`Commands` and all monkey-patch vars; instance-level state + test hooks on `*Module`
- Adds `TableName()` to `UserBeveragePreference` → `coffee_user_beverage_preferences` and `UserGreeting` → `coffee_user_greetings`
- Migrates component custom IDs: `grab_coffee` → `coffee:grab_coffee`, `grab_milk` → `coffee:grab_milk`, `grab_sugar` → `coffee:grab_sugar`
- `internal/admin` no longer imports `internal/coffee`; uses `bot.AdminProvider` interface with `RegisterProvider()`
- All four coffee test files rewritten to use `newTestModule(t)` instance pattern

## Pre-deploy migration required

Before deploying this PR, migrate all coffee data from `coffee.db` into the new shared `gidbig.db` and rename the tables:

```bash
systemctl stop gidbig
sqlite3 gidbig.db <<'SQL'
ATTACH DATABASE 'coffee.db' AS old;

CREATE TABLE IF NOT EXISTS coffee_user_beverage_preferences AS
  SELECT * FROM old.user_beverage_preferences;

CREATE TABLE IF NOT EXISTS coffee_user_greetings AS
  SELECT * FROM old.user_greetings;

DETACH DATABASE old;
SQL
```

If you prefer to keep using `coffee.db` instead of migrating, set `database.path: coffee.db` in `config.yaml` and rename the tables in place:

```bash
systemctl stop gidbig
sqlite3 coffee.db <<'SQL'
ALTER TABLE user_beverage_preferences RENAME TO coffee_user_beverage_preferences;
ALTER TABLE user_greetings RENAME TO coffee_user_greetings;
SQL
```

In-flight brew messages with bare `grab_coffee`/`grab_milk`/`grab_sugar` IDs will be orphaned at deploy (acceptable per #171 open question 1).

## Test plan

- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — clean
- [x] `go build ./...` — clean

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)