### PR TITLE
Fix version-tag race under rebase merges (tag on PR-merge event)

### DIFF
--- a/.github/workflows/version-tag.yaml
+++ b/.github/workflows/version-tag.yaml
@@ -1,13 +1,24 @@
 name: Auto version tag
 
+# Triggered when a PR is merged into master (not on raw pushes) so the semver bump can be
+# read directly from the merged PR's labels in the event payload. This deliberately avoids
+# the commits/<sha>/pulls association lookup: GitHub rewrites commit hashes on rebase merge
+# (this repo is rebase-only) and links the new SHA to the PR only after an indexing delay,
+# so a push-triggered lookup races that delay and silently defaults every PR to a patch bump.
+#
+# Note: direct pushes to master no longer auto-tag — by design. All version bumps must come
+# through a labeled PR (see require-version-label.yaml and CLAUDE.md "Versioning").
+
 on:
-    push:
+    pull_request:
+        types: [closed]
         branches:
             - master
 
 jobs:
     tag:
         name: Bump and tag version
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -16,11 +27,13 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
+                  fetch-tags: true
+                  ref: ${{ github.event.pull_request.base.ref }}
 
             - name: Compute next version
               id: version
               env:
-                  GH_TOKEN: ${{ github.token }}
+                  LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
               run: |
                   # Get latest semver tag; default to v0.0.0 if none exists
                   LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
@@ -31,18 +44,19 @@ jobs:
                   PATCH=$(echo "$LATEST" | cut -d. -f3)
 
                   echo "Latest tag : $LATEST"
-
-                  # Determine bump level from PR labels (major/breaking → major, minor → minor, default → patch)
-                  LABELS=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-                      --jq '.[0].labels[].name' 2>/dev/null || echo "")
-
                   echo "PR labels  : $LABELS"
 
+                  # Bump level from the merged PR's labels (major/breaking → major, minor → minor, else patch)
                   BUMP=patch
-                  if echo "$LABELS" | grep -qE '^(major|breaking)$'; then
-                      BUMP=major
-                  elif echo "$LABELS" | grep -q '^minor$'; then
-                      BUMP=minor
+                  for label in $LABELS; do
+                      case "$label" in
+                          major | breaking) BUMP=major ;;
+                      esac
+                  done
+                  if [ "$BUMP" = patch ]; then
+                      for label in $LABELS; do
+                          if [ "$label" = minor ]; then BUMP=minor; fi
+                      done
                   fi
 
                   case "$BUMP" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,13 +22,15 @@ Each PR should represent one logical, independently reversible change — don't 
 
 ### Versioning
 
-`version-tag.yaml` auto-tags a new semver version on every push to `master`. It derives the bump level from the **labels of the PR associated with the pushed commit**: a `breaking` or `major` label → major bump, `minor` → minor bump, otherwise → **patch** bump. The repo defines four version labels: `major`, `minor`, `breaking`, `patch`.
+`version-tag.yaml` auto-tags a new semver version **when a PR is merged into `master`**. It derives the bump level from the merged PR's labels, read straight from the `pull_request` event payload: a `breaking` or `major` label → major bump, `minor` → minor bump, otherwise → **patch** bump. The repo defines four version labels: `major`, `minor`, `breaking`, `patch`.
+
+The workflow triggers on the PR-merge event (not on raw pushes) on purpose: this repo is **rebase-only**, so GitHub rewrites commit hashes on merge and links the new SHA to the PR only after an indexing delay. A push-triggered `commits/<sha>/pulls` lookup races that delay and silently defaults every PR to a patch bump. Reading labels from the event payload avoids the lookup entirely.
 
 Because the bump comes from PR labels, **every PR must carry exactly one version label** — this is enforced by the `require-version-label.yaml` workflow, which fails the PR until a version label is present. Choose the label by semver intent: new feature → `minor`, bug fix / docs / chore → `patch`, backwards-incompatible change → `breaking`/`major`.
 
-**A direct push to `master` has no associated PR, so it always bumps as `patch`** — a feature or breaking change pushed directly will be mis-versioned. Features and breaking changes must therefore go through a labeled PR, never a direct push.
+**A direct push to `master` does not auto-tag at all** (no PR-merge event fires), so it produces no version bump or release. Every version bump must go through a labeled PR.
 
-IMPORTANT: If the user asks you to push directly to `master`, you MUST first inform them that a direct push yields only a `patch` bump (no PR labels are read), and confirm that is the intended version bump before pushing. If the change is actually a feature or breaking change, recommend a labeled PR instead.
+IMPORTANT: If the user asks you to push directly to `master`, you MUST first inform them that a direct push produces no version tag or release (the bump only happens on a labeled PR merge), and confirm that is intended before pushing. For anything that should ship as a release, recommend a labeled PR instead.
 
 ### Bot commands
 


### PR DESCRIPTION
## Problem

`version-tag.yaml` triggered on **push to master** and read the bump label via `commits/<sha>/pulls`. This repo is **rebase-only**, so GitHub rewrites the commit hash on merge and only associates the new SHA with the PR after an indexing delay. The push-triggered lookup ran ~8s after merge, before the association existed → empty labels → **patch** by default.

Proof — #214 (labeled `minor`) ran:
```
Latest tag : v0.26.10
PR labels  :              ← empty
Bump       : patch  →  v0.26.11
```
So the feature shipped as `v0.26.11` instead of `v0.27.0`. This would mis-bump **every** labeled PR.

## Fix

Trigger on the `pull_request` **closed + merged** event and read the bump from `github.event.pull_request.labels` directly. No `commits/<sha>/pulls` lookup, so the rebase hash-rewrite and association delay are irrelevant. Checkout `base.ref` (master tip, post-merge) and tag that.

## Tradeoff

Direct pushes to `master` no longer auto-tag (no PR-merge event) — by design; it reinforces the PR-first / labeled-bump policy. CLAUDE.md "Versioning" updated to match.

## Note

`v0.26.11` (the mis-bumped feature release) is left as-is per decision; this PR only prevents recurrence.

## Versioning

Labeled `patch` — CI fix, no app change.