### PR TITLE
Require a version label on every PR

### DIFF
--- a/.github/workflows/require-version-label.yaml
+++ b/.github/workflows/require-version-label.yaml
@@ -1,0 +1,33 @@
+name: Require version label
+
+# Gate every PR on having exactly the version label needed by version-tag.yaml,
+# which derives the semver bump (major/minor/breaking → otherwise patch) from the
+# merged PR's labels. Without this gate a mislabelled or unlabelled PR silently
+# bumps as patch on merge.
+
+on:
+    pull_request:
+        types: [opened, reopened, labeled, unlabeled, synchronize]
+        branches:
+            - master
+
+jobs:
+    require-label:
+        name: Require version label
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check for a version label
+              env:
+                  LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+              run: |
+                  echo "PR labels: ${LABELS:-<none>}"
+                  for label in $LABELS; do
+                      case "$label" in
+                          major | minor | breaking | patch)
+                              echo "OK: found version label '$label'"
+                              exit 0
+                              ;;
+                      esac
+                  done
+                  echo "::error::PR must carry one version label (major, minor, breaking, or patch) so version-tag.yaml bumps the version correctly on merge. Add the right label and re-run."
+                  exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,16 @@ Prefer a linear, readable history: use `--squash` when merging PRs, rebase featu
 
 Each PR should represent one logical, independently reversible change — don't bundle unrelated fixes or features into a single PR just because they're convenient. If a task touches multiple separable concerns, open a PR per concern.
 
+### Versioning
+
+`version-tag.yaml` auto-tags a new semver version on every push to `master`. It derives the bump level from the **labels of the PR associated with the pushed commit**: a `breaking` or `major` label → major bump, `minor` → minor bump, otherwise → **patch** bump. The repo defines four version labels: `major`, `minor`, `breaking`, `patch`.
+
+Because the bump comes from PR labels, **every PR must carry exactly one version label** — this is enforced by the `require-version-label.yaml` workflow, which fails the PR until a version label is present. Choose the label by semver intent: new feature → `minor`, bug fix / docs / chore → `patch`, backwards-incompatible change → `breaking`/`major`.
+
+**A direct push to `master` has no associated PR, so it always bumps as `patch`** — a feature or breaking change pushed directly will be mis-versioned. Features and breaking changes must therefore go through a labeled PR, never a direct push.
+
+IMPORTANT: If the user asks you to push directly to `master`, you MUST first inform them that a direct push yields only a `patch` bump (no PR labels are read), and confirm that is the intended version bump before pushing. If the change is actually a feature or breaking change, recommend a labeled PR instead.
+
 ### Bot commands
 
 Prefer Discord slash commands (`/` prefix) over legacy chat commands (`!` prefix). Register slash commands via `discordgo.Session.ApplicationCommandCreate` on startup and handle them in an `InteractionCreate` handler. When implementing a new command or touching an existing legacy `!`-prefix command during any task, refactor it to a slash command. Use ephemeral responses (`discordgo.MessageFlagsEphemeral`) for owner/admin replies to avoid leaking data in public channels.


### PR DESCRIPTION
## Why

`version-tag.yaml` auto-tags a new version on every push to `master`, deriving the bump from the **labels of the associated PR** (`breaking`/`major` → major, `minor` → minor, else **patch**). A PR merged without a version label silently bumps as `patch`, so features/breaking changes get mis-versioned.

## What

- **`.github/workflows/require-version-label.yaml`** — fails any PR to `master` that lacks one of `major`, `minor`, `breaking`, `patch`. Re-runs on label add/remove. Since `auto-merge.yaml` refuses to merge while any check is failing, this gates the merge; make it a required status check in branch protection to also block the manual merge button.
- **`patch` label** added to the repo so an explicit patch bump can satisfy the gate.
- **CLAUDE.md** — documents the versioning rules and the direct-push patch-only caveat.

## Versioning

Labeled `patch` — CI/docs only, no app behavior change.

## Note

Merge this before #214 so the workflow exists on `master`; then #214 (rebased) will be gated too.