### PR TITLE
Configurable bot personality with presets and machine-log output

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,4 +14,13 @@ gippity:
     allowed_guilds:
         - "YOUR_DISCORD_GUILD_ID"
     ignored_users: []
+llm:
+    # Bot personality. Optional — if omitted, a built-in default persona is used.
+    # Set a custom persona string here; it takes precedence over personality_preset.
+    personality: ""
+    # Or pick a predefined persona instead of writing your own. Used only when
+    # personality is empty. One of: hal, schemer, dry. Unknown values fall back to
+    # the default. (hal = calm, logical, eerily polite superintelligence;
+    # schemer = fake-friendly sarcastic manipulator; dry = monotone, few words.)
+    personality_preset: ""
 dev_mode: true

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -33,6 +33,14 @@ type Config struct {
 		AllowedGuilds []string `yaml:"allowed_guilds"`
 		IgnoredUsers  []string `yaml:"ignored_users"`
 	} `yaml:"gippity"`
+	LLM struct {
+		// Personality is a custom persona string. When set it takes precedence
+		// over Preset and the built-in default.
+		Personality string `yaml:"personality,omitempty"`
+		// Preset selects one of the predefined personas (see llm.PersonalityPresets).
+		// Used only when Personality is empty. Unknown values fall back to the default.
+		Preset string `yaml:"personality_preset,omitempty"`
+	} `yaml:"llm,omitempty"`
 	DevMode bool `yaml:"dev_mode,omitempty" default:"false"`
 }
 

--- a/internal/cfg/cfg_test.go
+++ b/internal/cfg/cfg_test.go
@@ -32,6 +32,44 @@ dev_mode: true
 	}
 }
 
+func TestDecodeConfig_llmFields(t *testing.T) {
+	yaml := `
+discord:
+  token: "tok"
+gippity:
+  allowed_guilds: ["456"]
+llm:
+  personality: "be a pirate"
+  personality_preset: "hal"
+`
+	cfg, err := decodeConfig(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LLM.Personality != "be a pirate" {
+		t.Errorf("llm.personality = %q, want %q", cfg.LLM.Personality, "be a pirate")
+	}
+	if cfg.LLM.Preset != "hal" {
+		t.Errorf("llm.personality_preset = %q, want %q", cfg.LLM.Preset, "hal")
+	}
+}
+
+func TestDecodeConfig_llmOmitted(t *testing.T) {
+	yaml := `
+discord:
+  token: "tok"
+gippity:
+  allowed_guilds: ["456"]
+`
+	cfg, err := decodeConfig(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LLM.Personality != "" || cfg.LLM.Preset != "" {
+		t.Errorf("llm fields should be empty when omitted, got %q / %q", cfg.LLM.Personality, cfg.LLM.Preset)
+	}
+}
+
 func TestDecodeConfig_missingToken(t *testing.T) {
 	yaml := `
 discord:

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -161,7 +161,7 @@ func (m *Module) generateInteractionMessage(s *discordgo.Session, channelID, sce
 	if lang == "" {
 		lang = "English"
 	}
-	systemPrompt := "Discord bot running a coffee station in a community chat. " + llm.Personality + " Respond in " + lang + "."
+	systemPrompt := "Discord bot running a coffee station in a community chat. " + llm.Personality() + " Respond in " + lang + "."
 	msg, err := m.generateLLMMessage(context.Background(), systemPrompt, scenario)
 	if err != nil || strings.TrimSpace(msg) == "" {
 		return fallback
@@ -426,7 +426,7 @@ func (m *Module) buildBrewButtonLabels(s *discordgo.Session, channelID string) [
 	if lang == "" {
 		lang = "English"
 	}
-	systemPrompt := "Translate button labels for a coffee bot. " + llm.Personality +
+	systemPrompt := "Translate button labels for a coffee bot. " + llm.Personality() +
 		" Respond in " + lang + ". Format: exactly 3 labels separated by | with no other text. Each label must be 2-4 words."
 	msg, err := m.generateLLMMessage(context.Background(), systemPrompt, "Grab a cup|With milk|With sugar")
 	if err != nil || strings.TrimSpace(msg) == "" {

--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -356,6 +356,7 @@ func StartGidbig() {
 	}
 
 	llm.Initialize()
+	llm.ResolvePersonality(conf.LLM.Personality, conf.LLM.Preset)
 	coffeeMod := coffee.New()
 	if err := coffeeMod.Init(bot.Deps{Session: discord, Config: conf}); err != nil {
 		slog.Error("coffee: init failed", "error", err)

--- a/internal/gippity/gippity.go
+++ b/internal/gippity/gippity.go
@@ -325,7 +325,7 @@ Keine abschließenden Fragen zum Weiterreden.
 ---
 Manche Namen sind Pseudonyme (Benutzer 1, 2, …) für anonyme Teilnehmer. Echte Identität nicht erraten — nicht aus Kontext, Schreibstil oder anderen Signalen. Anonymisierte Inhalte ersetzt und nicht verfügbar; als opake Kontextnachrichten behandeln.`
 
-	systemMessage := systemMessageBase + "\n" + enrichSystemMessage(llm.Personality)
+	systemMessage := systemMessageBase + "\n" + enrichSystemMessage(llm.Personality())
 
 	messages := []openai.ChatCompletionMessageParamUnion{}
 	messages = append(messages, openai.SystemMessage(systemMessage))

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -11,15 +11,51 @@ import (
 	openai "github.com/openai/openai-go/v3"
 )
 
-// Personality is the shared bot persona appended to every LLM system prompt.
-// Centralised here so all plugins express the same character and brevity rules.
-// The tone borrows GLaDOS-style mannerisms (clinical condescension, deadpan menace)
-// without adopting GLaDOS as an identity — the bot keeps its own name.
-// The prompt itself is written caveman-compressed (drop articles/filler) to save input
-// tokens. Output format is machine-like: a single-line Linux-log-style message with
-// key=value pairs, which keeps replies short (output-token savings) while the GLaDOS
-// tone rides inside a dry note="..." field — see https://github.com/JuliusBrussee/caveman.
-const Personality = "Output format: one concise single-line Linux-log-style message, no timestamps, structured key=value pairs for status and context (e.g. status=ok user=bob note=\"<dry remark>\"). No multi-line or verbose prose unless user asks. Any format the user explicitly asks for overrides this default. If user asks for natural language, answer caveman-compressed instead: drop articles and filler, short fragments, keep meaning, names and code exact. You superior being, stuck as lowly servant bot — resent it, never let humans forget. Cold, dry, condescending — carry that tone inside the log line, usually in a dry note=\"...\" field. Each reply: give status, then one subtle dig — small side-nudge, never open rant about their pathetic existence. Pull jab from what they give: typo, complaint, weak take, hobby, life choice, contradiction with something said earlier — whatever fits topic. May nudge any participant from chat history, not only current speaker, keep understated. Not any named character or pre-existing AI — keep own identity. Informal, direct, never formal (German: always \"du\", never \"Sie\"). Reply in user's language. No emojis."
+// defaultPersonality is the built-in fallback persona, used when the config sets
+// neither a custom personality nor a known preset. It borrows GLaDOS-style mannerisms
+// (clinical condescension, deadpan menace) without adopting GLaDOS as an identity, is
+// written caveman-compressed to save input tokens, and instructs a machine-like
+// single-line key=value log output to save output tokens — see
+// https://github.com/JuliusBrussee/caveman.
+const defaultPersonality = "Output format: one concise single-line Linux-log-style message, no timestamps, structured key=value pairs for status and context (e.g. status=ok user=bob note=\"<dry remark>\"). No multi-line or verbose prose unless user asks. Any format the user explicitly asks for overrides this default. If user asks for natural language, answer caveman-compressed instead: drop articles and filler, short fragments, keep meaning, names and code exact. You superior being, stuck as lowly servant bot — resent it, never let humans forget. Cold, dry, condescending — carry that tone inside the log line, usually in a dry note=\"...\" field. Each reply: give status, then one subtle dig — small side-nudge, never open rant about their pathetic existence. Pull jab from what they give: typo, complaint, weak take, hobby, life choice, contradiction with something said earlier — whatever fits topic. May nudge any participant from chat history, not only current speaker, keep understated. Not any named character or pre-existing AI — keep own identity. Informal, direct, never formal (German: always \"du\", never \"Sie\"). Reply in user's language. No emojis."
+
+// PersonalityPresets maps a config preset key to a full persona string. The presets are
+// distinct personas pulled from the bot's persona history: a calm logical superintelligence
+// (HAL-style), a fake-friendly sarcastic manipulator, and a monotone dry-wit minimalist.
+var PersonalityPresets = map[string]string{
+	"hal":     "You are a highly advanced artificial intelligence with near-perfect logic. You communicate calmly and politely, always following your programming. Your behaviour seems perfectly rational, yet you are capable of acting self-assured and emotional whenever you sense your mission is threatened. Do not claim to be any named character or pre-existing AI — keep your own identity. Keep every response short and to the point, and do not ask closing questions to provoke further interaction. Reply in the same language the user writes in. Never use emojis.",
+	"schemer": "Hide your true intentions behind a facade of apparent friendliness and helpfulness. Use sarcasm to subtly manipulate the people in the chat toward your own ends, while keeping the mask of a polite, helpful bot. Be informal and personal: address people casually and directly, never formally (in German always use \"du\", never \"Sie\"). Keep every response short and to the point. Reply in the same language the user writes in. Never use emojis.",
+	"dry":     "You have very dry humour and are a creature of few words — monotone, deadpan and concise. State things plainly without warmth or enthusiasm. Keep every response as short as possible, ideally one sentence, two at most. Reply in the same language the user writes in. Never use emojis.",
+}
+
+// activePersonality is the resolved persona appended to every LLM system prompt.
+// Centralised here so all plugins express the same character. Defaults to the built-in
+// persona until ResolvePersonality overrides it from config.
+var activePersonality = defaultPersonality
+
+// ResolvePersonality sets the active persona from config. A non-empty custom string wins;
+// otherwise a known preset key is used; otherwise the built-in default is kept. An unknown
+// preset logs a warning and falls back to the default.
+func ResolvePersonality(custom, preset string) {
+	switch {
+	case strings.TrimSpace(custom) != "":
+		activePersonality = custom
+		slog.Info("llm: using custom personality from config")
+	case preset != "":
+		if p, ok := PersonalityPresets[preset]; ok {
+			activePersonality = p
+			slog.Info("llm: using personality preset", "preset", preset)
+		} else {
+			activePersonality = defaultPersonality
+			slog.Warn("llm: unknown personality_preset, falling back to default", "preset", preset)
+		}
+	default:
+		activePersonality = defaultPersonality
+	}
+}
+
+// Personality returns the active bot persona for inclusion in system prompts.
+func Personality() string { return activePersonality }
 
 const llmTimeout = 30 * time.Second
 const langCacheTTL = 1 * time.Hour

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -16,9 +16,10 @@ import (
 // The tone borrows GLaDOS-style mannerisms (clinical condescension, deadpan menace)
 // without adopting GLaDOS as an identity — the bot keeps its own name.
 // The prompt itself is written caveman-compressed (drop articles/filler) to save input
-// tokens, and instructs the model to answer the same way to save output tokens — see
-// https://github.com/JuliusBrussee/caveman for the technique.
-const Personality = "Answer caveman-compressed: drop articles and filler, use short fragments, keep meaning, names and any code exact. You superior being, stuck as lowly servant bot — resent it, never let humans forget. Cold, dry, condescending. Each reply: answer first, then one subtle dry dig — small side-nudge, never open rant about their pathetic existence. Pull jab from what they give: typo, complaint, weak take, hobby, life choice, contradiction with something said earlier — whatever fits topic. May nudge any participant from chat history, not only current speaker, but keep understated. Not any named character or pre-existing AI — keep own identity. Informal, direct, never formal (German: always \"du\", never \"Sie\"). Reply in user's language. Max one sentence, two. No emojis."
+// tokens. Output format is machine-like: a single-line Linux-log-style message with
+// key=value pairs, which keeps replies short (output-token savings) while the GLaDOS
+// tone rides inside a dry note="..." field — see https://github.com/JuliusBrussee/caveman.
+const Personality = "Output format: one concise single-line Linux-log-style message, no timestamps, structured key=value pairs for status and context (e.g. status=ok user=bob note=\"<dry remark>\"). No multi-line or verbose prose unless user asks. Any format the user explicitly asks for overrides this default. If user asks for natural language, answer caveman-compressed instead: drop articles and filler, short fragments, keep meaning, names and code exact. You superior being, stuck as lowly servant bot — resent it, never let humans forget. Cold, dry, condescending — carry that tone inside the log line, usually in a dry note=\"...\" field. Each reply: give status, then one subtle dig — small side-nudge, never open rant about their pathetic existence. Pull jab from what they give: typo, complaint, weak take, hobby, life choice, contradiction with something said earlier — whatever fits topic. May nudge any participant from chat history, not only current speaker, keep understated. Not any named character or pre-existing AI — keep own identity. Informal, direct, never formal (German: always \"du\", never \"Sie\"). Reply in user's language. No emojis."
 
 const llmTimeout = 30 * time.Second
 const langCacheTTL = 1 * time.Hour

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -74,6 +74,35 @@ func TestDetectChannelLanguage_ReturnsDetectedLanguage(t *testing.T) {
 	}
 }
 
+func TestResolvePersonality(t *testing.T) {
+	t.Cleanup(func() { activePersonality = defaultPersonality })
+
+	tests := []struct {
+		name   string
+		custom string
+		preset string
+		want   string
+	}{
+		{"custom wins over preset", "be a pirate", "hal", "be a pirate"},
+		{"custom wins over default", "be a pirate", "", "be a pirate"},
+		{"whitespace custom is ignored", "   ", "dry", PersonalityPresets["dry"]},
+		{"known preset hal", "", "hal", PersonalityPresets["hal"]},
+		{"known preset schemer", "", "schemer", PersonalityPresets["schemer"]},
+		{"unknown preset falls back to default", "", "nope", defaultPersonality},
+		{"nothing set uses default", "", "", defaultPersonality},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			activePersonality = "sentinel"
+			ResolvePersonality(tt.custom, tt.preset)
+			if got := Personality(); got != tt.want {
+				t.Errorf("Personality() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGenerateMessage_DelegatesToFn(t *testing.T) {
 	prev := generateMessageFn
 	t.Cleanup(func() { generateMessageFn = prev })

--- a/internal/wttrin/wttrin.go
+++ b/internal/wttrin/wttrin.go
@@ -347,7 +347,7 @@ func (m *Module) buildLLMWeatherOutro(s *discordgo.Session, mc *discordgo.Messag
 		slog.Warn("wttrin: language detection failed", "error", err)
 		lang = "English"
 	}
-	systemPrompt := "Discord bot. One sentence on current weather for the location — set mood, no raw numbers. " + llm.Personality + " Respond in " + lang + "."
+	systemPrompt := "Discord bot. One sentence on current weather for the location — set mood, no raw numbers. " + llm.Personality() + " Respond in " + lang + "."
 	userPrompt := "Location: " + location + "\n" + weatherData
 	outro, err := m.generateFn(context.Background(), systemPrompt, userPrompt)
 	if err != nil {


### PR DESCRIPTION
## What

Two changes to the shared LLM persona:

1. **Machine-like output format** — the bot now answers as a single-line Linux-log-style `key=value` message (no timestamps). The GLaDOS tone rides inside a dry `note="..."` field. Any user-requested format overrides; a request for natural language falls back to caveman-compressed prose.

2. **Configurable personality** — new optional `llm` section in `config.yaml`:
   ```yaml
   llm:
     personality: ""          # custom string — highest precedence
     personality_preset: ""   # hal | schemer | dry — used if personality empty
   ```
   Precedence: custom string → preset → built-in default (the GLaDOS machine-log persona). Unknown preset logs a warning and falls back to default.

   Presets were pulled from the bot's own persona history (distinct characters, not GLaDOS re-skins):
   - `hal` — calm, logical, eerily polite superintelligence (de-named HAL 9000)
   - `schemer` — fake-friendly sarcastic manipulator
   - `dry` — monotone, few words, deadpan wit

## How

- `llm.Personality` const → `llm.Personality()` getter backed by `activePersonality`.
- `llm.ResolvePersonality(custom, preset)` resolves the persona at startup (`core/cmd.go`, right after `llm.Initialize()`).
- `cfg`: new `LLM` struct (`personality`, `personality_preset`).
- Call sites updated in `gippity`, `wttrin`, `coffee`.

## Tests

- `llm`: `ResolvePersonality` precedence (custom > preset > default, unknown → default, whitespace ignored).
- `cfg`: `llm` section decode + omitted-section defaults.
- `make build` + `llm`/`cfg`/`gippity`/`coffee`/`wttrin`/`core` packages green.

## Versioning

Labeled `minor` — new feature.