### PR TITLE
feat(eso): add optional thema parameter

### DIFF
--- a/internal/eso/eso.go
+++ b/internal/eso/eso.go
@@ -12,7 +12,7 @@ import (
 	"github.com/toksikk/gidbig/internal/util"
 )
 
-const systemPromptTemplate = `Du bist ein esoterischer Unsinn-Generator. Produziere genau einen Satz mystischen, pseudo-tiefgründigen deutschen Unsinns. Orientiere dich an Ton und Struktur dieser Beispiele:
+const systemPromptTemplate = `Du bist ein esoterischer Unsinn-Generator. Produziere genau einen Satz mystischen, pseudo-tiefgründigen deutschen Unsinns. Falls ein Thema angegeben wird, beziehe dich darauf. Orientiere dich an Ton und Struktur dieser Beispiele:
 {{examples}}
 Antworte ausschließlich mit dem generierten Satz auf Deutsch. Keine Erklärung, keine Begrüßung.`
 
@@ -48,7 +48,18 @@ func (m *Module) Init(d bot.Deps) error {
 
 func (m *Module) Commands() []*discordgo.ApplicationCommand {
 	return []*discordgo.ApplicationCommand{
-		{Name: "eso", Description: "Erhalte esoterischen Unsinn"},
+		{
+			Name:        "eso",
+			Description: "Erhalte esoterischen Unsinn",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "thema",
+					Description: "Optionales Thema für den esoterischen Unsinn",
+					Required:    false,
+				},
+			},
+		},
 	}
 }
 
@@ -75,8 +86,20 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 		return
 	}
 
+	var subject string
+	for _, opt := range i.ApplicationCommandData().Options {
+		if opt.Name == "thema" {
+			subject = opt.StringValue()
+			break
+		}
+	}
+
 	go func() {
-		text := m.responder.Generate(context.Background())
+		userPrompt := "Generiere einen esoterischen Unsinn-Satz."
+		if subject != "" {
+			userPrompt = "Generiere esoterischen Unsinn über das Thema: " + subject
+		}
+		text := m.responder.GenerateWithPrompt(context.Background(), userPrompt)
 		if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &text}); err != nil {
 			slog.Error("eso: failed to edit interaction response", "error", err)
 			return

--- a/internal/eso/eso.go
+++ b/internal/eso/eso.go
@@ -90,7 +90,7 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 	var subject string
 	for _, opt := range i.ApplicationCommandData().Options {
 		if opt.Name == "thema" {
-			subject = opt.StringValue()
+			subject = util.ResolveMentions(s, i.GuildID, opt.StringValue())
 			break
 		}
 	}

--- a/internal/eso/eso.go
+++ b/internal/eso/eso.go
@@ -57,6 +57,7 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 					Name:        "thema",
 					Description: "Optionales Thema für den esoterischen Unsinn",
 					Required:    false,
+					MaxLength:   200,
 				},
 			},
 		},

--- a/internal/eso/eso.go
+++ b/internal/eso/eso.go
@@ -88,9 +88,10 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 	}
 
 	var subject string
+	restoreMentions := func(s string) string { return s }
 	for _, opt := range i.ApplicationCommandData().Options {
 		if opt.Name == "thema" {
-			subject = util.ResolveMentions(s, i.GuildID, opt.StringValue())
+			subject, restoreMentions = util.ResolveMentionsWithRestore(s, i.GuildID, opt.StringValue())
 			break
 		}
 	}
@@ -100,7 +101,7 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 		if subject != "" {
 			userPrompt = "Generiere esoterischen Unsinn über das Thema: " + subject
 		}
-		text := m.responder.GenerateWithPrompt(context.Background(), userPrompt)
+		text := restoreMentions(m.responder.GenerateWithPrompt(context.Background(), userPrompt))
 		if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &text}); err != nil {
 			slog.Error("eso: failed to edit interaction response", "error", err)
 			return

--- a/internal/eso/eso_test.go
+++ b/internal/eso/eso_test.go
@@ -62,6 +62,9 @@ func TestModule_Commands_HasThemaOption(t *testing.T) {
 	if opt.Required {
 		t.Fatal("thema option must not be required")
 	}
+	if opt.MaxLength != 200 {
+		t.Fatalf("expected MaxLength 200, got %d", opt.MaxLength)
+	}
 }
 
 func TestModule_Components_Empty(t *testing.T) {

--- a/internal/eso/eso_test.go
+++ b/internal/eso/eso_test.go
@@ -47,6 +47,23 @@ func TestModule_Commands_HasEso(t *testing.T) {
 	}
 }
 
+func TestModule_Commands_HasThemaOption(t *testing.T) {
+	cmds := New().Commands()
+	if len(cmds[0].Options) != 1 {
+		t.Fatalf("expected 1 option, got %d", len(cmds[0].Options))
+	}
+	opt := cmds[0].Options[0]
+	if opt.Name != "thema" {
+		t.Fatalf("expected option name 'thema', got %q", opt.Name)
+	}
+	if opt.Type != discordgo.ApplicationCommandOptionString {
+		t.Fatalf("expected string option type, got %v", opt.Type)
+	}
+	if opt.Required {
+		t.Fatal("thema option must not be required")
+	}
+}
+
 func TestModule_Components_Empty(t *testing.T) {
 	if comps := New().Components(); len(comps) != 0 {
 		t.Fatalf("expected 0 components, got %d", len(comps))
@@ -115,6 +132,26 @@ func TestModule_OnInteractionCreate_EsoCommand(t *testing.T) {
 	}
 	// InteractionRespond fails (no real connection) → handler returns early, no panic.
 	m.onInteractionCreate(s, i)
+}
+
+func TestModule_Responder_WithSubject(t *testing.T) {
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	var capturedUser string
+	m.responder.GenerateFn = func(_ context.Context, _, user string) (string, error) {
+		capturedUser = user
+		return "Kristallenergie fließt durch dein Auto.", nil
+	}
+	got := m.responder.GenerateWithPrompt(context.Background(), "Generiere esoterischen Unsinn über das Thema: Auto")
+	if got != "Kristallenergie fließt durch dein Auto." {
+		t.Fatalf("unexpected result: %q", got)
+	}
+	if !strings.Contains(capturedUser, "Auto") {
+		t.Fatalf("subject not in user prompt: %q", capturedUser)
+	}
 }
 
 func TestModule_Responder_AIPath(t *testing.T) {

--- a/internal/eso/eso_test.go
+++ b/internal/eso/eso_test.go
@@ -137,6 +137,29 @@ func TestModule_OnInteractionCreate_EsoCommand(t *testing.T) {
 	m.onInteractionCreate(s, i)
 }
 
+func TestModule_Responder_ResolvedSubjectReachesLLM(t *testing.T) {
+	// Verifies that a pre-resolved subject (mention already replaced by name)
+	// reaches the LLM user prompt unchanged — i.e. no raw <@ID> tokens.
+	m := New()
+	s, _ := discordgo.New("Bot fake-token")
+	if err := m.Init(bot.Deps{Session: s}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	var capturedUser string
+	m.responder.GenerateFn = func(_ context.Context, _, user string) (string, error) {
+		capturedUser = user
+		return "output", nil
+	}
+	resolved := "Alice" // what util.ResolveMentions would return for a known user
+	m.responder.GenerateWithPrompt(context.Background(), "Generiere esoterischen Unsinn über das Thema: "+resolved)
+	if !strings.Contains(capturedUser, "Alice") {
+		t.Fatalf("resolved name not in LLM prompt: %q", capturedUser)
+	}
+	if strings.Contains(capturedUser, "<@") {
+		t.Fatalf("raw mention token leaked into LLM prompt: %q", capturedUser)
+	}
+}
+
 func TestModule_Responder_WithSubject(t *testing.T) {
 	m := New()
 	s, _ := discordgo.New("Bot fake-token")

--- a/internal/eso/eso_test.go
+++ b/internal/eso/eso_test.go
@@ -139,7 +139,7 @@ func TestModule_OnInteractionCreate_EsoCommand(t *testing.T) {
 
 func TestModule_Responder_ResolvedSubjectReachesLLM(t *testing.T) {
 	// Verifies that a pre-resolved subject (mention already replaced by name)
-	// reaches the LLM user prompt unchanged — i.e. no raw <@ID> tokens.
+	// reaches the LLM user prompt without raw <@ID> tokens.
 	m := New()
 	s, _ := discordgo.New("Bot fake-token")
 	if err := m.Init(bot.Deps{Session: s}); err != nil {
@@ -148,15 +148,19 @@ func TestModule_Responder_ResolvedSubjectReachesLLM(t *testing.T) {
 	var capturedUser string
 	m.responder.GenerateFn = func(_ context.Context, _, user string) (string, error) {
 		capturedUser = user
-		return "output", nil
+		return "Energie von Alice fließt.", nil
 	}
-	resolved := "Alice" // what util.ResolveMentions would return for a known user
-	m.responder.GenerateWithPrompt(context.Background(), "Generiere esoterischen Unsinn über das Thema: "+resolved)
+	resolved := "Alice"
+	restore := func(s string) string { return strings.ReplaceAll(s, "Alice", "<@42>") }
+	text := restore(m.responder.GenerateWithPrompt(context.Background(), "Generiere esoterischen Unsinn über das Thema: "+resolved))
 	if !strings.Contains(capturedUser, "Alice") {
 		t.Fatalf("resolved name not in LLM prompt: %q", capturedUser)
 	}
 	if strings.Contains(capturedUser, "<@") {
 		t.Fatalf("raw mention token leaked into LLM prompt: %q", capturedUser)
+	}
+	if !strings.Contains(text, "<@42>") {
+		t.Fatalf("mention not restored in output: %q", text)
 	}
 }
 

--- a/internal/util/airesponder.go
+++ b/internal/util/airesponder.go
@@ -20,12 +20,18 @@ type AIResponder struct {
 // SystemPromptTemplate replacing "{{examples}}", calls GenerateFn, and returns the
 // trimmed response. Falls back to Fallback() on any error or empty result.
 func (r *AIResponder) Generate(ctx context.Context) string {
+	return r.GenerateWithPrompt(ctx, "Generate a response.")
+}
+
+// GenerateWithPrompt is like Generate but lets the caller supply the user-turn message,
+// enabling topic-scoped or otherwise customised requests.
+func (r *AIResponder) GenerateWithPrompt(ctx context.Context, userPrompt string) string {
 	if r.GenerateFn == nil {
 		return r.Fallback()
 	}
 	examples := pickExamples(r.ExamplePool, r.ExampleCount)
 	sys := strings.ReplaceAll(r.SystemPromptTemplate, "{{examples}}", strings.Join(examples, "\n\n"))
-	text, err := r.GenerateFn(ctx, sys, "Generate a response.")
+	text, err := r.GenerateFn(ctx, sys, userPrompt)
 	if err != nil || strings.TrimSpace(text) == "" {
 		return r.Fallback()
 	}

--- a/internal/util/airesponder_test.go
+++ b/internal/util/airesponder_test.go
@@ -98,6 +98,34 @@ func TestAIResponder_Generate_TrimsResponse(t *testing.T) {
 	}
 }
 
+func TestAIResponder_GenerateWithPrompt_PassesUserMessage(t *testing.T) {
+	var capturedUser string
+	r := &AIResponder{
+		SystemPromptTemplate: "{{examples}}",
+		ExamplePool:          []string{"a"},
+		ExampleCount:         1,
+		Fallback:             func() string { return "x" },
+		GenerateFn: func(_ context.Context, _, user string) (string, error) {
+			capturedUser = user
+			return "ok", nil
+		},
+	}
+	r.GenerateWithPrompt(context.Background(), "custom user prompt")
+	if capturedUser != "custom user prompt" {
+		t.Fatalf("expected custom user prompt, got %q", capturedUser)
+	}
+}
+
+func TestAIResponder_GenerateWithPrompt_FallbackWhenGenerateFnNil(t *testing.T) {
+	r := &AIResponder{
+		Fallback: func() string { return "fallback" },
+	}
+	got := r.GenerateWithPrompt(context.Background(), "any prompt")
+	if got != "fallback" {
+		t.Fatalf("expected 'fallback', got %q", got)
+	}
+}
+
 func TestPickExamples_EmptyPool(t *testing.T) {
 	got := pickExamples(nil, 3)
 	if len(got) != 0 {

--- a/internal/util/discordhelper.go
+++ b/internal/util/discordhelper.go
@@ -180,23 +180,41 @@ func GetUsernameForUserIDInGuild(discordSession *discordgo.Session, userid strin
 // the display name of the referenced user. Falls back to GetUsernameForUserIDInGuild
 // for unknown users. Returns the original text unchanged when there are no mentions.
 func ResolveMentions(session *discordgo.Session, guildID, text string) string {
+	resolved, _ := ResolveMentionsWithRestore(session, guildID, text)
+	return resolved
+}
+
+// ResolveMentionsWithRestore is like ResolveMentions but also returns a restore
+// function that replaces display names in a generated string back to their original
+// Discord mention tokens. Use it when the resolved text is sent to an LLM and the
+// output should contain real pings rather than plain names.
+func ResolveMentionsWithRestore(session *discordgo.Session, guildID, text string) (string, func(string) string) {
 	matches := mentionRe.FindAllStringSubmatch(text, -1)
 	if len(matches) == 0 {
-		return text
+		return text, func(s string) string { return s }
 	}
-	idToName := make(map[string]string, len(matches))
+	tokenToName := make(map[string]string, len(matches))
+	nameToToken := make(map[string]string, len(matches))
 	for _, m := range matches {
 		full, id := m[0], m[1]
-		if _, seen := idToName[full]; seen {
+		if _, seen := tokenToName[full]; seen {
 			continue
 		}
-		idToName[full] = GetUsernameForUserIDInGuild(session, id, guildID)
+		name := GetUsernameForUserIDInGuild(session, id, guildID)
+		tokenToName[full] = name
+		nameToToken[name] = full
 	}
-	result := text
-	for full, name := range idToName {
-		result = strings.ReplaceAll(result, full, name)
+	resolved := text
+	for token, name := range tokenToName {
+		resolved = strings.ReplaceAll(resolved, token, name)
 	}
-	return result
+	restore := func(generated string) string {
+		for name, token := range nameToToken {
+			generated = strings.ReplaceAll(generated, name, token)
+		}
+		return generated
+	}
+	return resolved, restore
 }
 
 // ReactOnMessage reacts to a message with an emoji concurrently

--- a/internal/util/discordhelper.go
+++ b/internal/util/discordhelper.go
@@ -2,11 +2,15 @@ package util
 
 import (
 	"log/slog"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
+
+var mentionRe = regexp.MustCompile(`<@!?(\d+)>`)
 
 type reactionItem struct {
 	session      *discordgo.Session
@@ -170,6 +174,29 @@ func GetUsernameForUserIDInGuild(discordSession *discordgo.Session, userid strin
 	}
 	slog.Warn("Error while getting user", "error", err, "user_id", userid)
 	return "Unbekannter Benutzer"
+}
+
+// ResolveMentions replaces Discord mention tokens (<@ID> / <@!ID>) in text with
+// the display name of the referenced user. Falls back to GetUsernameForUserIDInGuild
+// for unknown users. Returns the original text unchanged when there are no mentions.
+func ResolveMentions(session *discordgo.Session, guildID, text string) string {
+	matches := mentionRe.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return text
+	}
+	idToName := make(map[string]string, len(matches))
+	for _, m := range matches {
+		full, id := m[0], m[1]
+		if _, seen := idToName[full]; seen {
+			continue
+		}
+		idToName[full] = GetUsernameForUserIDInGuild(session, id, guildID)
+	}
+	result := text
+	for full, name := range idToName {
+		result = strings.ReplaceAll(result, full, name)
+	}
+	return result
 }
 
 // ReactOnMessage reacts to a message with an emoji concurrently

--- a/internal/util/discordhelper_test.go
+++ b/internal/util/discordhelper_test.go
@@ -54,3 +54,38 @@ func TestResolveMentions_DuplicateMention_ResolvedOnce(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expected, got)
 	}
 }
+
+func TestResolveMentionsWithRestore_NoMentions_NoopRestore(t *testing.T) {
+	s, _ := discordgo.New("Bot fake-token")
+	resolved, restore := ResolveMentionsWithRestore(s, "guild-1", "kein Mention hier")
+	if resolved != "kein Mention hier" {
+		t.Fatalf("expected unchanged text, got %q", resolved)
+	}
+	if got := restore("some generated text"); got != "some generated text" {
+		t.Fatalf("no-op restore changed text: %q", got)
+	}
+}
+
+func TestResolveMentionsWithRestore_RestoresToken(t *testing.T) {
+	s, _ := discordgo.New("Bot fake-token")
+	// Fake session: unknown user → "Unbekannter Benutzer"
+	_, restore := ResolveMentionsWithRestore(s, "guild-1", "<@123456789>")
+	generated := "Die Energie von Unbekannter Benutzer ist stark."
+	got := restore(generated)
+	if got != "Die Energie von <@123456789> ist stark." {
+		t.Fatalf("unexpected restored text: %q", got)
+	}
+}
+
+func TestResolveMentionsWithRestore_ResolveThenRestore_RoundTrip(t *testing.T) {
+	s, _ := discordgo.New("Bot fake-token")
+	input := "Unsinn über <@999>"
+	resolved, restore := ResolveMentionsWithRestore(s, "guild-1", input)
+	if resolved == input {
+		t.Fatal("resolve should have replaced the mention token")
+	}
+	restored := restore(resolved)
+	if restored != input {
+		t.Fatalf("round-trip failed: got %q, want %q", restored, input)
+	}
+}

--- a/internal/util/discordhelper_test.go
+++ b/internal/util/discordhelper_test.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestResolveMentions_NoMentions(t *testing.T) {
+	s, _ := discordgo.New("Bot fake-token")
+	got := ResolveMentions(s, "guild-1", "esoterischer Unsinn über Kristalle")
+	if got != "esoterischer Unsinn über Kristalle" {
+		t.Fatalf("expected unchanged text, got %q", got)
+	}
+}
+
+func TestResolveMentions_EmptyText(t *testing.T) {
+	s, _ := discordgo.New("Bot fake-token")
+	if got := ResolveMentions(s, "guild-1", ""); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestResolveMentions_UnknownUser_FallsBack(t *testing.T) {
+	// Fake session: GuildMember and User both fail → fallback name.
+	s, _ := discordgo.New("Bot fake-token")
+	got := ResolveMentions(s, "guild-1", "Unsinn über <@123456789>")
+	if got == "Unsinn über <@123456789>" {
+		t.Fatal("raw mention token should have been replaced")
+	}
+	if got != "Unsinn über Unbekannter Benutzer" {
+		t.Fatalf("expected fallback name, got %q", got)
+	}
+}
+
+func TestResolveMentions_NicknameFormat(t *testing.T) {
+	s, _ := discordgo.New("Bot fake-token")
+	got := ResolveMentions(s, "guild-1", "Unsinn über <@!987654321>")
+	if got == "Unsinn über <@!987654321>" {
+		t.Fatal("nickname-format mention token should have been replaced")
+	}
+}
+
+func TestResolveMentions_DuplicateMention_ResolvedOnce(t *testing.T) {
+	s, _ := discordgo.New("Bot fake-token")
+	text := "<@111> und <@111>"
+	got := ResolveMentions(s, "guild-1", text)
+	if got == text {
+		t.Fatal("mentions should have been replaced")
+	}
+	// Both occurrences should be resolved to the same name.
+	expected := "Unbekannter Benutzer und Unbekannter Benutzer"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an optional `thema` (subject) string option to the `/eso` slash command
- When provided, the subject is injected into the LLM user prompt: *"Generiere esoterischen Unsinn über das Thema: <subject>"*
- System prompt updated to mention that a topic may be given
- Template-based fallback ignores the subject and returns generic nonsense as before
- Introduces `AIResponder.GenerateWithPrompt` in `internal/util` so callers can supply a custom user-turn message without breaking the existing `Generate` API

## Test plan

- [x] `TestModule_Commands_HasThemaOption` — option present, string type, not required
- [x] `TestModule_Responder_WithSubject` — subject flows into LLM user prompt
- [x] `TestAIResponder_GenerateWithPrompt_PassesUserMessage` — new util method forwards custom prompt
- [x] `TestAIResponder_GenerateWithPrompt_FallbackWhenGenerateFnNil` — fallback path works
- [x] Full suite passes (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)