### PR TITLE
coffee: /coffee + /tea menus, private orders, slacker tracking, richer stats

### DIFF
--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -68,6 +68,7 @@ func TestCommands_CoffeeBeveragesSubcommand(t *testing.T) {
 	}
 	if coffeeGroup == nil {
 		t.Fatal("no coffee subcommand group")
+		return
 	}
 	if coffeeGroup.Type != discordgo.ApplicationCommandOptionSubCommandGroup {
 		t.Errorf("coffee Type = %v, want SubCommandGroup", coffeeGroup.Type)
@@ -81,6 +82,7 @@ func TestCommands_CoffeeBeveragesSubcommand(t *testing.T) {
 	}
 	if beverages == nil {
 		t.Fatal("no beverages subcommand under coffee")
+		return
 	}
 	if beverages.Type != discordgo.ApplicationCommandOptionSubCommand {
 		t.Errorf("beverages Type = %v, want SubCommand", beverages.Type)
@@ -98,6 +100,7 @@ func TestCommands_GippitySubcommands(t *testing.T) {
 	}
 	if gippityGroup == nil {
 		t.Fatal("no gippity subcommand group")
+		return
 	}
 
 	subNames := make(map[string]bool)
@@ -122,6 +125,7 @@ func TestCommands_InfoSubcommand(t *testing.T) {
 	}
 	if info == nil {
 		t.Fatal("no info subcommand")
+		return
 	}
 	if info.Type != discordgo.ApplicationCommandOptionSubCommand {
 		t.Errorf("info Type = %v, want SubCommand", info.Type)

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -47,6 +47,11 @@ type Module struct {
 	// machineMu serializes mutations to the per-guild machine inventory.
 	machineMu sync.Mutex
 
+	// uiCache holds LLM-translated fixed UI strings (menu prompts, rejection
+	// nudges, generic errors) keyed by channel+text, so menu re-renders and
+	// rejection clicks never trigger an LLM call on every interaction.
+	uiCache sync.Map
+
 	// Test hooks
 	nowFunc              func() time.Time
 	isSpecialDay         func() bool
@@ -293,6 +298,34 @@ func (m *Module) generateInteractionMessage(s *discordgo.Session, channelID, sce
 		return fallback
 	}
 	return strings.TrimSpace(msg)
+}
+
+// cachedUIText is a per-channel localized UI string with an expiry.
+type cachedUIText struct {
+	text      string
+	expiresAt time.Time
+}
+
+const uiTextCacheTTL = time.Hour
+
+// localizeUI returns a fixed UI string rendered in the channel's language via the
+// LLM, cached per channel so menu re-renders and rejection nudges never trigger
+// an LLM call on every interaction. Button labels and select placeholders are
+// deliberately not routed through here — they stay short English. Falls back to
+// english on any error or empty reply.
+func (m *Module) localizeUI(s *discordgo.Session, channelID, english string) string {
+	key := channelID + "\x00" + english
+	if v, ok := m.uiCache.Load(key); ok {
+		if e := v.(cachedUIText); m.nowFunc().Before(e.expiresAt) {
+			return e.text
+		}
+		m.uiCache.Delete(key)
+	}
+	out := m.generateInteractionMessage(s, channelID,
+		"Translate this coffee-station line into the channel's language, keeping every `/slash-command`, **markdown** marker and emoji exactly as written. Reply with only the translated line:\n"+english,
+		english)
+	m.uiCache.Store(key, cachedUIText{text: out, expiresAt: m.nowFunc().Add(uiTextCacheTTL)})
+	return out
 }
 
 func (m *Module) beverageEmojiFor(userID string) string {

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -461,11 +461,13 @@ func (m *Module) respondUpdateImpl(s *discordgo.Session, i *discordgo.Interactio
 	}
 }
 
-// openMenuImpl sends an ephemeral message carrying interactive components.
+// openMenuImpl sends a public message carrying interactive components. The menu
+// is public (so brewing/readiness stay visible to the channel) but gated to its
+// opener, who is encoded in every component custom ID.
 func (m *Module) openMenuImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string, comps []discordgo.MessageComponent) {
 	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{Content: content, Components: comps, Flags: discordgo.MessageFlagsEphemeral},
+		Data: &discordgo.InteractionResponseData{Content: content, Components: comps},
 	}); err != nil {
 		slog.Error("coffee: open menu failed", "error", err)
 	}

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -57,6 +57,9 @@ type Module struct {
 	deferInteraction     func(*discordgo.Session, *discordgo.InteractionCreate, bool) error
 	editDeferredResponse func(*discordgo.Session, *discordgo.InteractionCreate, string)
 	respond              func(*discordgo.Session, *discordgo.InteractionCreate, string, bool)
+	respondUpdate        func(*discordgo.Session, *discordgo.InteractionCreate, string)
+	openMenu             func(*discordgo.Session, *discordgo.InteractionCreate, string, []discordgo.MessageComponent)
+	updateMenu           func(*discordgo.Session, *discordgo.InteractionCreate, string, []discordgo.MessageComponent)
 	sleep                func(time.Duration)
 }
 
@@ -73,6 +76,9 @@ func New() *Module {
 	m.deferInteraction = m.deferInteractionImpl
 	m.editDeferredResponse = m.editDeferredResponseImpl
 	m.respond = m.respondImpl
+	m.respondUpdate = m.respondUpdateImpl
+	m.openMenu = m.openMenuImpl
+	m.updateMenu = m.updateMenuImpl
 	m.sleep = time.Sleep
 	return m
 }
@@ -110,7 +116,7 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 		},
 		{
 			Name:        "brew",
-			Description: "Get a fresh drink from the coffee machine",
+			Description: "Get a fresh drink from the coffee machine (no options opens a menu)",
 			Options: []*discordgo.ApplicationCommandOption{
 				{
 					Type:        discordgo.ApplicationCommandOptionString,
@@ -131,12 +137,30 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 					Description: "Add sugar",
 					Required:    false,
 				},
+			},
+		},
+		{
+			Name:        "tea",
+			Description: "Steep a tea bag in fresh hot water",
+			Options: []*discordgo.ApplicationCommandOption{
 				{
 					Type:        discordgo.ApplicationCommandOptionString,
-					Name:        "tea",
-					Description: "Drop in a tea bag (hot water only)",
-					Required:    false,
+					Name:        "flavor",
+					Description: "Which tea bag to steep",
+					Required:    true,
 					Choices:     teaChoices(),
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionBoolean,
+					Name:        "milk",
+					Description: "Add a splash of milk",
+					Required:    false,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionBoolean,
+					Name:        "sugar",
+					Description: "Add sugar",
+					Required:    false,
 				},
 			},
 		},
@@ -166,7 +190,20 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 				{
 					Type:        discordgo.ApplicationCommandOptionSubCommand,
 					Name:        "status",
-					Description: "Show machine levels and stats",
+					Description: "Show machine levels and leaderboards",
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "stats",
+					Description: "Detailed coffee stats for a user (default: you)",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionUser,
+							Name:        "user",
+							Description: "Whose stats to show (omit for your own)",
+							Required:    false,
+						},
+					},
 				},
 			},
 		},
@@ -294,6 +331,12 @@ func (m *Module) onMessageCreate(s *discordgo.Session, mc *discordgo.MessageCrea
 }
 
 func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type == discordgo.InteractionMessageComponent {
+		if strings.HasPrefix(i.MessageComponentData().CustomID, brewCfgPrefix) {
+			m.handleBrewComponent(s, i)
+		}
+		return
+	}
 	if i.Type != discordgo.InteractionApplicationCommand {
 		return
 	}
@@ -302,6 +345,9 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 	switch data.Name {
 	case "brew":
 		m.handleBrewInteraction(s, i)
+		return
+	case "tea":
+		m.handleTeaInteraction(s, i)
 		return
 	case "coffeemachine":
 		m.handleMachineInteraction(s, i)
@@ -382,6 +428,38 @@ func (m *Module) respondImpl(s *discordgo.Session, i *discordgo.InteractionCreat
 		Data: &discordgo.InteractionResponseData{Content: content, Flags: flags},
 	}); err != nil {
 		slog.Error("coffee: respond failed", "error", err)
+	}
+}
+
+// respondUpdateImpl replaces a component message's content in place and clears
+// its components (used when the interactive menu transitions to brewing/result).
+func (m *Module) respondUpdateImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	empty := []discordgo.MessageComponent{}
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{Content: content, Components: empty},
+	}); err != nil {
+		slog.Error("coffee: respond update failed", "error", err)
+	}
+}
+
+// openMenuImpl sends an ephemeral message carrying interactive components.
+func (m *Module) openMenuImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string, comps []discordgo.MessageComponent) {
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{Content: content, Components: comps, Flags: discordgo.MessageFlagsEphemeral},
+	}); err != nil {
+		slog.Error("coffee: open menu failed", "error", err)
+	}
+}
+
+// updateMenuImpl re-renders a component message's content and components in place.
+func (m *Module) updateMenuImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string, comps []discordgo.MessageComponent) {
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{Content: content, Components: comps},
+	}); err != nil {
+		slog.Error("coffee: update menu failed", "error", err)
 	}
 }
 

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -56,6 +56,7 @@ type Module struct {
 	generateLLMMessage   func(context.Context, string, string) (string, error)
 	deferInteraction     func(*discordgo.Session, *discordgo.InteractionCreate, bool) error
 	editDeferredResponse func(*discordgo.Session, *discordgo.InteractionCreate, string)
+	editWithComponents   func(*discordgo.Session, *discordgo.InteractionCreate, string, []discordgo.MessageComponent)
 	respond              func(*discordgo.Session, *discordgo.InteractionCreate, string, bool)
 	respondUpdate        func(*discordgo.Session, *discordgo.InteractionCreate, string)
 	openMenu             func(*discordgo.Session, *discordgo.InteractionCreate, string, []discordgo.MessageComponent)
@@ -75,6 +76,7 @@ func New() *Module {
 	m.generateLLMMessage = llm.GenerateMessage
 	m.deferInteraction = m.deferInteractionImpl
 	m.editDeferredResponse = m.editDeferredResponseImpl
+	m.editWithComponents = m.editWithComponentsImpl
 	m.respond = m.respondImpl
 	m.respondUpdate = m.respondUpdateImpl
 	m.openMenu = m.openMenuImpl
@@ -115,13 +117,13 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 			},
 		},
 		{
-			Name:        "brew",
-			Description: "Get a fresh drink from the coffee machine (no options opens a menu)",
+			Name:        "coffee",
+			Description: "Pull a fresh coffee from the machine (no options opens a menu)",
 			Options: []*discordgo.ApplicationCommandOption{
 				{
 					Type:        discordgo.ApplicationCommandOptionString,
 					Name:        "drink",
-					Description: "What to brew (default: coffee)",
+					Description: "Which coffee (default: coffee)",
 					Required:    false,
 					Choices:     drinkChoices(),
 				},
@@ -141,13 +143,13 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 		},
 		{
 			Name:        "tea",
-			Description: "Steep a tea bag in fresh hot water",
+			Description: "Steep a tea bag in fresh hot water (no options opens a menu)",
 			Options: []*discordgo.ApplicationCommandOption{
 				{
 					Type:        discordgo.ApplicationCommandOptionString,
 					Name:        "flavor",
 					Description: "Which tea bag to steep",
-					Required:    true,
+					Required:    false,
 					Choices:     teaChoices(),
 				},
 				{
@@ -210,10 +212,12 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 	}
 }
 
-// drinkChoices builds the /brew drink option choices from the menu.
+// drinkChoices builds the /coffee drink option choices from the coffee menu
+// (hot water is excluded — it lives behind /tea).
 func drinkChoices() []*discordgo.ApplicationCommandOptionChoice {
-	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(menu))
-	for _, r := range menu {
+	coffees := coffeeMenu()
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(coffees))
+	for _, r := range coffees {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{Name: r.label, Value: r.key})
 	}
 	return choices
@@ -228,7 +232,7 @@ func refillChoices() []*discordgo.ApplicationCommandOptionChoice {
 	return choices
 }
 
-// teaChoices builds the /brew tea option choices.
+// teaChoices builds the /tea flavor option choices.
 func teaChoices() []*discordgo.ApplicationCommandOptionChoice {
 	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(teaFlavors))
 	for _, t := range teaFlavors {
@@ -267,6 +271,14 @@ func (m *Module) deferInteractionImpl(s *discordgo.Session, i *discordgo.Interac
 func (m *Module) editDeferredResponseImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
 	if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content}); err != nil {
 		slog.Error("coffee: failed to edit deferred response", "error", err)
+	}
+}
+
+// editWithComponentsImpl edits the interaction's response, replacing both its
+// content and its components (used to attach the "Take cup" button).
+func (m *Module) editWithComponentsImpl(s *discordgo.Session, i *discordgo.InteractionCreate, content string, comps []discordgo.MessageComponent) {
+	if _, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content, Components: &comps}); err != nil {
+		slog.Error("coffee: failed to edit response with components", "error", err)
 	}
 }
 
@@ -332,8 +344,14 @@ func (m *Module) onMessageCreate(s *discordgo.Session, mc *discordgo.MessageCrea
 
 func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.Type == discordgo.InteractionMessageComponent {
-		if strings.HasPrefix(i.MessageComponentData().CustomID, brewCfgPrefix) {
-			m.handleBrewComponent(s, i)
+		id := i.MessageComponentData().CustomID
+		switch {
+		case strings.HasPrefix(id, teaCfgPrefix):
+			m.handleTeaComponent(s, i)
+		case strings.HasPrefix(id, coffeeCfgPrefix):
+			m.handleCoffeeComponent(s, i)
+		case strings.HasPrefix(id, takeCupPrefix):
+			m.handleTakeCupComponent(s, i)
 		}
 		return
 	}
@@ -343,8 +361,8 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 
 	data := i.ApplicationCommandData()
 	switch data.Name {
-	case "brew":
-		m.handleBrewInteraction(s, i)
+	case "coffee":
+		m.handleCoffeeInteraction(s, i)
 		return
 	case "tea":
 		m.handleTeaInteraction(s, i)

--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -122,45 +122,20 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 			},
 		},
 		{
-			Name:        "coffee",
-			Description: "Pull a fresh coffee from the machine (no options opens a menu)",
+			Name:        "brew",
+			Description: "Order a hot drink from the machine (no options opens a menu)",
 			Options: []*discordgo.ApplicationCommandOption{
 				{
 					Type:        discordgo.ApplicationCommandOptionString,
 					Name:        "drink",
-					Description: "Which coffee (default: coffee)",
+					Description: "Coffee or tea variety (default: coffee)",
 					Required:    false,
-					Choices:     drinkChoices(),
+					Choices:     brewChoices(),
 				},
 				{
 					Type:        discordgo.ApplicationCommandOptionBoolean,
 					Name:        "milk",
 					Description: "Add a splash of milk (ignored for milk-based drinks)",
-					Required:    false,
-				},
-				{
-					Type:        discordgo.ApplicationCommandOptionBoolean,
-					Name:        "sugar",
-					Description: "Add sugar",
-					Required:    false,
-				},
-			},
-		},
-		{
-			Name:        "tea",
-			Description: "Steep a tea bag in fresh hot water (no options opens a menu)",
-			Options: []*discordgo.ApplicationCommandOption{
-				{
-					Type:        discordgo.ApplicationCommandOptionString,
-					Name:        "flavor",
-					Description: "Which tea bag to steep",
-					Required:    false,
-					Choices:     teaChoices(),
-				},
-				{
-					Type:        discordgo.ApplicationCommandOptionBoolean,
-					Name:        "milk",
-					Description: "Add a splash of milk",
 					Required:    false,
 				},
 				{
@@ -217,31 +192,22 @@ func (m *Module) Commands() []*discordgo.ApplicationCommand {
 	}
 }
 
-// drinkChoices builds the /coffee drink option choices from the coffee menu
-// (hot water is excluded — it lives behind /tea).
-func drinkChoices() []*discordgo.ApplicationCommandOptionChoice {
-	coffees := coffeeMenu()
-	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(coffees))
-	for _, r := range coffees {
+// brewChoices builds the /brew drink option choices: all coffees followed by
+// all tea varieties.
+func brewChoices() []*discordgo.ApplicationCommandOptionChoice {
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(menu))
+	for _, r := range menu {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{Name: r.label, Value: r.key})
 	}
 	return choices
 }
 
-// refillChoices builds the /coffeemachine refill part option choices.
+// refillChoices builds the /coffeemachine refill part option choices (machine
+// parts + tea bag varieties).
 func refillChoices() []*discordgo.ApplicationCommandOptionChoice {
 	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(refillParts))
 	for _, p := range refillParts {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{Name: p.label, Value: p.key})
-	}
-	return choices
-}
-
-// teaChoices builds the /tea flavor option choices.
-func teaChoices() []*discordgo.ApplicationCommandOptionChoice {
-	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(teaFlavors))
-	for _, t := range teaFlavors {
-		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{Name: t.label, Value: t.key})
 	}
 	return choices
 }
@@ -379,10 +345,8 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 	if i.Type == discordgo.InteractionMessageComponent {
 		id := i.MessageComponentData().CustomID
 		switch {
-		case strings.HasPrefix(id, teaCfgPrefix):
-			m.handleTeaComponent(s, i)
-		case strings.HasPrefix(id, coffeeCfgPrefix):
-			m.handleCoffeeComponent(s, i)
+		case strings.HasPrefix(id, brewCfgPrefix):
+			m.handleBrewComponent(s, i)
 		case strings.HasPrefix(id, takeCupPrefix):
 			m.handleTakeCupComponent(s, i)
 		}
@@ -394,11 +358,8 @@ func (m *Module) onInteractionCreate(s *discordgo.Session, i *discordgo.Interact
 
 	data := i.ApplicationCommandData()
 	switch data.Name {
-	case "coffee":
-		m.handleCoffeeInteraction(s, i)
-		return
-	case "tea":
-		m.handleTeaInteraction(s, i)
+	case "brew":
+		m.handleBrewInteraction(s, i)
 		return
 	case "coffeemachine":
 		m.handleMachineInteraction(s, i)

--- a/internal/coffee/machine.go
+++ b/internal/coffee/machine.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/bwmarrin/discordgo"
 	"gorm.io/gorm"
@@ -124,6 +125,74 @@ func refillPartByKey(key string) (refillPart, bool) {
 	return refillPart{}, false
 }
 
+// partLabel returns a human-facing name for a refillable part or the grounds
+// container.
+func partLabel(key string) string {
+	if key == partGrounds {
+		return "grounds container"
+	}
+	if p, ok := refillPartByKey(key); ok {
+		return strings.ToLower(p.label)
+	}
+	return key
+}
+
+// maxPartDemand returns the largest amount of the given part a single drink can
+// consume across the whole menu (milk includes the worst-case optional splash).
+// It is the threshold below which the next brew of some drink could be blocked.
+func maxPartDemand(part string) int {
+	max := 0
+	for _, r := range menu {
+		v := 0
+		switch part {
+		case "beans_mild":
+			if r.bean == beanMild {
+				v = r.beanGrams
+			}
+		case "beans_espresso":
+			if r.bean == beanEspresso {
+				v = r.beanGrams
+			}
+		case "water":
+			v = r.waterMl
+		case "milk":
+			v = r.milkMl
+			if r.allowsMilk {
+				v += addMilkMl
+			}
+		case partGrounds:
+			v = r.groundsG
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+// partsNeedingService reports which parts the given inventory has left low (or,
+// for grounds, too full) enough that the next brew of some drink would be
+// blocked. The order matches the machine status display.
+func partsNeedingService(inv MachineInventory) []string {
+	var parts []string
+	if inv.BeansMildGrams < maxPartDemand("beans_mild") {
+		parts = append(parts, "beans_mild")
+	}
+	if inv.BeansEspressoGrams < maxPartDemand("beans_espresso") {
+		parts = append(parts, "beans_espresso")
+	}
+	if inv.WaterMl < maxPartDemand("water") {
+		parts = append(parts, "water")
+	}
+	if inv.MilkMl < maxPartDemand("milk") {
+		parts = append(parts, "milk")
+	}
+	if inv.GroundsGrams+maxPartDemand(partGrounds) > maxGroundsG {
+		parts = append(parts, partGrounds)
+	}
+	return parts
+}
+
 // seedInventoryTx loads the guild's inventory, creating a full machine on first
 // use. Works on any *gorm.DB (a live handle or an open transaction).
 func seedInventoryTx(db *gorm.DB, guildID string) (MachineInventory, error) {
@@ -158,6 +227,16 @@ type dispenseOutcome struct {
 	failMsg    string // user-facing reason when ok is false
 	splashMilk bool   // an optional milk splash was added to a black drink
 	withSugar  bool
+
+	// serviceNeeded lists parts this (successful) brew left low/full enough that
+	// the next brew could be blocked; the brewer is nudged to refill/empty them.
+	serviceNeeded []string
+
+	// blamedUserID and blamedPart name the previous brewer who left the blocking
+	// part empty/full and never serviced it, when this brew was blocked. Empty
+	// when there is no one to blame.
+	blamedUserID string
+	blamedPart   string
 }
 
 // dispense brews one drink for userID in guildID, deducting consumables and
@@ -191,21 +270,29 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 			return e
 		}
 
+		blockPart := ""
 		switch {
 		case r.bean == beanMild && inv.BeansMildGrams < r.beanGrams:
-			out.failMsg = outOfMsg("mild beans", "beans_mild")
+			out.failMsg, blockPart = outOfMsg("mild beans", "beans_mild"), "beans_mild"
 		case r.bean == beanEspresso && inv.BeansEspressoGrams < r.beanGrams:
-			out.failMsg = outOfMsg("espresso beans", "beans_espresso")
+			out.failMsg, blockPart = outOfMsg("espresso beans", "beans_espresso"), "beans_espresso"
 		case inv.WaterMl < r.waterMl:
-			out.failMsg = outOfMsg("water", "water")
+			out.failMsg, blockPart = outOfMsg("water", "water"), "water"
 		case inv.MilkMl < milkNeeded:
-			out.failMsg = outOfMsg("milk", "milk")
+			out.failMsg, blockPart = outOfMsg("milk", "milk"), "milk"
 		case inv.GroundsGrams+r.groundsG > maxGroundsG:
-			out.failMsg = "The grounds container is full. Empty it with `/coffeemachine empty`."
+			out.failMsg, blockPart = "The grounds container is full. Empty it with `/coffeemachine empty`.", partGrounds
 		}
 		if out.failMsg != "" {
 			out.inventory = inv
-			return nil // commit nothing; caller sees ok=false
+			// The next user is now forced to service blockPart. If a previous
+			// brewer left it that way and never fixed it, blame them once.
+			if blockPart != "" {
+				if e = m.blameSlackerTx(tx, guildID, blockPart, userID, &out); e != nil {
+					return e
+				}
+			}
+			return nil // no inventory change; caller sees ok=false
 		}
 
 		switch r.bean {
@@ -230,6 +317,14 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 		}).Error; e != nil {
 			return e
 		}
+		// Record which parts this brew left needing service and pin the brewer as
+		// responsible, so a later blocked brew can blame them.
+		out.serviceNeeded = partsNeedingService(inv)
+		for _, p := range out.serviceNeeded {
+			if e = setPendingServiceTx(tx, guildID, p, userID); e != nil {
+				return e
+			}
+		}
 		out.inventory = inv
 		out.ok = true
 		return nil
@@ -242,6 +337,30 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 
 func outOfMsg(name, partKey string) string {
 	return fmt.Sprintf("Out of %s. Top it up with `/coffeemachine refill part:%s`.", name, partKey)
+}
+
+// blameSlackerTx handles a brew blocked on blockPart. If a previous brewer was
+// pinned as responsible for that part (and is not the now-blocked user), it
+// records a SlackerEvent against them and stores the blame on out. The pending
+// record is always cleared: the now-blocked user will have to service the part,
+// so the episode is resolved either way.
+func (m *Module) blameSlackerTx(tx *gorm.DB, guildID, blockPart, blockedUserID string, out *dispenseOutcome) error {
+	var ps PendingService
+	err := tx.Where("guild_id = ? AND part = ?", guildID, blockPart).First(&ps).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if ps.UserID != "" && ps.UserID != blockedUserID {
+		if e := tx.Create(&SlackerEvent{GuildID: guildID, UserID: ps.UserID, Part: blockPart}).Error; e != nil {
+			return e
+		}
+		out.blamedUserID = ps.UserID
+		out.blamedPart = blockPart
+	}
+	return clearPendingServiceTx(tx, guildID, blockPart)
 }
 
 // refillOutcome is the result of a refill attempt.
@@ -272,6 +391,10 @@ func (m *Module) refill(guildID, userID, partKey string) (refillOutcome, error) 
 	err := d.Transaction(func(tx *gorm.DB) error {
 		inv, e := seedInventoryTx(tx, guildID)
 		if e != nil {
+			return e
+		}
+		// The part is being serviced; nobody is on the hook for it anymore.
+		if e = clearPendingServiceTx(tx, guildID, p.key); e != nil {
 			return e
 		}
 		var cur *int
@@ -333,6 +456,10 @@ func (m *Module) emptyGrounds(guildID, userID string) (emptyOutcome, error) {
 	err := d.Transaction(func(tx *gorm.DB) error {
 		inv, e := seedInventoryTx(tx, guildID)
 		if e != nil {
+			return e
+		}
+		// The grounds are being serviced; nobody is on the hook anymore.
+		if e = clearPendingServiceTx(tx, guildID, partGrounds); e != nil {
 			return e
 		}
 		if inv.GroundsGrams <= 0 {
@@ -408,8 +535,65 @@ func formatDispenseSuccess(r recipe, splashMilk, withSugar bool, tea string) str
 	return fmt.Sprintf("%s Here's your %s%s!", drinkEmoji(r, tea), drinkLabel(r, tea), extrasSuffix(splashMilk, withSugar))
 }
 
-// formatStatus renders the machine status, levels, and stat leaderboards.
-func formatStatus(inv MachineInventory, drinkers, refillers []userCount, groundsEmpties int64) string {
+// humanJoin renders a slice as "a", "a and b", or "a, b and c".
+func humanJoin(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " and " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + " and " + items[len(items)-1]
+	}
+}
+
+// serviceHint renders the nudge appended to a brew confirmation when the brew
+// left parts needing service, naming the parts and the fixing commands. Empty
+// when nothing needs service.
+func serviceHint(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	labels := make([]string, 0, len(parts))
+	emptyGrounds := false
+	for _, p := range parts {
+		labels = append(labels, partLabel(p))
+		if p == partGrounds {
+			emptyGrounds = true
+		}
+	}
+	verb := "is"
+	if len(labels) > 1 {
+		verb = "are"
+	}
+	action := "refill with `/coffeemachine refill`"
+	switch {
+	case emptyGrounds && len(labels) == 1:
+		action = "empty it with `/coffeemachine empty`"
+	case emptyGrounds:
+		action = "refill/empty with `/coffeemachine`"
+	}
+	return fmt.Sprintf("\n\n⚠️ Heads up: the %s %s running low — please %s so the next person isn't left stranded.",
+		humanJoin(labels), verb, action)
+}
+
+// blockedFallback builds the user-facing reason a brew was blocked, naming the
+// previous brewer to blame when one was recorded.
+func blockedFallback(out dispenseOutcome) string {
+	msg := out.failMsg
+	if out.blamedUserID != "" {
+		msg += fmt.Sprintf(" <@%s> used the last of the %s and never refilled it — looks like it's on you now.",
+			out.blamedUserID, partLabel(out.blamedPart))
+	}
+	return msg
+}
+
+// formatStatus renders the machine status, levels, and stat leaderboards. The
+// per-drink and per-part breakdowns live in /coffeemachine stats; this view
+// keeps one headline number per leaderboard.
+func formatStatus(inv MachineInventory, drinkers, refillers []userCount, emptiers []groundsEmptier, slackers []userCount) string {
 	var sb strings.Builder
 	sb.WriteString("☕ **Coffee machine status**\n")
 	fmt.Fprintf(&sb, "Mild beans: %d/%dg (%d%%)\n", inv.BeansMildGrams, maxBeansMildG, percent(inv.BeansMildGrams, maxBeansMildG))
@@ -434,16 +618,128 @@ func formatStatus(inv MachineInventory, drinkers, refillers []userCount, grounds
 		fmt.Fprintf(&sb, "<@%s>: %d refills\n", u.UserID, u.Count)
 	}
 
-	fmt.Fprintf(&sb, "\nGrounds emptied %d times.", groundsEmpties)
-	return sb.String()
+	sb.WriteString("\n**Top grounds-emptiers**\n")
+	if len(emptiers) == 0 {
+		sb.WriteString("_none yet_\n")
+	}
+	for _, e := range emptiers {
+		fmt.Fprintf(&sb, "<@%s>: %d× · %dg total · %dg avg\n", e.UserID, e.Count, e.TotalGrams, avgGrams(e.TotalGrams, e.Count))
+	}
+
+	if len(slackers) > 0 {
+		sb.WriteString("\n**Slackers** _(left it empty for the next person)_\n")
+		for _, u := range slackers {
+			fmt.Fprintf(&sb, "<@%s>: %d misses\n", u.UserID, u.Count)
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
 }
 
-// handleBrewInteraction serves a drink for /brew.
+// avgGrams returns the integer average of total over count, 0 when count is 0.
+func avgGrams(total, count int) int {
+	if count <= 0 {
+		return 0
+	}
+	return int(math.Round(float64(total) / float64(count)))
+}
+
+// formatUserStats renders the detailed per-user breakdown for /coffeemachine
+// stats: drinks by type, refills by part, grounds emptied, and slacker misses.
+func formatUserStats(userID string, drinks, refills []labelCount, groundsCount, groundsTotal int, slackers []labelCount) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "📊 **Coffee stats for <@%s>**\n", userID)
+
+	sb.WriteString("\n**Drinks**\n")
+	if len(drinks) == 0 {
+		sb.WriteString("_none yet_\n")
+	}
+	for _, d := range drinks {
+		fmt.Fprintf(&sb, "%s: %d\n", drinkKeyLabel(d.Key), d.Count)
+	}
+
+	sb.WriteString("\n**Refills**\n")
+	if len(refills) == 0 {
+		sb.WriteString("_none yet_\n")
+	}
+	for _, r := range refills {
+		fmt.Fprintf(&sb, "%s: %d× (%d total)\n", titleCase(partLabel(r.Key)), r.Count, r.Amount)
+	}
+
+	if groundsCount > 0 {
+		fmt.Fprintf(&sb, "\n**Grounds emptied:** %d× · %dg total · %dg avg\n", groundsCount, groundsTotal, avgGrams(groundsTotal, groundsCount))
+	} else {
+		sb.WriteString("\n**Grounds emptied:** never\n")
+	}
+
+	if len(slackers) > 0 {
+		sb.WriteString("\n**Slacker misses** _(left empty for the next person)_\n")
+		for _, s := range slackers {
+			fmt.Fprintf(&sb, "%s: %d\n", titleCase(partLabel(s.Key)), s.Count)
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// drinkKeyLabel maps a drink key to its menu label, falling back to the key.
+func drinkKeyLabel(key string) string {
+	if r, ok := recipeByKey(key); ok {
+		return r.label
+	}
+	return key
+}
+
+// titleCase upper-cases the first rune of s.
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
+// brewResponder abstracts how a brew flow talks back to Discord so the same
+// dispense+animation logic serves both the public slash commands (/brew, /tea)
+// and the ephemeral interactive menu (component "go" button).
+type brewResponder struct {
+	brewing func(content string) // the initial "brewing…" status message
+	final   func(content string) // edit of that message to the finished drink
+	blocked func(content string) // a brew that could not be served
+}
+
+// slashResponder responds publicly for /brew and /tea: a fresh public message
+// for brewing, edited to the final drink; blocks are ephemeral.
+func (m *Module) slashResponder(s *discordgo.Session, i *discordgo.InteractionCreate) brewResponder {
+	return brewResponder{
+		brewing: func(c string) { m.respond(s, i, c, false) },
+		final:   func(c string) { m.editDeferredResponse(s, i, c) },
+		blocked: func(c string) { m.respond(s, i, c, true) },
+	}
+}
+
+// menuResponder responds for the interactive menu: it updates the ephemeral
+// menu message in place (dropping its components) for every state, keeping the
+// whole order private to the invoker.
+func (m *Module) menuResponder(s *discordgo.Session, i *discordgo.InteractionCreate) brewResponder {
+	return brewResponder{
+		brewing: func(c string) { m.respondUpdate(s, i, c) },
+		final:   func(c string) { m.editDeferredResponse(s, i, c) },
+		blocked: func(c string) { m.respondUpdate(s, i, c) },
+	}
+}
+
+// handleBrewInteraction serves /brew. With no options it opens the interactive
+// drink menu; otherwise it brews the chosen drink directly.
 func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	data := i.ApplicationCommandData()
+	if len(data.Options) == 0 {
+		m.openBrewMenu(s, i)
+		return
+	}
 	drinkKey := menu[0].key
 	addMilk, addSugar := false, false
-	tea := ""
 	for _, o := range data.Options {
 		switch o.Name {
 		case "drink":
@@ -452,25 +748,50 @@ func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.Intera
 			addMilk = o.BoolValue()
 		case "sugar":
 			addSugar = o.BoolValue()
-		case "tea":
-			tea = o.StringValue()
 		}
 	}
+	m.executeBrew(s, i, drinkKey, addMilk, addSugar, "", m.slashResponder(s, i))
+}
 
+// handleTeaInteraction serves /tea: hot water with a chosen tea-bag flavor and
+// optional milk/sugar. Splitting tea out of /brew avoids tea options that only
+// make sense for one drink.
+func (m *Module) handleTeaInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	data := i.ApplicationCommandData()
+	tea := ""
+	addMilk, addSugar := false, false
+	for _, o := range data.Options {
+		switch o.Name {
+		case "flavor":
+			tea = o.StringValue()
+		case "milk":
+			addMilk = o.BoolValue()
+		case "sugar":
+			addSugar = o.BoolValue()
+		}
+	}
+	m.executeBrew(s, i, "hot_water", addMilk, addSugar, tea, m.slashResponder(s, i))
+}
+
+// executeBrew dispenses one drink and drives the brewing animation through the
+// supplied responder. tea is cosmetic and only applies to hot water.
+func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreate, drinkKey string, addMilk, addSugar bool, tea string, r brewResponder) {
 	out, err := m.dispense(i.GuildID, interactionUserID(i), drinkKey, addMilk, addSugar)
 	if err != nil {
 		slog.Error("coffee: dispense failed", "error", err)
-		m.respond(s, i, "The machine sputtered and failed. Try again later.", true)
+		r.blocked("The machine sputtered and failed. Try again later.")
 		return
 	}
 	if !out.ok {
 		// Blocked on a missing/low ingredient (or full grounds). Keep the exact
-		// fail message as the fallback so the slash-command hint stays correct.
+		// fail message (with any blame) as the fallback so the slash-command hint
+		// and user mention stay correct.
+		fallback := blockedFallback(out)
 		msg := m.generateInteractionMessage(s, i.ChannelID,
-			"The coffee machine cannot make the drink right now: "+out.failMsg+
-				" Tell the user in one short sentence and keep the slash command hint intact.",
-			out.failMsg)
-		m.respond(s, i, msg, true)
+			"The coffee machine cannot make the drink right now: "+fallback+
+				" Tell the user in one short sentence and keep the slash command hint and any user mention intact.",
+			fallback)
+		r.blocked(msg)
 		return
 	}
 
@@ -485,14 +806,17 @@ func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.Intera
 	brewing := m.generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("A user ordered a %s%s. Tell them it is brewing now, in one short sentence.", label, extras),
 		fmt.Sprintf("%s Brewing your %s%s…", drinkEmoji(out.recipe, tea), label, extras))
-	m.respond(s, i, brewing+" Ready "+ts, false)
+	r.brewing(brewing + " Ready " + ts)
 
 	m.sleep(wait)
 
 	final := m.generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("A freshly made %s%s is ready at the coffee machine. Announce it to the user in one short, inviting sentence.", label, extras),
 		formatDispenseSuccess(out.recipe, out.splashMilk, out.withSugar, tea))
-	m.editDeferredResponse(s, i, final)
+	// Append the service nudge verbatim (never paraphrased by the LLM) so the
+	// brewer who left the machine low is reminded to refill for the next person.
+	final += serviceHint(out.serviceNeeded)
+	r.final(final)
 }
 
 // handleMachineInteraction handles /coffeemachine refill|empty|status.
@@ -558,7 +882,134 @@ func (m *Module) handleMachineInteraction(s *discordgo.Session, i *discordgo.Int
 		}
 		drinkers, _ := m.topDrinkers(i.GuildID, 3)
 		refillers, _ := m.topRefillers(i.GuildID, 3)
-		groundsEmpties, _ := m.groundsEmptiedCount(i.GuildID)
-		m.respond(s, i, formatStatus(inv, drinkers, refillers, groundsEmpties), true)
+		emptiers, _ := m.topGroundsEmptiers(i.GuildID, 3)
+		slackers, _ := m.topSlackers(i.GuildID, 3)
+		m.respond(s, i, formatStatus(inv, drinkers, refillers, emptiers, slackers), true)
+
+	case "stats":
+		targetID := userID
+		for _, o := range sub.Options {
+			if o.Name == "user" {
+				if u := o.UserValue(s); u != nil {
+					targetID = u.ID
+				}
+			}
+		}
+		m.respond(s, i, m.buildUserStats(i.GuildID, targetID), true)
+	}
+}
+
+// buildUserStats gathers and renders the detailed per-user stat breakdown.
+func (m *Module) buildUserStats(guildID, userID string) string {
+	drinks, _ := m.userDrinkBreakdown(guildID, userID)
+	refills, _ := m.userRefillBreakdown(guildID, userID)
+	groundsCount, groundsTotal, _ := m.userGroundsStats(guildID, userID)
+	slackers, _ := m.userSlackerBreakdown(guildID, userID)
+	return formatUserStats(userID, drinks, refills, groundsCount, groundsTotal, slackers)
+}
+
+// --- Interactive /brew menu (no-options path) --------------------------------
+
+// brewCfgPrefix tags every interactive-menu component custom ID. The menu is
+// ephemeral, so only the invoker can see and operate its components.
+const brewCfgPrefix = "coffee_brew_cfg"
+
+const brewMenuPrompt = "☕ What can I get you? Pick a drink, toggle the extras, then hit **Brew**."
+
+// brewCfg is the full state of an in-progress interactive order, carried inside
+// every component custom ID so no server-side session state is needed.
+type brewCfg struct {
+	drink string
+	milk  bool
+	sugar bool
+}
+
+func boolFlag(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// encodeBrewCfg renders an action plus the current order state into a component
+// custom ID, e.g. "coffee_brew_cfg:milk:espresso:1:0".
+func encodeBrewCfg(action string, c brewCfg) string {
+	return strings.Join([]string{brewCfgPrefix, action, c.drink, boolFlag(c.milk), boolFlag(c.sugar)}, ":")
+}
+
+// parseBrewCfg reverses encodeBrewCfg. Drink keys never contain a colon.
+func parseBrewCfg(customID string) (action string, c brewCfg, ok bool) {
+	parts := strings.Split(customID, ":")
+	if len(parts) != 5 || parts[0] != brewCfgPrefix {
+		return "", brewCfg{}, false
+	}
+	return parts[1], brewCfg{drink: parts[2], milk: parts[3] == "1", sugar: parts[4] == "1"}, true
+}
+
+// brewMenuComponents builds the select menu and toggle/brew buttons reflecting
+// the given order state.
+func brewMenuComponents(c brewCfg) []discordgo.MessageComponent {
+	options := make([]discordgo.SelectMenuOption, 0, len(menu))
+	for _, r := range menu {
+		options = append(options, discordgo.SelectMenuOption{
+			Label:   r.label,
+			Value:   r.key,
+			Default: r.key == c.drink,
+		})
+	}
+
+	milkLabel, milkStyle := "🥛 Milk: off", discordgo.SecondaryButton
+	if c.milk {
+		milkLabel, milkStyle = "🥛 Milk: on", discordgo.SuccessButton
+	}
+	sugarLabel, sugarStyle := "🍬 Sugar: off", discordgo.SecondaryButton
+	if c.sugar {
+		sugarLabel, sugarStyle = "🍬 Sugar: on", discordgo.SuccessButton
+	}
+
+	return []discordgo.MessageComponent{
+		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+			discordgo.SelectMenu{
+				CustomID:    encodeBrewCfg("drink", c),
+				Placeholder: "Choose your drink",
+				Options:     options,
+			},
+		}},
+		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+			discordgo.Button{Label: milkLabel, Style: milkStyle, CustomID: encodeBrewCfg("milk", c)},
+			discordgo.Button{Label: sugarLabel, Style: sugarStyle, CustomID: encodeBrewCfg("sugar", c)},
+			discordgo.Button{Label: "Brew", Emoji: &discordgo.ComponentEmoji{Name: "☕"}, Style: discordgo.PrimaryButton, CustomID: encodeBrewCfg("go", c)},
+		}},
+	}
+}
+
+// openBrewMenu shows the interactive drink menu as an ephemeral message.
+func (m *Module) openBrewMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	c := brewCfg{drink: menu[0].key}
+	m.openMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+}
+
+// handleBrewComponent processes a click/selection on the interactive menu: drink
+// selection and milk/sugar toggles re-render the menu in place; Brew dispenses
+// the configured drink, updating the same ephemeral message.
+func (m *Module) handleBrewComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	action, c, ok := parseBrewCfg(i.MessageComponentData().CustomID)
+	if !ok {
+		return
+	}
+	switch action {
+	case "drink":
+		if vals := i.MessageComponentData().Values; len(vals) > 0 {
+			c.drink = vals[0]
+		}
+		m.updateMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+	case "milk":
+		c.milk = !c.milk
+		m.updateMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+	case "sugar":
+		c.sugar = !c.sugar
+		m.updateMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+	case "go":
+		m.executeBrew(s, i, c.drink, c.milk, c.sugar, "", m.menuResponder(s, i))
 	}
 }

--- a/internal/coffee/machine.go
+++ b/internal/coffee/machine.go
@@ -50,7 +50,8 @@ type recipe struct {
 	brewSecs   int  // simulated brew time, varies by drink
 }
 
-// menu is the ordered drink list. The first entry is the default for /brew.
+// menu is the ordered drink list. The first entry is the default for /coffee;
+// hot_water is served only via /tea.
 var menu = []recipe{
 	{key: "coffee", label: "Coffee", bean: beanMild, beanGrams: 11, waterMl: 120, groundsG: 20, allowsMilk: true, brewSecs: 28},
 	{key: "espresso", label: "Espresso", bean: beanEspresso, beanGrams: 9, waterMl: 40, groundsG: 18, allowsMilk: true, brewSecs: 24},
@@ -701,44 +702,43 @@ func titleCase(s string) string {
 }
 
 // brewResponder abstracts how a brew flow talks back to Discord so the same
-// dispense+animation logic serves both the public slash commands (/brew, /tea)
-// and the ephemeral interactive menu (component "go" button).
+// dispense+animation logic serves both the slash commands (/coffee, /tea) and
+// the interactive menus (component "go" button). Every brew is private to the
+// invoker.
 type brewResponder struct {
-	brewing func(content string) // the initial "brewing…" status message
-	final   func(content string) // edit of that message to the finished drink
-	blocked func(content string) // a brew that could not be served
+	brewing func(content string)                                     // the initial "brewing…" status message
+	final   func(content string, comps []discordgo.MessageComponent) // edit to the finished drink (carries the Take cup button)
+	blocked func(content string)                                     // a brew that could not be served
 }
 
-// slashResponder responds publicly for /brew and /tea: a fresh public message
-// for brewing, edited to the final drink; blocks are ephemeral.
-func (m *Module) slashResponder(s *discordgo.Session, i *discordgo.InteractionCreate) brewResponder {
-	return brewResponder{
-		brewing: func(c string) { m.respond(s, i, c, false) },
-		final:   func(c string) { m.editDeferredResponse(s, i, c) },
-		blocked: func(c string) { m.respond(s, i, c, true) },
+// brewResponder builds the responder used by both the slash commands and the
+// interactive menu. Every brew is private to the invoker: the slash path replies
+// ephemerally and edits that reply; the menu path updates its ephemeral message
+// in place. The final reveal carries the supplied components (the Take cup
+// button); brewing/blocked drop components.
+func (m *Module) brewResponder(s *discordgo.Session, i *discordgo.InteractionCreate, fromMenu bool) brewResponder {
+	r := brewResponder{
+		final: func(c string, comps []discordgo.MessageComponent) { m.editWithComponents(s, i, c, comps) },
 	}
-}
-
-// menuResponder responds for the interactive menu: it updates the ephemeral
-// menu message in place (dropping its components) for every state, keeping the
-// whole order private to the invoker.
-func (m *Module) menuResponder(s *discordgo.Session, i *discordgo.InteractionCreate) brewResponder {
-	return brewResponder{
-		brewing: func(c string) { m.respondUpdate(s, i, c) },
-		final:   func(c string) { m.editDeferredResponse(s, i, c) },
-		blocked: func(c string) { m.respondUpdate(s, i, c) },
+	if fromMenu {
+		r.brewing = func(c string) { m.respondUpdate(s, i, c) }
+		r.blocked = func(c string) { m.respondUpdate(s, i, c) }
+	} else {
+		r.brewing = func(c string) { m.respond(s, i, c, true) }
+		r.blocked = func(c string) { m.respond(s, i, c, true) }
 	}
+	return r
 }
 
-// handleBrewInteraction serves /brew. With no options it opens the interactive
-// drink menu; otherwise it brews the chosen drink directly.
-func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+// handleCoffeeInteraction serves /coffee. With no options it opens the
+// interactive drink menu; otherwise it brews the chosen coffee directly.
+func (m *Module) handleCoffeeInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	data := i.ApplicationCommandData()
 	if len(data.Options) == 0 {
-		m.openBrewMenu(s, i)
+		m.openCoffeeMenu(s, i)
 		return
 	}
-	drinkKey := menu[0].key
+	drinkKey := coffeeMenu()[0].key
 	addMilk, addSugar := false, false
 	for _, o := range data.Options {
 		switch o.Name {
@@ -750,15 +750,18 @@ func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.Intera
 			addSugar = o.BoolValue()
 		}
 	}
-	m.executeBrew(s, i, drinkKey, addMilk, addSugar, "", m.slashResponder(s, i))
+	m.executeBrew(s, i, drinkKey, addMilk, addSugar, "", m.brewResponder(s, i, false))
 }
 
 // handleTeaInteraction serves /tea: hot water with a chosen tea-bag flavor and
-// optional milk/sugar. Splitting tea out of /brew avoids tea options that only
-// make sense for one drink.
+// optional milk/sugar. With no options it opens the interactive tea menu.
 func (m *Module) handleTeaInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	data := i.ApplicationCommandData()
-	tea := ""
+	if len(data.Options) == 0 {
+		m.openTeaMenu(s, i)
+		return
+	}
+	tea := teaFlavors[0].key
 	addMilk, addSugar := false, false
 	for _, o := range data.Options {
 		switch o.Name {
@@ -770,7 +773,7 @@ func (m *Module) handleTeaInteraction(s *discordgo.Session, i *discordgo.Interac
 			addSugar = o.BoolValue()
 		}
 	}
-	m.executeBrew(s, i, "hot_water", addMilk, addSugar, tea, m.slashResponder(s, i))
+	m.executeBrew(s, i, "hot_water", addMilk, addSugar, tea, m.brewResponder(s, i, false))
 }
 
 // executeBrew dispenses one drink and drives the brewing animation through the
@@ -810,13 +813,15 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 
 	m.sleep(wait)
 
+	// The reply is private to the orderer, so the reveal is personal — their cup,
+	// for them to take — with a button to grab it out of the machine.
 	final := m.generateInteractionMessage(s, i.ChannelID,
-		fmt.Sprintf("A freshly made %s%s is ready at the coffee machine. Announce it to the user in one short, inviting sentence.", label, extras),
+		fmt.Sprintf("The user's own %s%s is ready in the machine. Tell them personally that their cup is ready to grab, in one short sentence.", label, extras),
 		formatDispenseSuccess(out.recipe, out.splashMilk, out.withSugar, tea))
 	// Append the service nudge verbatim (never paraphrased by the LLM) so the
 	// brewer who left the machine low is reminded to refill for the next person.
 	final += serviceHint(out.serviceNeeded)
-	r.final(final)
+	r.final(final, takeCupComponents(out.recipe.key, tea))
 }
 
 // handleMachineInteraction handles /coffeemachine refill|empty|status.
@@ -908,20 +913,42 @@ func (m *Module) buildUserStats(guildID, userID string) string {
 	return formatUserStats(userID, drinks, refills, groundsCount, groundsTotal, slackers)
 }
 
-// --- Interactive /brew menu (no-options path) --------------------------------
+// --- Interactive order menus (no-options /coffee and /tea) -------------------
 
-// brewCfgPrefix tags every interactive-menu component custom ID. The menu is
-// ephemeral, so only the invoker can see and operate its components.
-const brewCfgPrefix = "coffee_brew_cfg"
+// Component custom-ID prefixes. The menus are ephemeral, so only the invoker
+// can see and operate their components. coffeeCfgPrefix and teaCfgPrefix tag the
+// two order menus; takeCupPrefix tags the Take cup button on a finished drink.
+const (
+	coffeeCfgPrefix = "coffee_brew_cfg"
+	teaCfgPrefix    = "coffee_tea_cfg"
+	takeCupPrefix   = "coffee_take"
+)
 
-const brewMenuPrompt = "☕ What can I get you? Pick a drink, toggle the extras, then hit **Brew**."
+const (
+	coffeeMenuPrompt = "☕ What can I get you? Pick a coffee, toggle the extras, then hit **Brew**."
+	teaMenuPrompt    = "🍵 Fancy a tea? Pick a flavor, toggle the extras, then hit **Brew**."
+)
+
+// coffeeMenu returns the menu drinks offered by /coffee — everything but hot
+// water, which now lives behind /tea.
+func coffeeMenu() []recipe {
+	out := make([]recipe, 0, len(menu))
+	for _, r := range menu {
+		if r.key == "hot_water" {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
 
 // brewCfg is the full state of an in-progress interactive order, carried inside
-// every component custom ID so no server-side session state is needed.
+// every component custom ID so no server-side session state is needed. choice
+// holds a coffee drink key (coffee menu) or a tea flavor key (tea menu).
 type brewCfg struct {
-	drink string
-	milk  bool
-	sugar bool
+	choice string
+	milk   bool
+	sugar  bool
 }
 
 func boolFlag(b bool) string {
@@ -933,31 +960,22 @@ func boolFlag(b bool) string {
 
 // encodeBrewCfg renders an action plus the current order state into a component
 // custom ID, e.g. "coffee_brew_cfg:milk:espresso:1:0".
-func encodeBrewCfg(action string, c brewCfg) string {
-	return strings.Join([]string{brewCfgPrefix, action, c.drink, boolFlag(c.milk), boolFlag(c.sugar)}, ":")
+func encodeBrewCfg(prefix, action string, c brewCfg) string {
+	return strings.Join([]string{prefix, action, c.choice, boolFlag(c.milk), boolFlag(c.sugar)}, ":")
 }
 
-// parseBrewCfg reverses encodeBrewCfg. Drink keys never contain a colon.
-func parseBrewCfg(customID string) (action string, c brewCfg, ok bool) {
+// parseBrewCfg reverses encodeBrewCfg for the given prefix. Choice keys never
+// contain a colon.
+func parseBrewCfg(prefix, customID string) (action string, c brewCfg, ok bool) {
 	parts := strings.Split(customID, ":")
-	if len(parts) != 5 || parts[0] != brewCfgPrefix {
+	if len(parts) != 5 || parts[0] != prefix {
 		return "", brewCfg{}, false
 	}
-	return parts[1], brewCfg{drink: parts[2], milk: parts[3] == "1", sugar: parts[4] == "1"}, true
+	return parts[1], brewCfg{choice: parts[2], milk: parts[3] == "1", sugar: parts[4] == "1"}, true
 }
 
-// brewMenuComponents builds the select menu and toggle/brew buttons reflecting
-// the given order state.
-func brewMenuComponents(c brewCfg) []discordgo.MessageComponent {
-	options := make([]discordgo.SelectMenuOption, 0, len(menu))
-	for _, r := range menu {
-		options = append(options, discordgo.SelectMenuOption{
-			Label:   r.label,
-			Value:   r.key,
-			Default: r.key == c.drink,
-		})
-	}
-
+// extrasRow builds the milk/sugar toggle buttons and the Brew button for a menu.
+func extrasRow(prefix string, c brewCfg) discordgo.ActionsRow {
 	milkLabel, milkStyle := "🥛 Milk: off", discordgo.SecondaryButton
 	if c.milk {
 		milkLabel, milkStyle = "🥛 Milk: on", discordgo.SuccessButton
@@ -966,50 +984,135 @@ func brewMenuComponents(c brewCfg) []discordgo.MessageComponent {
 	if c.sugar {
 		sugarLabel, sugarStyle = "🍬 Sugar: on", discordgo.SuccessButton
 	}
+	return discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+		discordgo.Button{Label: milkLabel, Style: milkStyle, CustomID: encodeBrewCfg(prefix, "milk", c)},
+		discordgo.Button{Label: sugarLabel, Style: sugarStyle, CustomID: encodeBrewCfg(prefix, "sugar", c)},
+		discordgo.Button{Label: "Brew", Emoji: &discordgo.ComponentEmoji{Name: "☕"}, Style: discordgo.PrimaryButton, CustomID: encodeBrewCfg(prefix, "go", c)},
+	}}
+}
 
+// coffeeMenuComponents builds the /coffee drink select plus the extras row.
+func coffeeMenuComponents(c brewCfg) []discordgo.MessageComponent {
+	coffees := coffeeMenu()
+	options := make([]discordgo.SelectMenuOption, 0, len(coffees))
+	for _, r := range coffees {
+		options = append(options, discordgo.SelectMenuOption{Label: r.label, Value: r.key, Default: r.key == c.choice})
+	}
 	return []discordgo.MessageComponent{
 		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
-			discordgo.SelectMenu{
-				CustomID:    encodeBrewCfg("drink", c),
-				Placeholder: "Choose your drink",
-				Options:     options,
-			},
+			discordgo.SelectMenu{CustomID: encodeBrewCfg(coffeeCfgPrefix, "pick", c), Placeholder: "Choose your coffee", Options: options},
 		}},
+		extrasRow(coffeeCfgPrefix, c),
+	}
+}
+
+// teaMenuComponents builds the /tea flavor select plus the extras row.
+func teaMenuComponents(c brewCfg) []discordgo.MessageComponent {
+	options := make([]discordgo.SelectMenuOption, 0, len(teaFlavors))
+	for _, t := range teaFlavors {
+		options = append(options, discordgo.SelectMenuOption{Label: t.label, Value: t.key, Default: t.key == c.choice})
+	}
+	return []discordgo.MessageComponent{
 		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
-			discordgo.Button{Label: milkLabel, Style: milkStyle, CustomID: encodeBrewCfg("milk", c)},
-			discordgo.Button{Label: sugarLabel, Style: sugarStyle, CustomID: encodeBrewCfg("sugar", c)},
-			discordgo.Button{Label: "Brew", Emoji: &discordgo.ComponentEmoji{Name: "☕"}, Style: discordgo.PrimaryButton, CustomID: encodeBrewCfg("go", c)},
+			discordgo.SelectMenu{CustomID: encodeBrewCfg(teaCfgPrefix, "pick", c), Placeholder: "Choose your tea", Options: options},
+		}},
+		extrasRow(teaCfgPrefix, c),
+	}
+}
+
+// takeCupComponents builds the single-button row offering to grab a finished
+// drink out of the machine, encoding the drink so the confirmation can name it.
+func takeCupComponents(drinkKey, tea string) []discordgo.MessageComponent {
+	id := strings.Join([]string{takeCupPrefix, drinkKey, tea}, ":")
+	return []discordgo.MessageComponent{
+		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+			discordgo.Button{Label: "Take cup", Emoji: &discordgo.ComponentEmoji{Name: "🫴"}, Style: discordgo.SuccessButton, CustomID: id},
 		}},
 	}
 }
 
-// openBrewMenu shows the interactive drink menu as an ephemeral message.
-func (m *Module) openBrewMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	c := brewCfg{drink: menu[0].key}
-	m.openMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+// openCoffeeMenu shows the interactive coffee menu as an ephemeral message.
+func (m *Module) openCoffeeMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	c := brewCfg{choice: coffeeMenu()[0].key}
+	m.openMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
 }
 
-// handleBrewComponent processes a click/selection on the interactive menu: drink
-// selection and milk/sugar toggles re-render the menu in place; Brew dispenses
-// the configured drink, updating the same ephemeral message.
-func (m *Module) handleBrewComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	action, c, ok := parseBrewCfg(i.MessageComponentData().CustomID)
+// openTeaMenu shows the interactive tea menu as an ephemeral message.
+func (m *Module) openTeaMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	c := brewCfg{choice: teaFlavors[0].key}
+	m.openMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
+}
+
+// handleCoffeeComponent processes clicks on the interactive coffee menu: drink
+// selection and toggles re-render in place; Brew dispenses the configured drink.
+func (m *Module) handleCoffeeComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	action, c, ok := parseBrewCfg(coffeeCfgPrefix, i.MessageComponentData().CustomID)
 	if !ok {
 		return
 	}
 	switch action {
-	case "drink":
+	case "pick":
 		if vals := i.MessageComponentData().Values; len(vals) > 0 {
-			c.drink = vals[0]
+			c.choice = vals[0]
 		}
-		m.updateMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+		m.updateMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
 	case "milk":
 		c.milk = !c.milk
-		m.updateMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+		m.updateMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
 	case "sugar":
 		c.sugar = !c.sugar
-		m.updateMenu(s, i, brewMenuPrompt, brewMenuComponents(c))
+		m.updateMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
 	case "go":
-		m.executeBrew(s, i, c.drink, c.milk, c.sugar, "", m.menuResponder(s, i))
+		m.executeBrew(s, i, c.choice, c.milk, c.sugar, "", m.brewResponder(s, i, true))
 	}
+}
+
+// handleTeaComponent processes clicks on the interactive tea menu: flavor
+// selection and toggles re-render in place; Brew steeps the configured tea.
+func (m *Module) handleTeaComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	action, c, ok := parseBrewCfg(teaCfgPrefix, i.MessageComponentData().CustomID)
+	if !ok {
+		return
+	}
+	switch action {
+	case "pick":
+		if vals := i.MessageComponentData().Values; len(vals) > 0 {
+			c.choice = vals[0]
+		}
+		m.updateMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
+	case "milk":
+		c.milk = !c.milk
+		m.updateMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
+	case "sugar":
+		c.sugar = !c.sugar
+		m.updateMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
+	case "go":
+		m.executeBrew(s, i, "hot_water", c.milk, c.sugar, c.choice, m.brewResponder(s, i, true))
+	}
+}
+
+// handleTakeCupComponent acknowledges the Take cup button: it edits the private
+// drink message into a personal "grabbed it" confirmation and drops the button.
+func (m *Module) handleTakeCupComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	parts := strings.SplitN(i.MessageComponentData().CustomID, ":", 3)
+	drinkKey, tea := "", ""
+	if len(parts) >= 2 {
+		drinkKey = parts[1]
+	}
+	if len(parts) >= 3 {
+		tea = parts[2]
+	}
+	label := "drink"
+	if r, ok := recipeByKey(drinkKey); ok {
+		label = drinkLabel(r, tea)
+	}
+	m.respondUpdate(s, i, fmt.Sprintf("%s You grabbed your %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey, tea), label))
+}
+
+// drinkEmojiForKey is drinkEmoji by key, falling back to a coffee cup.
+func drinkEmojiForKey(drinkKey, tea string) string {
+	if r, ok := recipeByKey(drinkKey); ok {
+		return drinkEmoji(r, tea)
+	}
+	return "☕"
 }

--- a/internal/coffee/machine.go
+++ b/internal/coffee/machine.go
@@ -782,7 +782,7 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 	out, err := m.dispense(i.GuildID, interactionUserID(i), drinkKey, addMilk, addSugar)
 	if err != nil {
 		slog.Error("coffee: dispense failed", "error", err)
-		r.blocked("The machine sputtered and failed. Try again later.")
+		r.blocked(m.localizeUI(s, i.ChannelID, "The machine sputtered and failed. Try again later."))
 		return
 	}
 	if !out.ok {
@@ -817,12 +817,17 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 
 	// The reveal is public but personal: it names the orderer's own cup and
 	// carries a Take cup button that only they may press to grab it.
-	final := m.generateInteractionMessage(s, i.ChannelID,
-		fmt.Sprintf("The %s%s ordered by user <@%s> is ready in the machine. Announce to the channel that it is waiting for them to grab, in one short sentence, keeping the <@%s> mention.", label, extras, userID, userID),
-		fmt.Sprintf("%s <@%s>, your %s%s is ready — grab it!", drinkEmoji(out.recipe, tea), userID, label, extras))
-	// Append the service nudge verbatim (never paraphrased by the LLM) so the
-	// brewer who left the machine low is reminded to refill for the next person.
-	final += serviceHint(out.serviceNeeded)
+	readyFallback := fmt.Sprintf("%s <@%s>, your %s%s is ready — grab it!", drinkEmoji(out.recipe, tea), userID, label, extras)
+	scenario := fmt.Sprintf("The %s%s ordered by user <@%s> is ready in the machine. Announce to the channel that it is waiting for them to grab, in one short sentence, keeping the <@%s> mention.", label, extras, userID, userID)
+	// Fold the low-on-supplies nudge into the same generated message so it is
+	// translated alongside the ready announcement (instead of being appended as
+	// untranslated English); instruct the model to keep the exact command hints
+	// so /coffeemachine stays clickable.
+	hint := serviceHint(out.serviceNeeded)
+	if hint != "" {
+		scenario += " Also add a brief heads-up that the machine is running low: " + strings.TrimSpace(hint) + " Keep any `/coffeemachine` command and emoji exactly as written."
+	}
+	final := m.generateInteractionMessage(s, i.ChannelID, scenario, readyFallback+hint)
 	r.final(final, takeCupComponents(userID, out.recipe.key, tea))
 }
 
@@ -846,7 +851,7 @@ func (m *Module) handleMachineInteraction(s *discordgo.Session, i *discordgo.Int
 		out, err := m.refill(i.GuildID, userID, partKey)
 		if err != nil {
 			slog.Error("coffee: refill failed", "error", err)
-			m.respond(s, i, "The machine sputtered and failed. Try again later.", true)
+			m.respond(s, i, m.localizeUI(s, i.ChannelID, "The machine sputtered and failed. Try again later."), true)
 			return
 		}
 		if out.alreadyFull {
@@ -865,7 +870,7 @@ func (m *Module) handleMachineInteraction(s *discordgo.Session, i *discordgo.Int
 		out, err := m.emptyGrounds(i.GuildID, userID)
 		if err != nil {
 			slog.Error("coffee: empty grounds failed", "error", err)
-			m.respond(s, i, "The machine sputtered and failed. Try again later.", true)
+			m.respond(s, i, m.localizeUI(s, i.ChannelID, "The machine sputtered and failed. Try again later."), true)
 			return
 		}
 		if out.alreadyEmpty {
@@ -884,7 +889,7 @@ func (m *Module) handleMachineInteraction(s *discordgo.Session, i *discordgo.Int
 		inv, err := m.getOrSeedInventory(i.GuildID)
 		if err != nil {
 			slog.Error("coffee: status failed", "error", err)
-			m.respond(s, i, "The machine sputtered and failed. Try again later.", true)
+			m.respond(s, i, m.localizeUI(s, i.ChannelID, "The machine sputtered and failed. Try again later."), true)
 			return
 		}
 		drinkers, _ := m.topDrinkers(i.GuildID, 3)
@@ -985,7 +990,7 @@ func (m *Module) ensureOpener(s *discordgo.Session, i *discordgo.InteractionCrea
 	if interactionUserID(i) == opener {
 		return true
 	}
-	m.respond(s, i, "☕ That's not your order — run `/coffee` or `/tea` to start your own.", true)
+	m.respond(s, i, m.localizeUI(s, i.ChannelID, "☕ That's not your order — run `/coffee` or `/tea` to start your own."), true)
 	return false
 }
 
@@ -1050,13 +1055,13 @@ func takeCupComponents(opener, drinkKey, tea string) []discordgo.MessageComponen
 // openCoffeeMenu shows the interactive coffee menu, gated to its opener.
 func (m *Module) openCoffeeMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	c := brewCfg{opener: interactionUserID(i), choice: coffeeMenu()[0].key}
-	m.openMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
+	m.openMenu(s, i, m.localizeUI(s, i.ChannelID, coffeeMenuPrompt), coffeeMenuComponents(c))
 }
 
 // openTeaMenu shows the interactive tea menu, gated to its opener.
 func (m *Module) openTeaMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	c := brewCfg{opener: interactionUserID(i), choice: teaFlavors[0].key}
-	m.openMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
+	m.openMenu(s, i, m.localizeUI(s, i.ChannelID, teaMenuPrompt), teaMenuComponents(c))
 }
 
 // handleCoffeeComponent processes clicks on the interactive coffee menu: drink
@@ -1066,20 +1071,23 @@ func (m *Module) handleCoffeeComponent(s *discordgo.Session, i *discordgo.Intera
 	if !ok || !m.ensureOpener(s, i, c.opener) {
 		return
 	}
+	if action == "go" {
+		m.executeBrew(s, i, c.choice, c.milk, c.sugar, "", m.brewResponder(s, i, true))
+		return
+	}
+	prompt := m.localizeUI(s, i.ChannelID, coffeeMenuPrompt)
 	switch action {
 	case "pick":
 		if vals := i.MessageComponentData().Values; len(vals) > 0 {
 			c.choice = vals[0]
 		}
-		m.updateMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
+		m.updateMenu(s, i, prompt, coffeeMenuComponents(c))
 	case "milk":
 		c.milk = !c.milk
-		m.updateMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
+		m.updateMenu(s, i, prompt, coffeeMenuComponents(c))
 	case "sugar":
 		c.sugar = !c.sugar
-		m.updateMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
-	case "go":
-		m.executeBrew(s, i, c.choice, c.milk, c.sugar, "", m.brewResponder(s, i, true))
+		m.updateMenu(s, i, prompt, coffeeMenuComponents(c))
 	}
 }
 
@@ -1090,20 +1098,23 @@ func (m *Module) handleTeaComponent(s *discordgo.Session, i *discordgo.Interacti
 	if !ok || !m.ensureOpener(s, i, c.opener) {
 		return
 	}
+	if action == "go" {
+		m.executeBrew(s, i, "hot_water", c.milk, c.sugar, c.choice, m.brewResponder(s, i, true))
+		return
+	}
+	prompt := m.localizeUI(s, i.ChannelID, teaMenuPrompt)
 	switch action {
 	case "pick":
 		if vals := i.MessageComponentData().Values; len(vals) > 0 {
 			c.choice = vals[0]
 		}
-		m.updateMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
+		m.updateMenu(s, i, prompt, teaMenuComponents(c))
 	case "milk":
 		c.milk = !c.milk
-		m.updateMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
+		m.updateMenu(s, i, prompt, teaMenuComponents(c))
 	case "sugar":
 		c.sugar = !c.sugar
-		m.updateMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
-	case "go":
-		m.executeBrew(s, i, "hot_water", c.milk, c.sugar, c.choice, m.brewResponder(s, i, true))
+		m.updateMenu(s, i, prompt, teaMenuComponents(c))
 	}
 }
 
@@ -1129,7 +1140,10 @@ func (m *Module) handleTakeCupComponent(s *discordgo.Session, i *discordgo.Inter
 	if r, ok := recipeByKey(drinkKey); ok {
 		label = drinkLabel(r, tea)
 	}
-	m.respondUpdate(s, i, fmt.Sprintf("%s <@%s> grabbed their %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey, tea), opener, label))
+	msg := m.generateInteractionMessage(s, i.ChannelID,
+		fmt.Sprintf("User <@%s> just grabbed their %s out of the coffee machine. Tell the channel to enjoy it, in one short sentence, keeping the <@%s> mention.", opener, label, opener),
+		fmt.Sprintf("%s <@%s> grabbed their %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey, tea), opener, label))
+	m.respondUpdate(s, i, msg)
 }
 
 // drinkEmojiForKey is drinkEmoji by key, falling back to a coffee cup.

--- a/internal/coffee/machine.go
+++ b/internal/coffee/machine.go
@@ -703,8 +703,8 @@ func titleCase(s string) string {
 
 // brewResponder abstracts how a brew flow talks back to Discord so the same
 // dispense+animation logic serves both the slash commands (/coffee, /tea) and
-// the interactive menus (component "go" button). Every brew is private to the
-// invoker.
+// the interactive menus (component "go" button). Brewing, readiness, and blocks
+// are all public so the channel can see who is at the machine.
 type brewResponder struct {
 	brewing func(content string)                                     // the initial "brewing…" status message
 	final   func(content string, comps []discordgo.MessageComponent) // edit to the finished drink (carries the Take cup button)
@@ -712,10 +712,10 @@ type brewResponder struct {
 }
 
 // brewResponder builds the responder used by both the slash commands and the
-// interactive menu. Every brew is private to the invoker: the slash path replies
-// ephemerally and edits that reply; the menu path updates its ephemeral message
-// in place. The final reveal carries the supplied components (the Take cup
-// button); brewing/blocked drop components.
+// interactive menu. Output is public either way: the slash path posts a public
+// reply and edits it; the menu path edits its (public) menu message in place.
+// The final reveal carries the supplied components (the Take cup button);
+// brewing/blocked drop components.
 func (m *Module) brewResponder(s *discordgo.Session, i *discordgo.InteractionCreate, fromMenu bool) brewResponder {
 	r := brewResponder{
 		final: func(c string, comps []discordgo.MessageComponent) { m.editWithComponents(s, i, c, comps) },
@@ -724,8 +724,8 @@ func (m *Module) brewResponder(s *discordgo.Session, i *discordgo.InteractionCre
 		r.brewing = func(c string) { m.respondUpdate(s, i, c) }
 		r.blocked = func(c string) { m.respondUpdate(s, i, c) }
 	} else {
-		r.brewing = func(c string) { m.respond(s, i, c, true) }
-		r.blocked = func(c string) { m.respond(s, i, c, true) }
+		r.brewing = func(c string) { m.respond(s, i, c, false) }
+		r.blocked = func(c string) { m.respond(s, i, c, false) }
 	}
 	return r
 }
@@ -800,28 +800,30 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 
 	label := drinkLabel(out.recipe, tea)
 	extras := extrasSuffix(out.splashMilk, out.withSugar)
+	userID := interactionUserID(i)
 
-	// Real machines take a few seconds; show a brewing status with a Discord
-	// relative-time countdown, then reveal the finished drink. Wait varies by drink.
+	// Real machines take a few seconds; show a public brewing status with a
+	// Discord relative-time countdown naming the orderer, then reveal the
+	// finished drink. Wait varies by drink.
 	wait := brewTime(out.recipe)
 	readyAt := m.nowFunc().Add(wait)
 	ts := fmt.Sprintf("<t:%d:R>", readyAt.Unix())
 	brewing := m.generateInteractionMessage(s, i.ChannelID,
-		fmt.Sprintf("A user ordered a %s%s. Tell them it is brewing now, in one short sentence.", label, extras),
-		fmt.Sprintf("%s Brewing your %s%s…", drinkEmoji(out.recipe, tea), label, extras))
+		fmt.Sprintf("User <@%s> ordered a %s%s. Tell the channel it is brewing for them now, in one short sentence, keeping the <@%s> mention.", userID, label, extras, userID),
+		fmt.Sprintf("%s Brewing <@%s>'s %s%s…", drinkEmoji(out.recipe, tea), userID, label, extras))
 	r.brewing(brewing + " Ready " + ts)
 
 	m.sleep(wait)
 
-	// The reply is private to the orderer, so the reveal is personal — their cup,
-	// for them to take — with a button to grab it out of the machine.
+	// The reveal is public but personal: it names the orderer's own cup and
+	// carries a Take cup button that only they may press to grab it.
 	final := m.generateInteractionMessage(s, i.ChannelID,
-		fmt.Sprintf("The user's own %s%s is ready in the machine. Tell them personally that their cup is ready to grab, in one short sentence.", label, extras),
-		formatDispenseSuccess(out.recipe, out.splashMilk, out.withSugar, tea))
+		fmt.Sprintf("The %s%s ordered by user <@%s> is ready in the machine. Announce to the channel that it is waiting for them to grab, in one short sentence, keeping the <@%s> mention.", label, extras, userID, userID),
+		fmt.Sprintf("%s <@%s>, your %s%s is ready — grab it!", drinkEmoji(out.recipe, tea), userID, label, extras))
 	// Append the service nudge verbatim (never paraphrased by the LLM) so the
 	// brewer who left the machine low is reminded to refill for the next person.
 	final += serviceHint(out.serviceNeeded)
-	r.final(final, takeCupComponents(out.recipe.key, tea))
+	r.final(final, takeCupComponents(userID, out.recipe.key, tea))
 }
 
 // handleMachineInteraction handles /coffeemachine refill|empty|status.
@@ -915,9 +917,10 @@ func (m *Module) buildUserStats(guildID, userID string) string {
 
 // --- Interactive order menus (no-options /coffee and /tea) -------------------
 
-// Component custom-ID prefixes. The menus are ephemeral, so only the invoker
-// can see and operate their components. coffeeCfgPrefix and teaCfgPrefix tag the
-// two order menus; takeCupPrefix tags the Take cup button on a finished drink.
+// Component custom-ID prefixes. The menus are public, so every custom ID also
+// carries the opener's user ID and only they may operate the components.
+// coffeeCfgPrefix and teaCfgPrefix tag the two order menus; takeCupPrefix tags
+// the Take cup button on a finished drink.
 const (
 	coffeeCfgPrefix = "coffee_brew_cfg"
 	teaCfgPrefix    = "coffee_tea_cfg"
@@ -943,9 +946,11 @@ func coffeeMenu() []recipe {
 }
 
 // brewCfg is the full state of an in-progress interactive order, carried inside
-// every component custom ID so no server-side session state is needed. choice
-// holds a coffee drink key (coffee menu) or a tea flavor key (tea menu).
+// every component custom ID so no server-side session state is needed. opener is
+// the user who started the menu (only they may operate it); choice holds a
+// coffee drink key (coffee menu) or a tea flavor key (tea menu).
 type brewCfg struct {
+	opener string
 	choice string
 	milk   bool
 	sugar  bool
@@ -959,19 +964,29 @@ func boolFlag(b bool) string {
 }
 
 // encodeBrewCfg renders an action plus the current order state into a component
-// custom ID, e.g. "coffee_brew_cfg:milk:espresso:1:0".
+// custom ID, e.g. "coffee_brew_cfg:milk:42:espresso:1:0".
 func encodeBrewCfg(prefix, action string, c brewCfg) string {
-	return strings.Join([]string{prefix, action, c.choice, boolFlag(c.milk), boolFlag(c.sugar)}, ":")
+	return strings.Join([]string{prefix, action, c.opener, c.choice, boolFlag(c.milk), boolFlag(c.sugar)}, ":")
 }
 
-// parseBrewCfg reverses encodeBrewCfg for the given prefix. Choice keys never
-// contain a colon.
+// parseBrewCfg reverses encodeBrewCfg for the given prefix. Opener IDs and choice
+// keys never contain a colon.
 func parseBrewCfg(prefix, customID string) (action string, c brewCfg, ok bool) {
 	parts := strings.Split(customID, ":")
-	if len(parts) != 5 || parts[0] != prefix {
+	if len(parts) != 6 || parts[0] != prefix {
 		return "", brewCfg{}, false
 	}
-	return parts[1], brewCfg{choice: parts[2], milk: parts[3] == "1", sugar: parts[4] == "1"}, true
+	return parts[1], brewCfg{opener: parts[2], choice: parts[3], milk: parts[4] == "1", sugar: parts[5] == "1"}, true
+}
+
+// ensureOpener reports whether the clicking user owns this order; if not, it
+// nudges them ephemerally and returns false.
+func (m *Module) ensureOpener(s *discordgo.Session, i *discordgo.InteractionCreate, opener string) bool {
+	if interactionUserID(i) == opener {
+		return true
+	}
+	m.respond(s, i, "☕ That's not your order — run `/coffee` or `/tea` to start your own.", true)
+	return false
 }
 
 // extrasRow builds the milk/sugar toggle buttons and the Brew button for a menu.
@@ -1021,9 +1036,10 @@ func teaMenuComponents(c brewCfg) []discordgo.MessageComponent {
 }
 
 // takeCupComponents builds the single-button row offering to grab a finished
-// drink out of the machine, encoding the drink so the confirmation can name it.
-func takeCupComponents(drinkKey, tea string) []discordgo.MessageComponent {
-	id := strings.Join([]string{takeCupPrefix, drinkKey, tea}, ":")
+// drink out of the machine. The custom ID carries the orderer (only they may
+// take it) and the drink so the confirmation can name it.
+func takeCupComponents(opener, drinkKey, tea string) []discordgo.MessageComponent {
+	id := strings.Join([]string{takeCupPrefix, opener, drinkKey, tea}, ":")
 	return []discordgo.MessageComponent{
 		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
 			discordgo.Button{Label: "Take cup", Emoji: &discordgo.ComponentEmoji{Name: "🫴"}, Style: discordgo.SuccessButton, CustomID: id},
@@ -1031,15 +1047,15 @@ func takeCupComponents(drinkKey, tea string) []discordgo.MessageComponent {
 	}
 }
 
-// openCoffeeMenu shows the interactive coffee menu as an ephemeral message.
+// openCoffeeMenu shows the interactive coffee menu, gated to its opener.
 func (m *Module) openCoffeeMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	c := brewCfg{choice: coffeeMenu()[0].key}
+	c := brewCfg{opener: interactionUserID(i), choice: coffeeMenu()[0].key}
 	m.openMenu(s, i, coffeeMenuPrompt, coffeeMenuComponents(c))
 }
 
-// openTeaMenu shows the interactive tea menu as an ephemeral message.
+// openTeaMenu shows the interactive tea menu, gated to its opener.
 func (m *Module) openTeaMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	c := brewCfg{choice: teaFlavors[0].key}
+	c := brewCfg{opener: interactionUserID(i), choice: teaFlavors[0].key}
 	m.openMenu(s, i, teaMenuPrompt, teaMenuComponents(c))
 }
 
@@ -1047,7 +1063,7 @@ func (m *Module) openTeaMenu(s *discordgo.Session, i *discordgo.InteractionCreat
 // selection and toggles re-render in place; Brew dispenses the configured drink.
 func (m *Module) handleCoffeeComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	action, c, ok := parseBrewCfg(coffeeCfgPrefix, i.MessageComponentData().CustomID)
-	if !ok {
+	if !ok || !m.ensureOpener(s, i, c.opener) {
 		return
 	}
 	switch action {
@@ -1071,7 +1087,7 @@ func (m *Module) handleCoffeeComponent(s *discordgo.Session, i *discordgo.Intera
 // selection and toggles re-render in place; Brew steeps the configured tea.
 func (m *Module) handleTeaComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	action, c, ok := parseBrewCfg(teaCfgPrefix, i.MessageComponentData().CustomID)
-	if !ok {
+	if !ok || !m.ensureOpener(s, i, c.opener) {
 		return
 	}
 	switch action {
@@ -1091,22 +1107,29 @@ func (m *Module) handleTeaComponent(s *discordgo.Session, i *discordgo.Interacti
 	}
 }
 
-// handleTakeCupComponent acknowledges the Take cup button: it edits the private
-// drink message into a personal "grabbed it" confirmation and drops the button.
+// handleTakeCupComponent acknowledges the Take cup button: only the orderer may
+// take it. It edits the public drink message into a personal "grabbed it"
+// confirmation and drops the button.
 func (m *Module) handleTakeCupComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	parts := strings.SplitN(i.MessageComponentData().CustomID, ":", 3)
-	drinkKey, tea := "", ""
+	parts := strings.SplitN(i.MessageComponentData().CustomID, ":", 4)
+	opener, drinkKey, tea := "", "", ""
 	if len(parts) >= 2 {
-		drinkKey = parts[1]
+		opener = parts[1]
 	}
 	if len(parts) >= 3 {
-		tea = parts[2]
+		drinkKey = parts[2]
+	}
+	if len(parts) >= 4 {
+		tea = parts[3]
+	}
+	if !m.ensureOpener(s, i, opener) {
+		return
 	}
 	label := "drink"
 	if r, ok := recipeByKey(drinkKey); ok {
 		label = drinkLabel(r, tea)
 	}
-	m.respondUpdate(s, i, fmt.Sprintf("%s You grabbed your %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey, tea), label))
+	m.respondUpdate(s, i, fmt.Sprintf("%s <@%s> grabbed their %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey, tea), opener, label))
 }
 
 // drinkEmojiForKey is drinkEmoji by key, falling back to a coffee cup.

--- a/internal/coffee/machine.go
+++ b/internal/coffee/machine.go
@@ -27,6 +27,10 @@ const (
 
 	// partGrounds is the RefillEvent.Part value denoting a grounds-empty action.
 	partGrounds = "grounds"
+
+	// Tea bag stock levels per variety. Seeded at first use; capped at max.
+	maxTeaBagsPerFlavor  = 50
+	seedTeaBagsPerFlavor = 20
 )
 
 type beanType int
@@ -50,15 +54,102 @@ type recipe struct {
 	brewSecs   int  // simulated brew time, varies by drink
 }
 
-// menu is the ordered drink list. The first entry is the default for /coffee;
-// hot_water is served only via /tea.
-var menu = []recipe{
+// coffeeRecipes are the espresso-machine drinks. The first entry is the default
+// for /brew when no drink is specified.
+var coffeeRecipes = []recipe{
 	{key: "coffee", label: "Coffee", bean: beanMild, beanGrams: 11, waterMl: 120, groundsG: 20, allowsMilk: true, brewSecs: 28},
 	{key: "espresso", label: "Espresso", bean: beanEspresso, beanGrams: 9, waterMl: 40, groundsG: 18, allowsMilk: true, brewSecs: 24},
 	{key: "milk_coffee", label: "Milk coffee", bean: beanMild, beanGrams: 11, waterMl: 80, milkMl: 120, groundsG: 20, brewSecs: 32},
 	{key: "latte_macchiato", label: "Latte macchiato", bean: beanEspresso, beanGrams: 9, waterMl: 40, milkMl: 180, groundsG: 18, brewSecs: 36},
 	{key: "flat_white", label: "Flat white", bean: beanEspresso, beanGrams: 18, waterMl: 60, milkMl: 120, groundsG: 36, brewSecs: 40},
-	{key: "hot_water", label: "Hot water", bean: beanNone, waterMl: 200, allowsMilk: true, brewSecs: 20},
+}
+
+// teaFlavor describes a tracked tea variety. Each consumes 1 tea bag and 200 ml
+// water per brew and is stored in TeaBagInventory keyed by flavor.key.
+type teaFlavor struct {
+	key   string
+	label string
+}
+
+var teaFlavors = []teaFlavor{
+	{key: "black", label: "Black"},
+	{key: "green", label: "Green"},
+	{key: "earl_grey", label: "Earl Grey"},
+	{key: "peppermint", label: "Peppermint"},
+	{key: "chamomile", label: "Chamomile"},
+	{key: "rooibos", label: "Rooibos"},
+	{key: "fennel", label: "Fennel"},
+}
+
+// teaFlavorLabel returns the display label for a tea flavor key, or the key
+// itself when unknown.
+func teaFlavorLabel(flavor string) string {
+	for _, t := range teaFlavors {
+		if t.key == flavor {
+			return t.label
+		}
+	}
+	return flavor
+}
+
+// menu is the full ordered drink list: coffee recipes followed by tea recipes.
+// Built in init so tea recipes are derived from teaFlavors.
+var menu []recipe
+
+// refillParts are the machine tanks/hoppers refillable via /coffeemachine refill.
+// teaRefillParts are appended in init from teaFlavors.
+var (
+	machineRefillParts = []refillPart{
+		{key: "beans_mild", label: "Mild beans", max: maxBeansMildG, unit: "g"},
+		{key: "beans_espresso", label: "Espresso beans", max: maxBeansEspressoG, unit: "g"},
+		{key: "water", label: "Water", max: maxWaterMl, unit: "ml"},
+		{key: "milk", label: "Milk", max: maxMilkMl, unit: "ml"},
+	}
+	teaRefillParts []refillPart
+	refillParts    []refillPart // machineRefillParts + teaRefillParts, built in init
+)
+
+func init() {
+	// Build full drink menu: coffee recipes + one recipe per tea flavor.
+	menu = make([]recipe, len(coffeeRecipes))
+	copy(menu, coffeeRecipes)
+	for _, t := range teaFlavors {
+		menu = append(menu, recipe{
+			key:        "tea_" + t.key,
+			label:      t.label + " tea",
+			waterMl:    200,
+			allowsMilk: true,
+			brewSecs:   20,
+		})
+	}
+
+	// Build tea refill parts list.
+	for _, t := range teaFlavors {
+		teaRefillParts = append(teaRefillParts, refillPart{
+			key:   "tea_" + t.key,
+			label: "Tea bags (" + t.label + ")",
+			max:   maxTeaBagsPerFlavor,
+			unit:  " bags",
+		})
+	}
+	refillParts = append(machineRefillParts, teaRefillParts...)
+}
+
+// refillPart describes a refillable tank/hopper or tea bag variety.
+type refillPart struct {
+	key   string // choice value, also RefillEvent.Part
+	label string
+	max   int
+	unit  string // "g", "ml", or " bags"
+}
+
+func refillPartByKey(key string) (refillPart, bool) {
+	for _, p := range refillParts {
+		if p.key == key {
+			return p, true
+		}
+	}
+	return refillPart{}, false
 }
 
 // brewTime is how long the machine pretends to take dispensing a drink.
@@ -75,62 +166,14 @@ func recipeByKey(key string) (recipe, bool) {
 	return recipe{}, false
 }
 
-// teaFlavor is an optional tea-bag flavor for the hot-water drink. Tea is
-// cosmetic: it flavors the cup but consumes no tracked inventory.
-type teaFlavor struct {
-	key   string
-	label string
-}
-
-var teaFlavors = []teaFlavor{
-	{key: "black", label: "Black"},
-	{key: "green", label: "Green"},
-	{key: "earl_grey", label: "Earl Grey"},
-	{key: "peppermint", label: "Peppermint"},
-	{key: "chamomile", label: "Chamomile"},
-	{key: "rooibos", label: "Rooibos"},
-	{key: "fennel", label: "Fennel"},
-}
-
-// teaLabel returns the display label for a tea-flavor key.
-func teaLabel(key string) (string, bool) {
-	for _, t := range teaFlavors {
-		if t.key == key {
-			return t.label, true
-		}
-	}
-	return "", false
-}
-
-// refillPart describes a refillable tank/hopper exposed by /coffeemachine refill.
-type refillPart struct {
-	key   string // choice value, also RefillEvent.Part
-	label string
-	max   int
-	unit  string // "g" or "ml"
-}
-
-var refillParts = []refillPart{
-	{key: "beans_mild", label: "Mild beans", max: maxBeansMildG, unit: "g"},
-	{key: "beans_espresso", label: "Espresso beans", max: maxBeansEspressoG, unit: "g"},
-	{key: "water", label: "Water", max: maxWaterMl, unit: "ml"},
-	{key: "milk", label: "Milk", max: maxMilkMl, unit: "ml"},
-}
-
-func refillPartByKey(key string) (refillPart, bool) {
-	for _, p := range refillParts {
-		if p.key == key {
-			return p, true
-		}
-	}
-	return refillPart{}, false
-}
-
 // partLabel returns a human-facing name for a refillable part or the grounds
 // container.
 func partLabel(key string) string {
 	if key == partGrounds {
 		return "grounds container"
+	}
+	if flavor, ok := strings.CutPrefix(key, "tea_"); ok {
+		return strings.ToLower(teaFlavorLabel(flavor)) + " tea bags"
 	}
 	if p, ok := refillPartByKey(key); ok {
 		return strings.ToLower(p.label)
@@ -262,6 +305,12 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 
 	out := dispenseOutcome{recipe: r, splashMilk: splashMilk, withSugar: addSugar}
 
+	// For tea drinks, extract the flavor key so we can check/deduct tea bags.
+	teaBagFlavor, isTea := strings.CutPrefix(drinkKey, "tea_")
+	if !isTea {
+		teaBagFlavor = ""
+	}
+
 	m.machineMu.Lock()
 	defer m.machineMu.Unlock()
 
@@ -269,6 +318,16 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 		inv, e := seedInventoryTx(tx, guildID)
 		if e != nil {
 			return e
+		}
+
+		// Load tea bag inventory up front so we can check stock in the switch below.
+		var teaBag *TeaBagInventory
+		if teaBagFlavor != "" {
+			tb, e2 := getOrSeedTeaBagTx(tx, guildID, teaBagFlavor)
+			if e2 != nil {
+				return e2
+			}
+			teaBag = &tb
 		}
 
 		blockPart := ""
@@ -283,6 +342,10 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 			out.failMsg, blockPart = outOfMsg("milk", "milk"), "milk"
 		case inv.GroundsGrams+r.groundsG > maxGroundsG:
 			out.failMsg, blockPart = "The grounds container is full. Empty it with `/coffeemachine empty`.", partGrounds
+		case teaBag != nil && teaBag.Count < 1:
+			partKey := "tea_" + teaBagFlavor
+			out.failMsg = outOfMsg(teaFlavorLabel(teaBagFlavor)+" tea bags", partKey)
+			blockPart = partKey
 		}
 		if out.failMsg != "" {
 			out.inventory = inv
@@ -309,6 +372,15 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 		if e = tx.Save(&inv).Error; e != nil {
 			return e
 		}
+
+		// Deduct one tea bag and flag service if now empty.
+		if teaBag != nil {
+			teaBag.Count--
+			if e = tx.Save(teaBag).Error; e != nil {
+				return e
+			}
+		}
+
 		if e = tx.Create(&DrinkEvent{
 			GuildID:   guildID,
 			UserID:    userID,
@@ -321,6 +393,9 @@ func (m *Module) dispense(guildID, userID, drinkKey string, addMilk, addSugar bo
 		// Record which parts this brew left needing service and pin the brewer as
 		// responsible, so a later blocked brew can blame them.
 		out.serviceNeeded = partsNeedingService(inv)
+		if teaBag != nil && teaBag.Count == 0 {
+			out.serviceNeeded = append(out.serviceNeeded, "tea_"+teaBagFlavor)
+		}
 		for _, p := range out.serviceNeeded {
 			if e = setPendingServiceTx(tx, guildID, p, userID); e != nil {
 				return e
@@ -495,21 +570,12 @@ func percent(cur, max int) int {
 	return int(math.Round(float64(cur) / float64(max) * 100))
 }
 
-// drinkLabel is the display name for a served drink. A non-empty tea flavor
-// turns hot water into the named tea (ignored for any other drink).
-func drinkLabel(r recipe, tea string) string {
-	if r.key == "hot_water" && tea != "" {
-		if tl, ok := teaLabel(tea); ok {
-			return tl + " tea"
-		}
-		return "tea"
-	}
-	return r.label
-}
+// drinkLabel is the display name for a served drink.
+func drinkLabel(r recipe) string { return r.label }
 
 // drinkEmoji picks the cup emoji for a served drink.
-func drinkEmoji(r recipe, tea string) string {
-	if r.key == "hot_water" && tea != "" {
+func drinkEmoji(r recipe) string {
+	if strings.HasPrefix(r.key, "tea_") {
 		return "🍵"
 	}
 	return "☕"
@@ -532,8 +598,8 @@ func extrasSuffix(splashMilk, withSugar bool) string {
 
 // formatDispenseSuccess builds the deterministic fallback confirmation for a
 // served drink (no machine stats — those live in /coffeemachine status).
-func formatDispenseSuccess(r recipe, splashMilk, withSugar bool, tea string) string {
-	return fmt.Sprintf("%s Here's your %s%s!", drinkEmoji(r, tea), drinkLabel(r, tea), extrasSuffix(splashMilk, withSugar))
+func formatDispenseSuccess(r recipe, splashMilk, withSugar bool) string {
+	return fmt.Sprintf("%s Here's your %s%s!", drinkEmoji(r), drinkLabel(r), extrasSuffix(splashMilk, withSugar))
 }
 
 // humanJoin renders a slice as "a", "a and b", or "a, b and c".
@@ -594,7 +660,7 @@ func blockedFallback(out dispenseOutcome) string {
 // formatStatus renders the machine status, levels, and stat leaderboards. The
 // per-drink and per-part breakdowns live in /coffeemachine stats; this view
 // keeps one headline number per leaderboard.
-func formatStatus(inv MachineInventory, drinkers, refillers []userCount, emptiers []groundsEmptier, slackers []userCount) string {
+func formatStatus(inv MachineInventory, drinkers, refillers []userCount, emptiers []groundsEmptier, slackers []userCount, teaBags []TeaBagInventory) string {
 	var sb strings.Builder
 	sb.WriteString("☕ **Coffee machine status**\n")
 	fmt.Fprintf(&sb, "Mild beans: %d/%dg (%d%%)\n", inv.BeansMildGrams, maxBeansMildG, percent(inv.BeansMildGrams, maxBeansMildG))
@@ -602,6 +668,15 @@ func formatStatus(inv MachineInventory, drinkers, refillers []userCount, emptier
 	fmt.Fprintf(&sb, "Water: %d/%dml (%d%%)\n", inv.WaterMl, maxWaterMl, percent(inv.WaterMl, maxWaterMl))
 	fmt.Fprintf(&sb, "Milk: %d/%dml (%d%%)\n", inv.MilkMl, maxMilkMl, percent(inv.MilkMl, maxMilkMl))
 	fmt.Fprintf(&sb, "Grounds: %d/%dg (%d%%)\n", inv.GroundsGrams, maxGroundsG, percent(inv.GroundsGrams, maxGroundsG))
+
+	if len(teaBags) > 0 {
+		sb.WriteString("\n**Tea bags**\n")
+		for _, tb := range teaBags {
+			fmt.Fprintf(&sb, "🍵 %s: %d/%d bags (%d%%)\n",
+				teaFlavorLabel(tb.Flavor)+" tea", tb.Count, maxTeaBagsPerFlavor,
+				percent(tb.Count, maxTeaBagsPerFlavor))
+		}
+	}
 
 	sb.WriteString("\n**Top baristas**\n")
 	if len(drinkers) == 0 {
@@ -730,15 +805,15 @@ func (m *Module) brewResponder(s *discordgo.Session, i *discordgo.InteractionCre
 	return r
 }
 
-// handleCoffeeInteraction serves /coffee. With no options it opens the
-// interactive drink menu; otherwise it brews the chosen coffee directly.
-func (m *Module) handleCoffeeInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+// handleBrewInteraction serves /brew. With no options it opens the interactive
+// drink menu (coffees + teas); otherwise it brews the chosen drink directly.
+func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	data := i.ApplicationCommandData()
 	if len(data.Options) == 0 {
-		m.openCoffeeMenu(s, i)
+		m.openBrewMenu(s, i)
 		return
 	}
-	drinkKey := coffeeMenu()[0].key
+	drinkKey := menu[0].key
 	addMilk, addSugar := false, false
 	for _, o := range data.Options {
 		switch o.Name {
@@ -750,35 +825,12 @@ func (m *Module) handleCoffeeInteraction(s *discordgo.Session, i *discordgo.Inte
 			addSugar = o.BoolValue()
 		}
 	}
-	m.executeBrew(s, i, drinkKey, addMilk, addSugar, "", m.brewResponder(s, i, false))
-}
-
-// handleTeaInteraction serves /tea: hot water with a chosen tea-bag flavor and
-// optional milk/sugar. With no options it opens the interactive tea menu.
-func (m *Module) handleTeaInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	data := i.ApplicationCommandData()
-	if len(data.Options) == 0 {
-		m.openTeaMenu(s, i)
-		return
-	}
-	tea := teaFlavors[0].key
-	addMilk, addSugar := false, false
-	for _, o := range data.Options {
-		switch o.Name {
-		case "flavor":
-			tea = o.StringValue()
-		case "milk":
-			addMilk = o.BoolValue()
-		case "sugar":
-			addSugar = o.BoolValue()
-		}
-	}
-	m.executeBrew(s, i, "hot_water", addMilk, addSugar, tea, m.brewResponder(s, i, false))
+	m.executeBrew(s, i, drinkKey, addMilk, addSugar, m.brewResponder(s, i, false))
 }
 
 // executeBrew dispenses one drink and drives the brewing animation through the
-// supplied responder. tea is cosmetic and only applies to hot water.
-func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreate, drinkKey string, addMilk, addSugar bool, tea string, r brewResponder) {
+// supplied responder.
+func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreate, drinkKey string, addMilk, addSugar bool, r brewResponder) {
 	out, err := m.dispense(i.GuildID, interactionUserID(i), drinkKey, addMilk, addSugar)
 	if err != nil {
 		slog.Error("coffee: dispense failed", "error", err)
@@ -786,9 +838,9 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 		return
 	}
 	if !out.ok {
-		// Blocked on a missing/low ingredient (or full grounds). Keep the exact
-		// fail message (with any blame) as the fallback so the slash-command hint
-		// and user mention stay correct.
+		// Blocked on a missing/low ingredient (or full grounds or tea bags). Keep
+		// the exact fail message (with any blame) as the fallback so the
+		// slash-command hint and user mention stay correct.
 		fallback := blockedFallback(out)
 		msg := m.generateInteractionMessage(s, i.ChannelID,
 			"The coffee machine cannot make the drink right now: "+fallback+
@@ -798,7 +850,7 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 		return
 	}
 
-	label := drinkLabel(out.recipe, tea)
+	label := drinkLabel(out.recipe)
 	extras := extrasSuffix(out.splashMilk, out.withSugar)
 	userID := interactionUserID(i)
 
@@ -810,14 +862,14 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 	ts := fmt.Sprintf("<t:%d:R>", readyAt.Unix())
 	brewing := m.generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("User <@%s> ordered a %s%s. Tell the channel it is brewing for them now, in one short sentence, keeping the <@%s> mention.", userID, label, extras, userID),
-		fmt.Sprintf("%s Brewing <@%s>'s %s%s…", drinkEmoji(out.recipe, tea), userID, label, extras))
+		fmt.Sprintf("%s Brewing <@%s>'s %s%s…", drinkEmoji(out.recipe), userID, label, extras))
 	r.brewing(brewing + " Ready " + ts)
 
 	m.sleep(wait)
 
 	// The reveal is public but personal: it names the orderer's own cup and
 	// carries a Take cup button that only they may press to grab it.
-	readyFallback := fmt.Sprintf("%s <@%s>, your %s%s is ready — grab it!", drinkEmoji(out.recipe, tea), userID, label, extras)
+	readyFallback := fmt.Sprintf("%s <@%s>, your %s%s is ready — grab it!", drinkEmoji(out.recipe), userID, label, extras)
 	scenario := fmt.Sprintf("The %s%s ordered by user <@%s> is ready in the machine. Announce to the channel that it is waiting for them to grab, in one short sentence, keeping the <@%s> mention.", label, extras, userID, userID)
 	// Fold the low-on-supplies nudge into the same generated message so it is
 	// translated alongside the ready announcement (instead of being appended as
@@ -828,7 +880,7 @@ func (m *Module) executeBrew(s *discordgo.Session, i *discordgo.InteractionCreat
 		scenario += " Also add a brief heads-up that the machine is running low: " + strings.TrimSpace(hint) + " Keep any `/coffeemachine` command and emoji exactly as written."
 	}
 	final := m.generateInteractionMessage(s, i.ChannelID, scenario, readyFallback+hint)
-	r.final(final, takeCupComponents(userID, out.recipe.key, tea))
+	r.final(final, takeCupComponents(userID, out.recipe.key))
 }
 
 // handleMachineInteraction handles /coffeemachine refill|empty|status.
@@ -847,6 +899,27 @@ func (m *Module) handleMachineInteraction(s *discordgo.Session, i *discordgo.Int
 			if o.Name == "part" {
 				partKey = o.StringValue()
 			}
+		}
+		// Tea bag refills go to a separate store path; machine parts use refill().
+		if flavor, ok := strings.CutPrefix(partKey, "tea_"); ok {
+			out, err := m.refillTeaBags(i.GuildID, userID, flavor)
+			if err != nil {
+				slog.Error("coffee: tea bag refill failed", "error", err)
+				m.respond(s, i, m.localizeUI(s, i.ChannelID, "The machine sputtered and failed. Try again later."), true)
+				return
+			}
+			if out.alreadyFull {
+				msg := m.generateInteractionMessage(s, i.ChannelID,
+					fmt.Sprintf("The %s tea bag box is already full. Tell the user in one short sentence.", out.label),
+					fmt.Sprintf("%s tea bags are already full.", out.label))
+				m.respond(s, i, msg, true)
+				return
+			}
+			msg := m.generateInteractionMessage(s, i.ChannelID,
+				fmt.Sprintf("A user just restocked the %s tea bags to the top (added %d bags). Thank them in one short sentence.", out.label, out.added),
+				fmt.Sprintf("🍵 <@%s> restocked %s tea bags (+%d bags).", userID, out.label, out.added))
+			m.respond(s, i, msg, false)
+			return
 		}
 		out, err := m.refill(i.GuildID, userID, partKey)
 		if err != nil {
@@ -896,7 +969,8 @@ func (m *Module) handleMachineInteraction(s *discordgo.Session, i *discordgo.Int
 		refillers, _ := m.topRefillers(i.GuildID, 3)
 		emptiers, _ := m.topGroundsEmptiers(i.GuildID, 3)
 		slackers, _ := m.topSlackers(i.GuildID, 3)
-		m.respond(s, i, formatStatus(inv, drinkers, refillers, emptiers, slackers), true)
+		teaBags, _ := m.getTeaBagInventory(i.GuildID)
+		m.respond(s, i, formatStatus(inv, drinkers, refillers, emptiers, slackers, teaBags), true)
 
 	case "stats":
 		targetID := userID
@@ -920,40 +994,23 @@ func (m *Module) buildUserStats(guildID, userID string) string {
 	return formatUserStats(userID, drinks, refills, groundsCount, groundsTotal, slackers)
 }
 
-// --- Interactive order menus (no-options /coffee and /tea) -------------------
+// --- Interactive order menu (no-options /brew) --------------------------------
 
-// Component custom-ID prefixes. The menus are public, so every custom ID also
+// Component custom-ID prefixes. The menu is public, so every custom ID also
 // carries the opener's user ID and only they may operate the components.
-// coffeeCfgPrefix and teaCfgPrefix tag the two order menus; takeCupPrefix tags
-// the Take cup button on a finished drink.
+// brewCfgPrefix tags the unified brew menu; takeCupPrefix tags the Take cup
+// button on a finished drink.
 const (
-	coffeeCfgPrefix = "coffee_brew_cfg"
-	teaCfgPrefix    = "coffee_tea_cfg"
-	takeCupPrefix   = "coffee_take"
+	brewCfgPrefix = "coffee_brew_cfg"
+	takeCupPrefix = "coffee_take"
 )
 
-const (
-	coffeeMenuPrompt = "☕ What can I get you? Pick a coffee, toggle the extras, then hit **Brew**."
-	teaMenuPrompt    = "🍵 Fancy a tea? Pick a flavor, toggle the extras, then hit **Brew**."
-)
-
-// coffeeMenu returns the menu drinks offered by /coffee — everything but hot
-// water, which now lives behind /tea.
-func coffeeMenu() []recipe {
-	out := make([]recipe, 0, len(menu))
-	for _, r := range menu {
-		if r.key == "hot_water" {
-			continue
-		}
-		out = append(out, r)
-	}
-	return out
-}
+const brewMenuPrompt = "☕🍵 What can I get you? Pick a drink, toggle the extras, then hit **Brew**."
 
 // brewCfg is the full state of an in-progress interactive order, carried inside
 // every component custom ID so no server-side session state is needed. opener is
-// the user who started the menu (only they may operate it); choice holds a
-// coffee drink key (coffee menu) or a tea flavor key (tea menu).
+// the user who started the menu (only they may operate it); choice holds a full
+// drinkKey from the menu (e.g. "coffee", "tea_black").
 type brewCfg struct {
 	opener string
 	choice string
@@ -974,8 +1031,8 @@ func encodeBrewCfg(prefix, action string, c brewCfg) string {
 	return strings.Join([]string{prefix, action, c.opener, c.choice, boolFlag(c.milk), boolFlag(c.sugar)}, ":")
 }
 
-// parseBrewCfg reverses encodeBrewCfg for the given prefix. Opener IDs and choice
-// keys never contain a colon.
+// parseBrewCfg reverses encodeBrewCfg for the given prefix. Opener IDs and
+// choice keys never contain a colon.
 func parseBrewCfg(prefix, customID string) (action string, c brewCfg, ok bool) {
 	parts := strings.Split(customID, ":")
 	if len(parts) != 6 || parts[0] != prefix {
@@ -990,7 +1047,7 @@ func (m *Module) ensureOpener(s *discordgo.Session, i *discordgo.InteractionCrea
 	if interactionUserID(i) == opener {
 		return true
 	}
-	m.respond(s, i, m.localizeUI(s, i.ChannelID, "☕ That's not your order — run `/coffee` or `/tea` to start your own."), true)
+	m.respond(s, i, m.localizeUI(s, i.ChannelID, "☕ That's not your order — run `/brew` to start your own."), true)
 	return false
 }
 
@@ -1011,40 +1068,35 @@ func extrasRow(prefix string, c brewCfg) discordgo.ActionsRow {
 	}}
 }
 
-// coffeeMenuComponents builds the /coffee drink select plus the extras row.
-func coffeeMenuComponents(c brewCfg) []discordgo.MessageComponent {
-	coffees := coffeeMenu()
-	options := make([]discordgo.SelectMenuOption, 0, len(coffees))
-	for _, r := range coffees {
-		options = append(options, discordgo.SelectMenuOption{Label: r.label, Value: r.key, Default: r.key == c.choice})
+// brewMenuComponents builds the unified /brew drink select (coffees + teas)
+// plus the extras row.
+func brewMenuComponents(c brewCfg) []discordgo.MessageComponent {
+	options := make([]discordgo.SelectMenuOption, 0, len(menu))
+	for _, r := range menu {
+		emoji := "☕"
+		if strings.HasPrefix(r.key, "tea_") {
+			emoji = "🍵"
+		}
+		options = append(options, discordgo.SelectMenuOption{
+			Label:   r.label,
+			Value:   r.key,
+			Default: r.key == c.choice,
+			Emoji:   &discordgo.ComponentEmoji{Name: emoji},
+		})
 	}
 	return []discordgo.MessageComponent{
 		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
-			discordgo.SelectMenu{CustomID: encodeBrewCfg(coffeeCfgPrefix, "pick", c), Placeholder: "Choose your coffee", Options: options},
+			discordgo.SelectMenu{CustomID: encodeBrewCfg(brewCfgPrefix, "pick", c), Placeholder: "Choose your drink", Options: options},
 		}},
-		extrasRow(coffeeCfgPrefix, c),
-	}
-}
-
-// teaMenuComponents builds the /tea flavor select plus the extras row.
-func teaMenuComponents(c brewCfg) []discordgo.MessageComponent {
-	options := make([]discordgo.SelectMenuOption, 0, len(teaFlavors))
-	for _, t := range teaFlavors {
-		options = append(options, discordgo.SelectMenuOption{Label: t.label, Value: t.key, Default: t.key == c.choice})
-	}
-	return []discordgo.MessageComponent{
-		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
-			discordgo.SelectMenu{CustomID: encodeBrewCfg(teaCfgPrefix, "pick", c), Placeholder: "Choose your tea", Options: options},
-		}},
-		extrasRow(teaCfgPrefix, c),
+		extrasRow(brewCfgPrefix, c),
 	}
 }
 
 // takeCupComponents builds the single-button row offering to grab a finished
 // drink out of the machine. The custom ID carries the orderer (only they may
-// take it) and the drink so the confirmation can name it.
-func takeCupComponents(opener, drinkKey, tea string) []discordgo.MessageComponent {
-	id := strings.Join([]string{takeCupPrefix, opener, drinkKey, tea}, ":")
+// take it) and the drink key so the confirmation can name it.
+func takeCupComponents(opener, drinkKey string) []discordgo.MessageComponent {
+	id := strings.Join([]string{takeCupPrefix, opener, drinkKey}, ":")
 	return []discordgo.MessageComponent{
 		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
 			discordgo.Button{Label: "Take cup", Emoji: &discordgo.ComponentEmoji{Name: "🫴"}, Style: discordgo.SuccessButton, CustomID: id},
@@ -1052,69 +1104,36 @@ func takeCupComponents(opener, drinkKey, tea string) []discordgo.MessageComponen
 	}
 }
 
-// openCoffeeMenu shows the interactive coffee menu, gated to its opener.
-func (m *Module) openCoffeeMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	c := brewCfg{opener: interactionUserID(i), choice: coffeeMenu()[0].key}
-	m.openMenu(s, i, m.localizeUI(s, i.ChannelID, coffeeMenuPrompt), coffeeMenuComponents(c))
+// openBrewMenu shows the interactive unified brew menu, gated to its opener.
+func (m *Module) openBrewMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	c := brewCfg{opener: interactionUserID(i), choice: menu[0].key}
+	m.openMenu(s, i, m.localizeUI(s, i.ChannelID, brewMenuPrompt), brewMenuComponents(c))
 }
 
-// openTeaMenu shows the interactive tea menu, gated to its opener.
-func (m *Module) openTeaMenu(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	c := brewCfg{opener: interactionUserID(i), choice: teaFlavors[0].key}
-	m.openMenu(s, i, m.localizeUI(s, i.ChannelID, teaMenuPrompt), teaMenuComponents(c))
-}
-
-// handleCoffeeComponent processes clicks on the interactive coffee menu: drink
+// handleBrewComponent processes clicks on the interactive brew menu: drink
 // selection and toggles re-render in place; Brew dispenses the configured drink.
-func (m *Module) handleCoffeeComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	action, c, ok := parseBrewCfg(coffeeCfgPrefix, i.MessageComponentData().CustomID)
+func (m *Module) handleBrewComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	action, c, ok := parseBrewCfg(brewCfgPrefix, i.MessageComponentData().CustomID)
 	if !ok || !m.ensureOpener(s, i, c.opener) {
 		return
 	}
 	if action == "go" {
-		m.executeBrew(s, i, c.choice, c.milk, c.sugar, "", m.brewResponder(s, i, true))
+		m.executeBrew(s, i, c.choice, c.milk, c.sugar, m.brewResponder(s, i, true))
 		return
 	}
-	prompt := m.localizeUI(s, i.ChannelID, coffeeMenuPrompt)
+	prompt := m.localizeUI(s, i.ChannelID, brewMenuPrompt)
 	switch action {
 	case "pick":
 		if vals := i.MessageComponentData().Values; len(vals) > 0 {
 			c.choice = vals[0]
 		}
-		m.updateMenu(s, i, prompt, coffeeMenuComponents(c))
+		m.updateMenu(s, i, prompt, brewMenuComponents(c))
 	case "milk":
 		c.milk = !c.milk
-		m.updateMenu(s, i, prompt, coffeeMenuComponents(c))
+		m.updateMenu(s, i, prompt, brewMenuComponents(c))
 	case "sugar":
 		c.sugar = !c.sugar
-		m.updateMenu(s, i, prompt, coffeeMenuComponents(c))
-	}
-}
-
-// handleTeaComponent processes clicks on the interactive tea menu: flavor
-// selection and toggles re-render in place; Brew steeps the configured tea.
-func (m *Module) handleTeaComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	action, c, ok := parseBrewCfg(teaCfgPrefix, i.MessageComponentData().CustomID)
-	if !ok || !m.ensureOpener(s, i, c.opener) {
-		return
-	}
-	if action == "go" {
-		m.executeBrew(s, i, "hot_water", c.milk, c.sugar, c.choice, m.brewResponder(s, i, true))
-		return
-	}
-	prompt := m.localizeUI(s, i.ChannelID, teaMenuPrompt)
-	switch action {
-	case "pick":
-		if vals := i.MessageComponentData().Values; len(vals) > 0 {
-			c.choice = vals[0]
-		}
-		m.updateMenu(s, i, prompt, teaMenuComponents(c))
-	case "milk":
-		c.milk = !c.milk
-		m.updateMenu(s, i, prompt, teaMenuComponents(c))
-	case "sugar":
-		c.sugar = !c.sugar
-		m.updateMenu(s, i, prompt, teaMenuComponents(c))
+		m.updateMenu(s, i, prompt, brewMenuComponents(c))
 	}
 }
 
@@ -1122,34 +1141,31 @@ func (m *Module) handleTeaComponent(s *discordgo.Session, i *discordgo.Interacti
 // take it. It edits the public drink message into a personal "grabbed it"
 // confirmation and drops the button.
 func (m *Module) handleTakeCupComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	parts := strings.SplitN(i.MessageComponentData().CustomID, ":", 4)
-	opener, drinkKey, tea := "", "", ""
+	parts := strings.SplitN(i.MessageComponentData().CustomID, ":", 3)
+	opener, drinkKey := "", ""
 	if len(parts) >= 2 {
 		opener = parts[1]
 	}
 	if len(parts) >= 3 {
 		drinkKey = parts[2]
 	}
-	if len(parts) >= 4 {
-		tea = parts[3]
-	}
 	if !m.ensureOpener(s, i, opener) {
 		return
 	}
 	label := "drink"
 	if r, ok := recipeByKey(drinkKey); ok {
-		label = drinkLabel(r, tea)
+		label = drinkLabel(r)
 	}
 	msg := m.generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("User <@%s> just grabbed their %s out of the coffee machine. Tell the channel to enjoy it, in one short sentence, keeping the <@%s> mention.", opener, label, opener),
-		fmt.Sprintf("%s <@%s> grabbed their %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey, tea), opener, label))
+		fmt.Sprintf("%s <@%s> grabbed their %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey), opener, label))
 	m.respondUpdate(s, i, msg)
 }
 
 // drinkEmojiForKey is drinkEmoji by key, falling back to a coffee cup.
-func drinkEmojiForKey(drinkKey, tea string) string {
+func drinkEmojiForKey(drinkKey string) string {
 	if r, ok := recipeByKey(drinkKey); ok {
-		return drinkEmoji(r, tea)
+		return drinkEmoji(r)
 	}
 	return "☕"
 }

--- a/internal/coffee/machine_test.go
+++ b/internal/coffee/machine_test.go
@@ -800,6 +800,7 @@ func TestCoffeeMenuComponents_ReflectState(t *testing.T) {
 
 func TestCoffee_NoOptionsOpensMenu(t *testing.T) {
 	m := newTestModule(t)
+	stubLLM(m, t, "", nil) // empty reply -> English fallback prompt
 	opens, _ := captureMenuIO(m)
 	resp, _, _ := captureBrewIO(m)
 
@@ -821,6 +822,7 @@ func TestCoffee_NoOptionsOpensMenu(t *testing.T) {
 
 func TestTea_NoOptionsOpensMenu(t *testing.T) {
 	m := newTestModule(t)
+	stubLLM(m, t, "", nil) // empty reply -> English fallback prompt
 	opens, _ := captureMenuIO(m)
 	resp, _, _ := captureBrewIO(m)
 
@@ -839,6 +841,7 @@ func TestTea_NoOptionsOpensMenu(t *testing.T) {
 
 func TestCoffeeComponent_TogglesAndSelect(t *testing.T) {
 	m := newTestModule(t)
+	stubLLM(m, t, "", nil) // empty reply -> English fallback prompt
 	_, updates := captureMenuIO(m)
 
 	// select espresso
@@ -859,6 +862,45 @@ func TestCoffeeComponent_TogglesAndSelect(t *testing.T) {
 	}
 	if c := menuCfg(t, coffeeCfgPrefix, (*updates)[2].comps); !c.sugar || !c.milk {
 		t.Errorf("after sugar toggle, cfg = %+v, want milk+sugar on", c)
+	}
+}
+
+func TestMenuPromptLocalizedAndCached(t *testing.T) {
+	m := newTestModule(t)
+	getCalls := stubLLM(m, t, "Was darf es sein?", nil)
+	opens, updates := captureMenuIO(m)
+
+	// Opening the menu translates the prompt once.
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1")) // no options -> menu
+	if len(*opens) != 1 || (*opens)[0].content != "Was darf es sein?" {
+		t.Fatalf("menu prompt should be the localized text, got %+v", *opens)
+	}
+
+	// A toggle re-renders the menu but must reuse the cached translation.
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{opener: "u1", choice: "coffee"})))
+	if len(*updates) != 1 || (*updates)[0].content != "Was darf es sein?" {
+		t.Fatalf("re-render should keep the localized prompt, got %+v", *updates)
+	}
+	if n := len(getCalls()); n != 1 {
+		t.Errorf("menu prompt should be translated once and cached, got %d LLM calls", n)
+	}
+}
+
+func TestEnsureOpenerNudgeLocalized(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "Nicht deine Bestellung.", nil)
+	resp, _, _ := captureBrewIO(m)
+	_, _ = captureMenuIO(m)
+
+	// The clicking user is "u1" (set by makeBrewComponent) but the menu is owned
+	// by "alice", so the click is rejected with a localized ephemeral nudge.
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{opener: "alice", choice: "coffee"})))
+
+	if len(*resp) != 1 || !(*resp)[0].ephemeral {
+		t.Fatalf("non-owner should get an ephemeral nudge, got %+v", *resp)
+	}
+	if (*resp)[0].content != "Nicht deine Bestellung." {
+		t.Errorf("nudge should be localized, got %q", (*resp)[0].content)
 	}
 }
 
@@ -912,6 +954,7 @@ func TestTeaComponent_GoBrews(t *testing.T) {
 
 func TestTakeCup_Confirms(t *testing.T) {
 	m := newTestModule(t)
+	stubLLM(m, t, "", nil) // empty reply -> English fallback confirmation
 	resp, _, _ := captureBrewIO(m)
 
 	id := strings.Join([]string{takeCupPrefix, "u1", "espresso", ""}, ":")
@@ -927,6 +970,7 @@ func TestTakeCup_Confirms(t *testing.T) {
 
 func TestTakeCup_RejectsNonOwner(t *testing.T) {
 	m := newTestModule(t)
+	stubLLM(m, t, "", nil) // empty reply -> English fallback nudge
 	resp, _, _ := captureBrewIO(m)
 	var updates int
 	m.respondUpdate = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ string) { updates++ }
@@ -1177,6 +1221,31 @@ func TestExecuteBrewAppendsServiceHint(t *testing.T) {
 
 	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Heads up") {
 		t.Fatalf("final brew message should carry the service nudge, got %v", *edits)
+	}
+}
+
+func TestExecuteBrew_FoldsServiceHintIntoLLMScenario(t *testing.T) {
+	m := newTestModule(t)
+	getCalls := stubLLM(m, t, "Fertig!", nil) // non-empty -> LLM output used as-is
+	_, edits, _ := captureBrewIO(m)
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 }) // empties on brew
+
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+
+	// The nudge must reach the LLM (so it gets translated), not be appended in
+	// English after generation.
+	foundHint := false
+	for _, c := range getCalls() {
+		if strings.Contains(c, "Heads up") || strings.Contains(c, "running low") {
+			foundHint = true
+		}
+	}
+	if !foundHint {
+		t.Errorf("service nudge should be folded into an LLM scenario, calls=%v", getCalls())
+	}
+	// The final message is the LLM output, with no English nudge appended.
+	if len(*edits) != 1 || (*edits)[0] != "Fertig!" {
+		t.Errorf("final should be the LLM message only, got %v", *edits)
 	}
 }
 

--- a/internal/coffee/machine_test.go
+++ b/internal/coffee/machine_test.go
@@ -455,6 +455,9 @@ func captureBrewIO(m *Module) (*[]respCall, *[]string, *[]time.Duration) {
 	m.editDeferredResponse = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string) {
 		*edits = append(*edits, content)
 	}
+	m.editWithComponents = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string, _ []discordgo.MessageComponent) {
+		*edits = append(*edits, content)
+	}
 	m.sleep = func(d time.Duration) { *sleeps = append(*sleeps, d) }
 	return resp, edits, sleeps
 }
@@ -500,7 +503,7 @@ func makeBrewInteraction(guildID string, opts ...*discordgo.ApplicationCommandIn
 			Type:      discordgo.InteractionApplicationCommand,
 			Member:    &discordgo.Member{User: &discordgo.User{ID: "u1"}},
 			Data: discordgo.ApplicationCommandInteractionData{
-				Name:    "brew",
+				Name:    "coffee",
 				Options: opts,
 			},
 		},
@@ -529,7 +532,7 @@ func TestHandleBrew_BlockedShowsErrorNoBrewing(t *testing.T) {
 	resp, edits, sleeps := captureBrewIO(m)
 	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 10 })
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*resp) != 1 || !(*resp)[0].ephemeral {
 		t.Fatalf("expected 1 ephemeral error response, got %+v", *resp)
@@ -552,10 +555,10 @@ func TestHandleBrew_SuccessShowsBrewingThenFinalNoStats(t *testing.T) {
 	stubLLM(m, t, "", nil) // fallback messages
 	resp, edits, sleeps := captureBrewIO(m)
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
-	if len(*resp) != 1 || (*resp)[0].ephemeral {
-		t.Fatalf("expected 1 public brewing response, got %+v", *resp)
+	if len(*resp) != 1 || !(*resp)[0].ephemeral {
+		t.Fatalf("expected 1 ephemeral brewing response, got %+v", *resp)
 	}
 	if !strings.Contains((*resp)[0].content, "Brewing") {
 		t.Errorf("first response should be a brewing status: %q", (*resp)[0].content)
@@ -588,7 +591,7 @@ func TestHandleBrew_UsesLLMForVariation(t *testing.T) {
 	stubLLM(m, t, "Dein Kaffee ist fertig!", nil) // non-empty -> LLM text used
 	_, edits, _ := captureBrewIO(m)
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*edits) != 1 || (*edits)[0] != "Dein Kaffee ist fertig!" {
 		t.Errorf("final message should come from the LLM, got %v", *edits)
@@ -717,7 +720,7 @@ func TestHandleTea_WithMilk(t *testing.T) {
 	}
 }
 
-// --- Interactive /brew menu --------------------------------------------------
+// --- Interactive /coffee and /tea menus --------------------------------------
 
 // menuSelectedDrink returns the drink marked Default in the menu's select.
 func menuSelectedDrink(t *testing.T, comps []discordgo.MessageComponent) string {
@@ -739,7 +742,7 @@ func menuSelectedDrink(t *testing.T, comps []discordgo.MessageComponent) string 
 }
 
 // menuCfg parses the full order state out of the Brew button's custom ID.
-func menuCfg(t *testing.T, comps []discordgo.MessageComponent) brewCfg {
+func menuCfg(t *testing.T, prefix string, comps []discordgo.MessageComponent) brewCfg {
 	t.Helper()
 	row, ok := comps[1].(discordgo.ActionsRow)
 	if !ok {
@@ -749,7 +752,7 @@ func menuCfg(t *testing.T, comps []discordgo.MessageComponent) brewCfg {
 	if !ok {
 		t.Fatalf("third button is not a Button: %T", row.Components[2])
 	}
-	_, c, ok := parseBrewCfg(btn.CustomID)
+	_, c, ok := parseBrewCfg(prefix, btn.CustomID)
 	if !ok {
 		t.Fatalf("brew button has unparseable custom ID %q", btn.CustomID)
 	}
@@ -757,61 +760,93 @@ func menuCfg(t *testing.T, comps []discordgo.MessageComponent) brewCfg {
 }
 
 func TestBrewCfgRoundTrip(t *testing.T) {
-	in := brewCfg{drink: "latte_macchiato", milk: true, sugar: false}
-	action, out, ok := parseBrewCfg(encodeBrewCfg("go", in))
+	in := brewCfg{choice: "latte_macchiato", milk: true, sugar: false}
+	action, out, ok := parseBrewCfg(coffeeCfgPrefix, encodeBrewCfg(coffeeCfgPrefix, "go", in))
 	if !ok || action != "go" || out != in {
 		t.Fatalf("round trip failed: action=%q out=%+v ok=%v", action, out, ok)
 	}
-	if _, _, ok := parseBrewCfg("not_our_prefix:go:coffee:0:0"); ok {
-		t.Error("foreign custom ID should not parse")
+	// The tea menu uses a different prefix, so a coffee custom ID must not parse
+	// as tea (prevents the two menus' components from cross-firing).
+	if _, _, ok := parseBrewCfg(teaCfgPrefix, encodeBrewCfg(coffeeCfgPrefix, "go", in)); ok {
+		t.Error("coffee custom ID should not parse under the tea prefix")
 	}
-	if _, _, ok := parseBrewCfg("coffee_brew_cfg:go:coffee"); ok {
+	if _, _, ok := parseBrewCfg(coffeeCfgPrefix, "coffee_brew_cfg:go:coffee"); ok {
 		t.Error("truncated custom ID should not parse")
 	}
 }
 
-func TestBrewMenuComponents_ReflectState(t *testing.T) {
-	comps := brewMenuComponents(brewCfg{drink: "espresso", milk: true, sugar: false})
+func TestCoffeeMenuExcludesHotWater(t *testing.T) {
+	for _, r := range coffeeMenu() {
+		if r.key == "hot_water" {
+			t.Fatal("coffee menu must not offer hot water (that's /tea now)")
+		}
+	}
+	for _, ch := range drinkChoices() {
+		if ch.Value == "hot_water" {
+			t.Fatal("/coffee drink choices must not include hot water")
+		}
+	}
+}
+
+func TestCoffeeMenuComponents_ReflectState(t *testing.T) {
+	comps := coffeeMenuComponents(brewCfg{choice: "espresso", milk: true, sugar: false})
 	if d := menuSelectedDrink(t, comps); d != "espresso" {
 		t.Errorf("selected drink = %q, want espresso", d)
 	}
-	if c := menuCfg(t, comps); !c.milk || c.sugar {
+	if c := menuCfg(t, coffeeCfgPrefix, comps); !c.milk || c.sugar {
 		t.Errorf("button state cfg = %+v, want milk on/sugar off", c)
 	}
 }
 
-func TestBrew_NoOptionsOpensMenu(t *testing.T) {
+func TestCoffee_NoOptionsOpensMenu(t *testing.T) {
 	m := newTestModule(t)
 	opens, _ := captureMenuIO(m)
 	resp, _, _ := captureBrewIO(m)
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1")) // no options
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1")) // no options
 
 	if len(*opens) != 1 {
 		t.Fatalf("expected the menu to open once, got %d", len(*opens))
 	}
 	if len(*resp) != 0 {
-		t.Errorf("no-options /brew should not brew directly, got responses %+v", *resp)
+		t.Errorf("no-options /coffee should not brew directly, got responses %+v", *resp)
 	}
 	if d := menuSelectedDrink(t, (*opens)[0].comps); d != "coffee" {
 		t.Errorf("menu should default to coffee, got %q", d)
 	}
-	// nothing brewed yet
 	if c := countDrinks(m, t, "g1"); c != 0 {
 		t.Errorf("opening the menu should brew nothing, got %d drinks", c)
 	}
 }
 
-func TestBrewComponent_TogglesAndSelect(t *testing.T) {
+func TestTea_NoOptionsOpensMenu(t *testing.T) {
+	m := newTestModule(t)
+	opens, _ := captureMenuIO(m)
+	resp, _, _ := captureBrewIO(m)
+
+	m.handleTeaInteraction(nil, makeTeaInteraction("g1")) // no options
+
+	if len(*opens) != 1 {
+		t.Fatalf("expected the tea menu to open once, got %d", len(*opens))
+	}
+	if len(*resp) != 0 {
+		t.Errorf("no-options /tea should not brew directly, got %+v", *resp)
+	}
+	if d := menuSelectedDrink(t, (*opens)[0].comps); d != teaFlavors[0].key {
+		t.Errorf("tea menu should default to %q, got %q", teaFlavors[0].key, d)
+	}
+}
+
+func TestCoffeeComponent_TogglesAndSelect(t *testing.T) {
 	m := newTestModule(t)
 	_, updates := captureMenuIO(m)
 
 	// select espresso
-	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("drink", brewCfg{drink: "coffee"}), "espresso"))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "pick", brewCfg{choice: "coffee"}), "espresso"))
 	// toggle milk on (state still carries espresso)
-	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("milk", brewCfg{drink: "espresso"})))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{choice: "espresso"})))
 	// toggle sugar on
-	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("sugar", brewCfg{drink: "espresso", milk: true})))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "sugar", brewCfg{choice: "espresso", milk: true})))
 
 	if len(*updates) != 3 {
 		t.Fatalf("expected 3 in-place menu updates, got %d", len(*updates))
@@ -819,21 +854,21 @@ func TestBrewComponent_TogglesAndSelect(t *testing.T) {
 	if d := menuSelectedDrink(t, (*updates)[0].comps); d != "espresso" {
 		t.Errorf("after select, drink = %q, want espresso", d)
 	}
-	if c := menuCfg(t, (*updates)[1].comps); !c.milk {
+	if c := menuCfg(t, coffeeCfgPrefix, (*updates)[1].comps); !c.milk {
 		t.Errorf("after milk toggle, cfg = %+v, want milk on", c)
 	}
-	if c := menuCfg(t, (*updates)[2].comps); !c.sugar || !c.milk {
+	if c := menuCfg(t, coffeeCfgPrefix, (*updates)[2].comps); !c.sugar || !c.milk {
 		t.Errorf("after sugar toggle, cfg = %+v, want milk+sugar on", c)
 	}
 }
 
-func TestBrewComponent_GoBrews(t *testing.T) {
+func TestCoffeeComponent_GoBrews(t *testing.T) {
 	m := newTestModule(t)
 	stubLLM(m, t, "", nil)
 	resp, edits, sleeps := captureBrewIO(m)
 	_, _ = captureMenuIO(m)
 
-	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("go", brewCfg{drink: "espresso", milk: true, sugar: true})))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "go", brewCfg{choice: "espresso", milk: true, sugar: true})))
 
 	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
 		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
@@ -848,6 +883,70 @@ func TestBrewComponent_GoBrews(t *testing.T) {
 	m.getDB().Where("guild_id = ?", "g1").First(&de)
 	if de.Drink != "espresso" || !de.WithMilk || !de.WithSugar {
 		t.Errorf("brewed DrinkEvent = %+v, want espresso milk+sugar", de)
+	}
+}
+
+func TestTeaComponent_GoBrews(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "", nil)
+	resp, edits, sleeps := captureBrewIO(m)
+	_, _ = captureMenuIO(m)
+
+	m.handleTeaComponent(nil, makeBrewComponent("g1", encodeBrewCfg(teaCfgPrefix, "go", brewCfg{choice: "rooibos", milk: true})))
+
+	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
+		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
+	}
+	if len(*sleeps) != 1 {
+		t.Errorf("expected one brew delay, got %d", len(*sleeps))
+	}
+	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Rooibos tea with milk") {
+		t.Fatalf("expected final Rooibos tea with milk, got %v", *edits)
+	}
+	var de DrinkEvent
+	m.getDB().Where("guild_id = ?", "g1").First(&de)
+	if de.Drink != "hot_water" || !de.WithMilk {
+		t.Errorf("tea brew DrinkEvent = %+v, want hot_water with milk", de)
+	}
+}
+
+func TestTakeCup_Confirms(t *testing.T) {
+	m := newTestModule(t)
+	resp, _, _ := captureBrewIO(m)
+
+	id := strings.Join([]string{takeCupPrefix, "espresso", ""}, ":")
+	m.handleTakeCupComponent(nil, makeBrewComponent("g1", id))
+
+	if len(*resp) != 1 {
+		t.Fatalf("expected 1 confirmation update, got %d", len(*resp))
+	}
+	if !strings.Contains((*resp)[0].content, "grabbed your Espresso") {
+		t.Errorf("take-cup confirmation should name the drink: %q", (*resp)[0].content)
+	}
+}
+
+func TestExecuteBrew_AttachesTakeCupButton(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "", nil)
+	var finalComps []discordgo.MessageComponent
+	m.respond = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ string, _ bool) {}
+	m.editWithComponents = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ string, comps []discordgo.MessageComponent) {
+		finalComps = comps
+	}
+	m.sleep = func(time.Duration) {}
+
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+
+	if len(finalComps) != 1 {
+		t.Fatalf("expected the finished drink to carry a Take cup row, got %d rows", len(finalComps))
+	}
+	row, ok := finalComps[0].(discordgo.ActionsRow)
+	if !ok || len(row.Components) != 1 {
+		t.Fatalf("take cup row malformed: %+v", finalComps[0])
+	}
+	btn, ok := row.Components[0].(discordgo.Button)
+	if !ok || !strings.HasPrefix(btn.CustomID, takeCupPrefix) {
+		t.Errorf("expected a Take cup button, got %+v", row.Components[0])
 	}
 }
 
@@ -1056,7 +1155,7 @@ func TestExecuteBrewAppendsServiceHint(t *testing.T) {
 	_, edits, _ := captureBrewIO(m)
 	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 })
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Heads up") {
 		t.Fatalf("final brew message should carry the service nudge, got %v", *edits)
@@ -1074,7 +1173,7 @@ func TestBlockedBrewMentionsSlacker(t *testing.T) {
 	resp, _, _ := captureBrewIO(m)
 	bob := makeBrewInteraction("g1", strOpt("drink", "coffee"))
 	bob.Member.User.ID = "bob"
-	m.handleBrewInteraction(nil, bob)
+	m.handleCoffeeInteraction(nil, bob)
 
 	if len(*resp) != 1 || !(*resp)[0].ephemeral {
 		t.Fatalf("expected 1 ephemeral blocked response, got %+v", *resp)

--- a/internal/coffee/machine_test.go
+++ b/internal/coffee/machine_test.go
@@ -2,6 +2,7 @@ package coffee
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -439,7 +440,8 @@ type respCall struct {
 }
 
 // captureBrewIO stubs the interaction response, edit, and sleep hooks so brew
-// handler behavior can be asserted without a live Discord session.
+// handler behavior can be asserted without a live Discord session. respondUpdate
+// (used by the interactive-menu brew path) is captured alongside respond.
 func captureBrewIO(m *Module) (*[]respCall, *[]string, *[]time.Duration) {
 	resp := &[]respCall{}
 	edits := &[]string{}
@@ -447,11 +449,47 @@ func captureBrewIO(m *Module) (*[]respCall, *[]string, *[]time.Duration) {
 	m.respond = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string, ephemeral bool) {
 		*resp = append(*resp, respCall{content, ephemeral})
 	}
+	m.respondUpdate = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string) {
+		*resp = append(*resp, respCall{content, false})
+	}
 	m.editDeferredResponse = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string) {
 		*edits = append(*edits, content)
 	}
 	m.sleep = func(d time.Duration) { *sleeps = append(*sleeps, d) }
 	return resp, edits, sleeps
+}
+
+type menuCall struct {
+	content string
+	comps   []discordgo.MessageComponent
+}
+
+// captureMenuIO stubs the openMenu/updateMenu hooks for interactive-menu tests.
+func captureMenuIO(m *Module) (opens, updates *[]menuCall) {
+	opens = &[]menuCall{}
+	updates = &[]menuCall{}
+	m.openMenu = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string, comps []discordgo.MessageComponent) {
+		*opens = append(*opens, menuCall{content, comps})
+	}
+	m.updateMenu = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string, comps []discordgo.MessageComponent) {
+		*updates = append(*updates, menuCall{content, comps})
+	}
+	return opens, updates
+}
+
+func makeBrewComponent(guildID, customID string, values ...string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   guildID,
+			ChannelID: "ch1",
+			Type:      discordgo.InteractionMessageComponent,
+			Member:    &discordgo.Member{User: &discordgo.User{ID: "u1"}},
+			Data: discordgo.MessageComponentInteractionData{
+				CustomID: customID,
+				Values:   values,
+			},
+		},
+	}
 }
 
 func makeBrewInteraction(guildID string, opts ...*discordgo.ApplicationCommandInteractionDataOption) *discordgo.InteractionCreate {
@@ -469,13 +507,29 @@ func makeBrewInteraction(guildID string, opts ...*discordgo.ApplicationCommandIn
 	}
 }
 
+func strOpt(name, value string) *discordgo.ApplicationCommandInteractionDataOption {
+	return &discordgo.ApplicationCommandInteractionDataOption{
+		Name:  name,
+		Type:  discordgo.ApplicationCommandOptionString,
+		Value: value,
+	}
+}
+
+func boolOpt(name string, value bool) *discordgo.ApplicationCommandInteractionDataOption {
+	return &discordgo.ApplicationCommandInteractionDataOption{
+		Name:  name,
+		Type:  discordgo.ApplicationCommandOptionBoolean,
+		Value: value,
+	}
+}
+
 func TestHandleBrew_BlockedShowsErrorNoBrewing(t *testing.T) {
 	m := newTestModule(t)
 	stubLLM(m, t, "", nil) // empty reply -> deterministic fallback
 	resp, edits, sleeps := captureBrewIO(m)
 	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 10 })
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1"))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*resp) != 1 || !(*resp)[0].ephemeral {
 		t.Fatalf("expected 1 ephemeral error response, got %+v", *resp)
@@ -498,7 +552,7 @@ func TestHandleBrew_SuccessShowsBrewingThenFinalNoStats(t *testing.T) {
 	stubLLM(m, t, "", nil) // fallback messages
 	resp, edits, sleeps := captureBrewIO(m)
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1")) // default coffee
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*resp) != 1 || (*resp)[0].ephemeral {
 		t.Fatalf("expected 1 public brewing response, got %+v", *resp)
@@ -534,7 +588,7 @@ func TestHandleBrew_UsesLLMForVariation(t *testing.T) {
 	stubLLM(m, t, "Dein Kaffee ist fertig!", nil) // non-empty -> LLM text used
 	_, edits, _ := captureBrewIO(m)
 
-	m.handleBrewInteraction(nil, makeBrewInteraction("g1"))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*edits) != 1 || (*edits)[0] != "Dein Kaffee ist fertig!" {
 		t.Errorf("final message should come from the LLM, got %v", *edits)
@@ -555,7 +609,8 @@ func TestFormatStatus(t *testing.T) {
 	got := formatStatus(inv,
 		[]userCount{{UserID: "A", Count: 3}},
 		nil,
-		2)
+		[]groundsEmptier{{UserID: "A", Count: 2, TotalGrams: 480}},
+		[]userCount{{UserID: "B", Count: 1}})
 	if !strings.Contains(got, "Mild beans: 500/1000g (50%)") {
 		t.Errorf("missing mild beans line with percent: %q", got)
 	}
@@ -565,8 +620,25 @@ func TestFormatStatus(t *testing.T) {
 	if !strings.Contains(got, "Top refillers") || !strings.Contains(got, "_none yet_") {
 		t.Errorf("missing empty refillers section: %q", got)
 	}
-	if !strings.Contains(got, "Grounds emptied 2 times") {
-		t.Errorf("missing grounds-emptied tally: %q", got)
+	if !strings.Contains(got, "Top grounds-emptiers") {
+		t.Errorf("missing grounds-emptiers section: %q", got)
+	}
+	if !strings.Contains(got, "<@A>: 2× · 480g total · 240g avg") {
+		t.Errorf("missing grounds-emptier leaderboard with times/grams/avg: %q", got)
+	}
+	if !strings.Contains(got, "Slackers") || !strings.Contains(got, "<@B>: 1 misses") {
+		t.Errorf("missing slacker section: %q", got)
+	}
+}
+
+func TestFormatStatus_NoSlackersHidesSection(t *testing.T) {
+	inv := MachineInventory{}
+	got := formatStatus(inv, nil, nil, nil, nil)
+	if strings.Contains(got, "Slackers") {
+		t.Errorf("slacker section should be hidden when there are none: %q", got)
+	}
+	if !strings.Contains(got, "Top grounds-emptiers") || !strings.Contains(got, "_none yet_") {
+		t.Errorf("grounds-emptiers section should show even when empty: %q", got)
 	}
 }
 
@@ -584,5 +656,521 @@ func TestPercent(t *testing.T) {
 		if got := percent(c.cur, c.max); got != c.want {
 			t.Errorf("percent(%d,%d) = %d, want %d", c.cur, c.max, got, c.want)
 		}
+	}
+}
+
+// --- /tea command -----------------------------------------------------------
+
+func makeTeaInteraction(guildID string, opts ...*discordgo.ApplicationCommandInteractionDataOption) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   guildID,
+			ChannelID: "ch1",
+			Type:      discordgo.InteractionApplicationCommand,
+			Member:    &discordgo.Member{User: &discordgo.User{ID: "u1"}},
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name:    "tea",
+				Options: opts,
+			},
+		},
+	}
+}
+
+func TestHandleTea_BrewsTeaNotCoffee(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "", nil) // deterministic fallback
+	_, edits, _ := captureBrewIO(m)
+
+	m.handleTeaInteraction(nil, makeTeaInteraction("g1", strOpt("flavor", "rooibos")))
+
+	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Rooibos tea") {
+		t.Fatalf("expected a Rooibos tea, got %v", *edits)
+	}
+	// Tea is hot water: no beans, no grounds, only water consumed.
+	inv, _ := m.getOrSeedInventory("g1")
+	if inv.GroundsGrams != 0 || inv.BeansMildGrams != maxBeansMildG || inv.BeansEspressoGrams != maxBeansEspressoG {
+		t.Errorf("tea should brew from hot water only: %+v", inv)
+	}
+	if inv.WaterMl != maxWaterMl-200 {
+		t.Errorf("tea should consume 200ml water, got %d", inv.WaterMl)
+	}
+	var de DrinkEvent
+	m.getDB().Where("guild_id = ?", "g1").First(&de)
+	if de.Drink != "hot_water" {
+		t.Errorf("tea DrinkEvent drink = %q, want hot_water", de.Drink)
+	}
+}
+
+func TestHandleTea_WithMilk(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "", nil)
+	_, edits, _ := captureBrewIO(m)
+
+	m.handleTeaInteraction(nil, makeTeaInteraction("g1", strOpt("flavor", "earl_grey"), boolOpt("milk", true)))
+
+	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Earl Grey tea with milk") {
+		t.Fatalf("expected Earl Grey tea with milk, got %v", *edits)
+	}
+	inv, _ := m.getOrSeedInventory("g1")
+	if inv.MilkMl != maxMilkMl-addMilkMl {
+		t.Errorf("tea+milk should add a %dml splash, got milk=%d", addMilkMl, inv.MilkMl)
+	}
+}
+
+// --- Interactive /brew menu --------------------------------------------------
+
+// menuSelectedDrink returns the drink marked Default in the menu's select.
+func menuSelectedDrink(t *testing.T, comps []discordgo.MessageComponent) string {
+	t.Helper()
+	row, ok := comps[0].(discordgo.ActionsRow)
+	if !ok {
+		t.Fatalf("comps[0] is not an ActionsRow: %T", comps[0])
+	}
+	sel, ok := row.Components[0].(discordgo.SelectMenu)
+	if !ok {
+		t.Fatalf("first component is not a SelectMenu: %T", row.Components[0])
+	}
+	for _, o := range sel.Options {
+		if o.Default {
+			return o.Value
+		}
+	}
+	return ""
+}
+
+// menuCfg parses the full order state out of the Brew button's custom ID.
+func menuCfg(t *testing.T, comps []discordgo.MessageComponent) brewCfg {
+	t.Helper()
+	row, ok := comps[1].(discordgo.ActionsRow)
+	if !ok {
+		t.Fatalf("comps[1] is not an ActionsRow: %T", comps[1])
+	}
+	btn, ok := row.Components[2].(discordgo.Button)
+	if !ok {
+		t.Fatalf("third button is not a Button: %T", row.Components[2])
+	}
+	_, c, ok := parseBrewCfg(btn.CustomID)
+	if !ok {
+		t.Fatalf("brew button has unparseable custom ID %q", btn.CustomID)
+	}
+	return c
+}
+
+func TestBrewCfgRoundTrip(t *testing.T) {
+	in := brewCfg{drink: "latte_macchiato", milk: true, sugar: false}
+	action, out, ok := parseBrewCfg(encodeBrewCfg("go", in))
+	if !ok || action != "go" || out != in {
+		t.Fatalf("round trip failed: action=%q out=%+v ok=%v", action, out, ok)
+	}
+	if _, _, ok := parseBrewCfg("not_our_prefix:go:coffee:0:0"); ok {
+		t.Error("foreign custom ID should not parse")
+	}
+	if _, _, ok := parseBrewCfg("coffee_brew_cfg:go:coffee"); ok {
+		t.Error("truncated custom ID should not parse")
+	}
+}
+
+func TestBrewMenuComponents_ReflectState(t *testing.T) {
+	comps := brewMenuComponents(brewCfg{drink: "espresso", milk: true, sugar: false})
+	if d := menuSelectedDrink(t, comps); d != "espresso" {
+		t.Errorf("selected drink = %q, want espresso", d)
+	}
+	if c := menuCfg(t, comps); !c.milk || c.sugar {
+		t.Errorf("button state cfg = %+v, want milk on/sugar off", c)
+	}
+}
+
+func TestBrew_NoOptionsOpensMenu(t *testing.T) {
+	m := newTestModule(t)
+	opens, _ := captureMenuIO(m)
+	resp, _, _ := captureBrewIO(m)
+
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1")) // no options
+
+	if len(*opens) != 1 {
+		t.Fatalf("expected the menu to open once, got %d", len(*opens))
+	}
+	if len(*resp) != 0 {
+		t.Errorf("no-options /brew should not brew directly, got responses %+v", *resp)
+	}
+	if d := menuSelectedDrink(t, (*opens)[0].comps); d != "coffee" {
+		t.Errorf("menu should default to coffee, got %q", d)
+	}
+	// nothing brewed yet
+	if c := countDrinks(m, t, "g1"); c != 0 {
+		t.Errorf("opening the menu should brew nothing, got %d drinks", c)
+	}
+}
+
+func TestBrewComponent_TogglesAndSelect(t *testing.T) {
+	m := newTestModule(t)
+	_, updates := captureMenuIO(m)
+
+	// select espresso
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("drink", brewCfg{drink: "coffee"}), "espresso"))
+	// toggle milk on (state still carries espresso)
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("milk", brewCfg{drink: "espresso"})))
+	// toggle sugar on
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("sugar", brewCfg{drink: "espresso", milk: true})))
+
+	if len(*updates) != 3 {
+		t.Fatalf("expected 3 in-place menu updates, got %d", len(*updates))
+	}
+	if d := menuSelectedDrink(t, (*updates)[0].comps); d != "espresso" {
+		t.Errorf("after select, drink = %q, want espresso", d)
+	}
+	if c := menuCfg(t, (*updates)[1].comps); !c.milk {
+		t.Errorf("after milk toggle, cfg = %+v, want milk on", c)
+	}
+	if c := menuCfg(t, (*updates)[2].comps); !c.sugar || !c.milk {
+		t.Errorf("after sugar toggle, cfg = %+v, want milk+sugar on", c)
+	}
+}
+
+func TestBrewComponent_GoBrews(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "", nil)
+	resp, edits, sleeps := captureBrewIO(m)
+	_, _ = captureMenuIO(m)
+
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg("go", brewCfg{drink: "espresso", milk: true, sugar: true})))
+
+	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
+		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
+	}
+	if len(*sleeps) != 1 {
+		t.Errorf("expected one brew delay, got %d", len(*sleeps))
+	}
+	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Espresso with milk and sugar") {
+		t.Fatalf("expected final espresso with milk+sugar, got %v", *edits)
+	}
+	var de DrinkEvent
+	m.getDB().Where("guild_id = ?", "g1").First(&de)
+	if de.Drink != "espresso" || !de.WithMilk || !de.WithSugar {
+		t.Errorf("brewed DrinkEvent = %+v, want espresso milk+sugar", de)
+	}
+}
+
+// --- Part-service detection & slacker mechanic ------------------------------
+
+func TestMaxPartDemand(t *testing.T) {
+	if g := maxPartDemand(partGrounds); g != 36 { // flat white
+		t.Errorf("max grounds demand = %d, want 36", g)
+	}
+	if w := maxPartDemand("water"); w != 200 { // hot water
+		t.Errorf("max water demand = %d, want 200", w)
+	}
+	if mk := maxPartDemand("milk"); mk != 180 { // latte macchiato
+		t.Errorf("max milk demand = %d, want 180", mk)
+	}
+}
+
+func TestPartsNeedingService(t *testing.T) {
+	full := MachineInventory{BeansMildGrams: maxBeansMildG, BeansEspressoGrams: maxBeansEspressoG, WaterMl: maxWaterMl, MilkMl: maxMilkMl, GroundsGrams: 0}
+	if parts := partsNeedingService(full); len(parts) != 0 {
+		t.Errorf("a full machine needs no service, got %v", parts)
+	}
+	low := MachineInventory{BeansMildGrams: 0, BeansEspressoGrams: maxBeansEspressoG, WaterMl: maxWaterMl, MilkMl: maxMilkMl, GroundsGrams: maxGroundsG}
+	parts := partsNeedingService(low)
+	if !slices.Contains(parts, "beans_mild") || !slices.Contains(parts, partGrounds) {
+		t.Errorf("expected beans_mild and grounds to need service, got %v", parts)
+	}
+	if slices.Contains(parts, "water") {
+		t.Errorf("water was full, should not need service: %v", parts)
+	}
+}
+
+func pendingServiceUser(m *Module, t *testing.T, guildID, part string) (string, bool) {
+	t.Helper()
+	var ps PendingService
+	err := m.getDB().Where("guild_id = ? AND part = ?", guildID, part).First(&ps).Error
+	if err != nil {
+		return "", false
+	}
+	return ps.UserID, true
+}
+
+func TestDispenseLeavesServiceNeededAndPending(t *testing.T) {
+	m := newTestModule(t)
+	// Just enough mild beans for one coffee, leaving 9g (< 11g demand) after.
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.BeansMildGrams = 20 })
+
+	out, err := m.dispense("g1", "alice", "coffee", false, false)
+	if err != nil || !out.ok {
+		t.Fatalf("dispense: err=%v fail=%q", err, out.failMsg)
+	}
+	if !slices.Contains(out.serviceNeeded, "beans_mild") {
+		t.Errorf("serviceNeeded = %v, want beans_mild", out.serviceNeeded)
+	}
+	if u, ok := pendingServiceUser(m, t, "g1", "beans_mild"); !ok || u != "alice" {
+		t.Errorf("pending beans_mild user = %q (ok=%v), want alice", u, ok)
+	}
+}
+
+func TestSlackerBlamedWhenNextUserBlocked(t *testing.T) {
+	m := newTestModule(t)
+	// Exactly one coffee's worth of water, so alice's brew empties the tank.
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 })
+
+	a, err := m.dispense("g1", "alice", "coffee", false, false)
+	if err != nil || !a.ok {
+		t.Fatalf("alice brew: err=%v fail=%q", err, a.failMsg)
+	}
+	if !slices.Contains(a.serviceNeeded, "water") {
+		t.Fatalf("alice should have been nudged about water, got %v", a.serviceNeeded)
+	}
+
+	// bob is now blocked and forced to refill; alice is to blame.
+	b, err := m.dispense("g1", "bob", "coffee", false, false)
+	if err != nil {
+		t.Fatalf("bob brew: %v", err)
+	}
+	if b.ok {
+		t.Fatal("bob should be blocked on empty water")
+	}
+	if b.blamedUserID != "alice" || b.blamedPart != "water" {
+		t.Errorf("blame = %q/%q, want alice/water", b.blamedUserID, b.blamedPart)
+	}
+	if c := countSlackers(m, t, "g1", "alice", "water"); c != 1 {
+		t.Errorf("alice should have 1 water slacker event, got %d", c)
+	}
+	// pending cleared, so a retry does not double-blame.
+	if _, ok := pendingServiceUser(m, t, "g1", "water"); ok {
+		t.Error("pending water should be cleared after blame")
+	}
+	b2, _ := m.dispense("g1", "bob", "coffee", false, false)
+	if b2.blamedUserID != "" {
+		t.Errorf("retry should not re-blame, got %q", b2.blamedUserID)
+	}
+	if c := countSlackers(m, t, "g1", "alice", "water"); c != 1 {
+		t.Errorf("retry should not add another slacker event, got %d", c)
+	}
+}
+
+func TestNoSelfBlame(t *testing.T) {
+	m := newTestModule(t)
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 })
+
+	if a, err := m.dispense("g1", "alice", "coffee", false, false); err != nil || !a.ok {
+		t.Fatalf("alice brew: err=%v fail=%q", err, a.failMsg)
+	}
+	// alice herself is blocked next; she shouldn't be blamed for her own mess.
+	a2, _ := m.dispense("g1", "alice", "coffee", false, false)
+	if a2.ok {
+		t.Fatal("expected block on empty water")
+	}
+	if a2.blamedUserID != "" {
+		t.Errorf("no self-blame expected, got %q", a2.blamedUserID)
+	}
+	if c := countSlackers(m, t, "g1", "alice", "water"); c != 0 {
+		t.Errorf("self-block should record no slacker event, got %d", c)
+	}
+}
+
+func TestRefillClearsPendingService(t *testing.T) {
+	m := newTestModule(t)
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 })
+	if a, err := m.dispense("g1", "alice", "coffee", false, false); err != nil || !a.ok {
+		t.Fatalf("alice brew: err=%v fail=%q", err, a.failMsg)
+	}
+	if _, ok := pendingServiceUser(m, t, "g1", "water"); !ok {
+		t.Fatal("expected pending water after alice's brew")
+	}
+
+	if _, err := m.refill("g1", "carol", "water"); err != nil {
+		t.Fatalf("refill: %v", err)
+	}
+	if _, ok := pendingServiceUser(m, t, "g1", "water"); ok {
+		t.Error("refilling water should clear the pending-service record")
+	}
+	// bob now brews fine and nobody is blamed.
+	b, _ := m.dispense("g1", "bob", "coffee", false, false)
+	if !b.ok || b.blamedUserID != "" {
+		t.Errorf("after refill bob should brew with no blame: ok=%v blame=%q", b.ok, b.blamedUserID)
+	}
+}
+
+func TestEmptyClearsPendingGrounds(t *testing.T) {
+	m := newTestModule(t)
+	// One coffee away from a full grounds container (coffee adds 20g).
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.GroundsGrams = maxGroundsG - 20 })
+	a, err := m.dispense("g1", "alice", "coffee", false, false)
+	if err != nil || !a.ok {
+		t.Fatalf("alice brew: err=%v fail=%q", err, a.failMsg)
+	}
+	if !slices.Contains(a.serviceNeeded, partGrounds) {
+		t.Fatalf("alice should be nudged about grounds, got %v", a.serviceNeeded)
+	}
+	if _, err := m.emptyGrounds("g1", "carol"); err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if _, ok := pendingServiceUser(m, t, "g1", partGrounds); ok {
+		t.Error("emptying grounds should clear the pending-service record")
+	}
+}
+
+func countSlackers(m *Module, t *testing.T, guildID, userID, part string) int64 {
+	t.Helper()
+	var c int64
+	if err := m.getDB().Model(&SlackerEvent{}).
+		Where("guild_id = ? AND user_id = ? AND part = ?", guildID, userID, part).
+		Count(&c).Error; err != nil {
+		t.Fatalf("count slackers: %v", err)
+	}
+	return c
+}
+
+func TestServiceHint(t *testing.T) {
+	if serviceHint(nil) != "" {
+		t.Error("no parts should yield no hint")
+	}
+	one := serviceHint([]string{"water"})
+	if !strings.Contains(one, "water") || !strings.Contains(one, "/coffeemachine refill") {
+		t.Errorf("single-part hint wrong: %q", one)
+	}
+	grounds := serviceHint([]string{partGrounds})
+	if !strings.Contains(grounds, "grounds container") || !strings.Contains(grounds, "/coffeemachine empty") {
+		t.Errorf("grounds hint should suggest empty: %q", grounds)
+	}
+	multi := serviceHint([]string{"water", "milk"})
+	if !strings.Contains(multi, "water and milk") || !strings.Contains(multi, "are running low") {
+		t.Errorf("multi-part hint wrong: %q", multi)
+	}
+}
+
+func TestBlockedFallbackWithBlame(t *testing.T) {
+	out := dispenseOutcome{failMsg: outOfMsg("water", "water"), blamedUserID: "alice", blamedPart: "water"}
+	got := blockedFallback(out)
+	if !strings.Contains(got, "<@alice>") || !strings.Contains(got, "water") {
+		t.Errorf("blame fallback should mention the slacker and part: %q", got)
+	}
+	noBlame := blockedFallback(dispenseOutcome{failMsg: "oops"})
+	if noBlame != "oops" {
+		t.Errorf("no-blame fallback should be the plain message, got %q", noBlame)
+	}
+}
+
+func TestExecuteBrewAppendsServiceHint(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "", nil)
+	_, edits, _ := captureBrewIO(m)
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 })
+
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+
+	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Heads up") {
+		t.Fatalf("final brew message should carry the service nudge, got %v", *edits)
+	}
+}
+
+func TestBlockedBrewMentionsSlacker(t *testing.T) {
+	m := newTestModule(t)
+	stubLLM(m, t, "", nil) // deterministic fallback keeps the mention intact
+	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 })
+	if _, err := m.dispense("g1", "alice", "coffee", false, false); err != nil {
+		t.Fatalf("alice brew: %v", err)
+	}
+
+	resp, _, _ := captureBrewIO(m)
+	bob := makeBrewInteraction("g1", strOpt("drink", "coffee"))
+	bob.Member.User.ID = "bob"
+	m.handleBrewInteraction(nil, bob)
+
+	if len(*resp) != 1 || !(*resp)[0].ephemeral {
+		t.Fatalf("expected 1 ephemeral blocked response, got %+v", *resp)
+	}
+	if !strings.Contains((*resp)[0].content, "<@alice>") {
+		t.Errorf("blocked message should name the slacker: %q", (*resp)[0].content)
+	}
+}
+
+// --- Detailed per-user stats -------------------------------------------------
+
+func TestTopGroundsEmptiers(t *testing.T) {
+	m := newTestModule(t)
+	d := m.getDB()
+	d.Create(&RefillEvent{GuildID: "g1", UserID: "A", Part: partGrounds, Amount: 200})
+	d.Create(&RefillEvent{GuildID: "g1", UserID: "A", Part: partGrounds, Amount: 280})
+	d.Create(&RefillEvent{GuildID: "g1", UserID: "B", Part: partGrounds, Amount: 100})
+	d.Create(&RefillEvent{GuildID: "g1", UserID: "A", Part: "water", Amount: 500}) // not a grounds empty
+
+	rows, err := m.topGroundsEmptiers("g1", 5)
+	if err != nil {
+		t.Fatalf("topGroundsEmptiers: %v", err)
+	}
+	if len(rows) != 2 || rows[0].UserID != "A" || rows[0].Count != 2 || rows[0].TotalGrams != 480 {
+		t.Fatalf("rows = %+v, want A first with 2×/480g", rows)
+	}
+	if avgGrams(rows[0].TotalGrams, rows[0].Count) != 240 {
+		t.Errorf("avg = %d, want 240", avgGrams(rows[0].TotalGrams, rows[0].Count))
+	}
+}
+
+func TestUserStatsBreakdowns(t *testing.T) {
+	m := newTestModule(t)
+	d := m.getDB()
+	d.Create(&DrinkEvent{GuildID: "g1", UserID: "A", Drink: "coffee"})
+	d.Create(&DrinkEvent{GuildID: "g1", UserID: "A", Drink: "coffee"})
+	d.Create(&DrinkEvent{GuildID: "g1", UserID: "A", Drink: "espresso"})
+	d.Create(&RefillEvent{GuildID: "g1", UserID: "A", Part: "water", Amount: 500})
+	d.Create(&RefillEvent{GuildID: "g1", UserID: "A", Part: "water", Amount: 300})
+	d.Create(&RefillEvent{GuildID: "g1", UserID: "A", Part: partGrounds, Amount: 250})
+	d.Create(&SlackerEvent{GuildID: "g1", UserID: "A", Part: "milk"})
+
+	drinks, _ := m.userDrinkBreakdown("g1", "A")
+	if len(drinks) != 2 || drinks[0].Key != "coffee" || drinks[0].Count != 2 {
+		t.Errorf("drink breakdown = %+v", drinks)
+	}
+	refills, _ := m.userRefillBreakdown("g1", "A")
+	if len(refills) != 1 || refills[0].Key != "water" || refills[0].Count != 2 || refills[0].Amount != 800 {
+		t.Errorf("refill breakdown = %+v (grounds must be excluded)", refills)
+	}
+	gc, gt, _ := m.userGroundsStats("g1", "A")
+	if gc != 1 || gt != 250 {
+		t.Errorf("grounds stats = %d×/%dg, want 1/250", gc, gt)
+	}
+	slack, _ := m.userSlackerBreakdown("g1", "A")
+	if len(slack) != 1 || slack[0].Key != "milk" || slack[0].Count != 1 {
+		t.Errorf("slacker breakdown = %+v", slack)
+	}
+}
+
+func TestFormatUserStats(t *testing.T) {
+	got := formatUserStats("A",
+		[]labelCount{{Key: "coffee", Count: 2}, {Key: "espresso", Count: 1}},
+		[]labelCount{{Key: "water", Count: 2, Amount: 800}},
+		1, 250,
+		[]labelCount{{Key: "milk", Count: 3}})
+	for _, want := range []string{"<@A>", "Coffee: 2", "Espresso: 1", "Water: 2× (800 total)", "1× · 250g total · 250g avg", "Milk: 3"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stats missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatUserStats_Empty(t *testing.T) {
+	got := formatUserStats("A", nil, nil, 0, 0, nil)
+	if !strings.Contains(got, "Grounds emptied:** never") {
+		t.Errorf("empty grounds should read 'never': %q", got)
+	}
+	if strings.Contains(got, "Slacker misses") {
+		t.Errorf("no slacker section when clean: %q", got)
+	}
+}
+
+func TestTopSlackers(t *testing.T) {
+	m := newTestModule(t)
+	d := m.getDB()
+	d.Create(&SlackerEvent{GuildID: "g1", UserID: "A", Part: "water"})
+	d.Create(&SlackerEvent{GuildID: "g1", UserID: "A", Part: "milk"})
+	d.Create(&SlackerEvent{GuildID: "g1", UserID: "B", Part: partGrounds})
+	d.Create(&SlackerEvent{GuildID: "other", UserID: "Z", Part: "water"})
+
+	rows, err := m.topSlackers("g1", 5)
+	if err != nil {
+		t.Fatalf("topSlackers: %v", err)
+	}
+	if len(rows) != 2 || rows[0].UserID != "A" || rows[0].Count != 2 {
+		t.Errorf("topSlackers = %+v, want A(2) then B(1)", rows)
 	}
 }

--- a/internal/coffee/machine_test.go
+++ b/internal/coffee/machine_test.go
@@ -534,8 +534,8 @@ func TestHandleBrew_BlockedShowsErrorNoBrewing(t *testing.T) {
 
 	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
-	if len(*resp) != 1 || !(*resp)[0].ephemeral {
-		t.Fatalf("expected 1 ephemeral error response, got %+v", *resp)
+	if len(*resp) != 1 || (*resp)[0].ephemeral {
+		t.Fatalf("expected 1 public error response, got %+v", *resp)
 	}
 	if !strings.Contains((*resp)[0].content, "water") {
 		t.Errorf("error should name the missing ingredient: %q", (*resp)[0].content)
@@ -557,8 +557,8 @@ func TestHandleBrew_SuccessShowsBrewingThenFinalNoStats(t *testing.T) {
 
 	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
-	if len(*resp) != 1 || !(*resp)[0].ephemeral {
-		t.Fatalf("expected 1 ephemeral brewing response, got %+v", *resp)
+	if len(*resp) != 1 || (*resp)[0].ephemeral {
+		t.Fatalf("expected 1 public brewing response, got %+v", *resp)
 	}
 	if !strings.Contains((*resp)[0].content, "Brewing") {
 		t.Errorf("first response should be a brewing status: %q", (*resp)[0].content)
@@ -575,7 +575,7 @@ func TestHandleBrew_SuccessShowsBrewingThenFinalNoStats(t *testing.T) {
 		t.Fatalf("expected 1 final edit, got %d", len(*edits))
 	}
 	final := (*edits)[0]
-	if !strings.Contains(final, "Here's your Coffee") {
+	if !strings.Contains(final, "Coffee is ready") {
 		t.Errorf("final message wrong: %q", final)
 	}
 	if strings.Contains(final, "Grounds") || strings.Contains(final, "·") {
@@ -842,11 +842,11 @@ func TestCoffeeComponent_TogglesAndSelect(t *testing.T) {
 	_, updates := captureMenuIO(m)
 
 	// select espresso
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "pick", brewCfg{choice: "coffee"}), "espresso"))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "pick", brewCfg{opener: "u1", choice: "coffee"}), "espresso"))
 	// toggle milk on (state still carries espresso)
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{choice: "espresso"})))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{opener: "u1", choice: "espresso"})))
 	// toggle sugar on
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "sugar", brewCfg{choice: "espresso", milk: true})))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "sugar", brewCfg{opener: "u1", choice: "espresso", milk: true})))
 
 	if len(*updates) != 3 {
 		t.Fatalf("expected 3 in-place menu updates, got %d", len(*updates))
@@ -868,7 +868,7 @@ func TestCoffeeComponent_GoBrews(t *testing.T) {
 	resp, edits, sleeps := captureBrewIO(m)
 	_, _ = captureMenuIO(m)
 
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "go", brewCfg{choice: "espresso", milk: true, sugar: true})))
+	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "go", brewCfg{opener: "u1", choice: "espresso", milk: true, sugar: true})))
 
 	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
 		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
@@ -892,7 +892,7 @@ func TestTeaComponent_GoBrews(t *testing.T) {
 	resp, edits, sleeps := captureBrewIO(m)
 	_, _ = captureMenuIO(m)
 
-	m.handleTeaComponent(nil, makeBrewComponent("g1", encodeBrewCfg(teaCfgPrefix, "go", brewCfg{choice: "rooibos", milk: true})))
+	m.handleTeaComponent(nil, makeBrewComponent("g1", encodeBrewCfg(teaCfgPrefix, "go", brewCfg{opener: "u1", choice: "rooibos", milk: true})))
 
 	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
 		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
@@ -914,14 +914,32 @@ func TestTakeCup_Confirms(t *testing.T) {
 	m := newTestModule(t)
 	resp, _, _ := captureBrewIO(m)
 
-	id := strings.Join([]string{takeCupPrefix, "espresso", ""}, ":")
+	id := strings.Join([]string{takeCupPrefix, "u1", "espresso", ""}, ":")
 	m.handleTakeCupComponent(nil, makeBrewComponent("g1", id))
 
 	if len(*resp) != 1 {
 		t.Fatalf("expected 1 confirmation update, got %d", len(*resp))
 	}
-	if !strings.Contains((*resp)[0].content, "grabbed your Espresso") {
+	if !strings.Contains((*resp)[0].content, "grabbed their Espresso") {
 		t.Errorf("take-cup confirmation should name the drink: %q", (*resp)[0].content)
+	}
+}
+
+func TestTakeCup_RejectsNonOwner(t *testing.T) {
+	m := newTestModule(t)
+	resp, _, _ := captureBrewIO(m)
+	var updates int
+	m.respondUpdate = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ string) { updates++ }
+
+	// orderer is "alice", but the interaction comes from "u1"
+	id := strings.Join([]string{takeCupPrefix, "alice", "espresso", ""}, ":")
+	m.handleTakeCupComponent(nil, makeBrewComponent("g1", id))
+
+	if updates != 0 {
+		t.Errorf("a non-owner must not alter the drink message")
+	}
+	if len(*resp) != 1 || !(*resp)[0].ephemeral {
+		t.Fatalf("non-owner should get an ephemeral nudge, got %+v", *resp)
 	}
 }
 
@@ -1175,8 +1193,8 @@ func TestBlockedBrewMentionsSlacker(t *testing.T) {
 	bob.Member.User.ID = "bob"
 	m.handleCoffeeInteraction(nil, bob)
 
-	if len(*resp) != 1 || !(*resp)[0].ephemeral {
-		t.Fatalf("expected 1 ephemeral blocked response, got %+v", *resp)
+	if len(*resp) != 1 || (*resp)[0].ephemeral {
+		t.Fatalf("expected 1 public blocked response, got %+v", *resp)
 	}
 	if !strings.Contains((*resp)[0].content, "<@alice>") {
 		t.Errorf("blocked message should name the slacker: %q", (*resp)[0].content)

--- a/internal/coffee/machine_test.go
+++ b/internal/coffee/machine_test.go
@@ -157,9 +157,9 @@ func TestDispenseSugar_IsCosmetic(t *testing.T) {
 	}
 }
 
-func TestDispenseHotWater_NoBeansNoGrounds(t *testing.T) {
+func TestDispenseTea_NoBeansNoGrounds(t *testing.T) {
 	m := newTestModule(t)
-	out, err := m.dispense("g1", "u", "hot_water", false, false)
+	out, err := m.dispense("g1", "u", "tea_black", false, false)
 	if err != nil || !out.ok {
 		t.Fatalf("dispense failed: err=%v fail=%q", err, out.failMsg)
 	}
@@ -167,10 +167,10 @@ func TestDispenseHotWater_NoBeansNoGrounds(t *testing.T) {
 		t.Errorf("water = %d, want %d", out.inventory.WaterMl, maxWaterMl-200)
 	}
 	if out.inventory.GroundsGrams != 0 {
-		t.Errorf("hot water should produce no grounds, got %d", out.inventory.GroundsGrams)
+		t.Errorf("tea should produce no grounds, got %d", out.inventory.GroundsGrams)
 	}
 	if out.inventory.BeansMildGrams != maxBeansMildG || out.inventory.BeansEspressoGrams != maxBeansEspressoG {
-		t.Error("hot water should use no beans")
+		t.Error("tea should use no beans")
 	}
 }
 
@@ -382,7 +382,7 @@ func TestLeaderboards(t *testing.T) {
 
 func TestFormatDispenseSuccess(t *testing.T) {
 	r, _ := recipeByKey("coffee")
-	got := formatDispenseSuccess(r, true, true, "")
+	got := formatDispenseSuccess(r, true, true)
 	if !strings.Contains(got, "Coffee with milk and sugar") {
 		t.Errorf("missing extras phrasing: %q", got)
 	}
@@ -391,46 +391,41 @@ func TestFormatDispenseSuccess(t *testing.T) {
 		t.Errorf("brew message should not include machine stats: %q", got)
 	}
 
-	plain := formatDispenseSuccess(r, false, false, "")
+	plain := formatDispenseSuccess(r, false, false)
 	if strings.Contains(plain, "with") {
 		t.Errorf("plain drink should have no extras phrasing: %q", plain)
 	}
 }
 
 func TestFormatDispenseSuccess_Tea(t *testing.T) {
-	hot, _ := recipeByKey("hot_water")
-
-	tea := formatDispenseSuccess(hot, false, false, "peppermint")
+	peppermint, _ := recipeByKey("tea_peppermint")
+	tea := formatDispenseSuccess(peppermint, false, false)
 	if !strings.Contains(tea, "🍵 Here's your Peppermint tea!") {
 		t.Errorf("tea phrasing wrong: %q", tea)
 	}
 
-	teaMilk := formatDispenseSuccess(hot, true, false, "earl_grey")
+	earlGrey, _ := recipeByKey("tea_earl_grey")
+	teaMilk := formatDispenseSuccess(earlGrey, true, false)
 	if !strings.Contains(teaMilk, "Earl Grey tea with milk") {
 		t.Errorf("tea+milk phrasing wrong: %q", teaMilk)
 	}
 
-	plainWater := formatDispenseSuccess(hot, false, false, "")
-	if !strings.Contains(plainWater, "☕ Here's your Hot water!") {
-		t.Errorf("plain hot water phrasing wrong: %q", plainWater)
-	}
-
-	// tea is ignored for non-hot-water drinks
+	// coffee drink should not show tea emoji
 	coffee, _ := recipeByKey("coffee")
-	c := formatDispenseSuccess(coffee, false, false, "green")
-	if strings.Contains(c, "tea") || strings.Contains(c, "🍵") {
-		t.Errorf("tea should be ignored for coffee: %q", c)
+	c := formatDispenseSuccess(coffee, false, false)
+	if strings.Contains(c, "🍵") {
+		t.Errorf("coffee should not show tea emoji: %q", c)
 	}
 }
 
 func TestBrewTimeVariesByDrink(t *testing.T) {
-	hot, _ := recipeByKey("hot_water")
+	tea, _ := recipeByKey("tea_black")
 	flat, _ := recipeByKey("flat_white")
-	if brewTime(hot) >= brewTime(flat) {
-		t.Errorf("hot water (%v) should brew faster than flat white (%v)", brewTime(hot), brewTime(flat))
+	if brewTime(tea) >= brewTime(flat) {
+		t.Errorf("tea (%v) should brew faster than flat white (%v)", brewTime(tea), brewTime(flat))
 	}
-	if brewTime(hot) <= 0 {
-		t.Errorf("brew time must be positive, got %v", brewTime(hot))
+	if brewTime(tea) <= 0 {
+		t.Errorf("brew time must be positive, got %v", brewTime(tea))
 	}
 }
 
@@ -532,7 +527,7 @@ func TestHandleBrew_BlockedShowsErrorNoBrewing(t *testing.T) {
 	resp, edits, sleeps := captureBrewIO(m)
 	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 10 })
 
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*resp) != 1 || (*resp)[0].ephemeral {
 		t.Fatalf("expected 1 public error response, got %+v", *resp)
@@ -555,7 +550,7 @@ func TestHandleBrew_SuccessShowsBrewingThenFinalNoStats(t *testing.T) {
 	stubLLM(m, t, "", nil) // fallback messages
 	resp, edits, sleeps := captureBrewIO(m)
 
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*resp) != 1 || (*resp)[0].ephemeral {
 		t.Fatalf("expected 1 public brewing response, got %+v", *resp)
@@ -591,19 +586,23 @@ func TestHandleBrew_UsesLLMForVariation(t *testing.T) {
 	stubLLM(m, t, "Dein Kaffee ist fertig!", nil) // non-empty -> LLM text used
 	_, edits, _ := captureBrewIO(m)
 
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*edits) != 1 || (*edits)[0] != "Dein Kaffee ist fertig!" {
 		t.Errorf("final message should come from the LLM, got %v", *edits)
 	}
 }
 
-func TestTeaLabel(t *testing.T) {
-	if l, ok := teaLabel("earl_grey"); !ok || l != "Earl Grey" {
-		t.Errorf("teaLabel(earl_grey) = %q,%v", l, ok)
+func TestTeaFlavorLabel(t *testing.T) {
+	if l := teaFlavorLabel("earl_grey"); l != "Earl Grey" {
+		t.Errorf("teaFlavorLabel(earl_grey) = %q, want Earl Grey", l)
 	}
-	if _, ok := teaLabel("bubble"); ok {
-		t.Error("teaLabel(bubble) should be unknown")
+	if l := teaFlavorLabel("peppermint"); l != "Peppermint" {
+		t.Errorf("teaFlavorLabel(peppermint) = %q, want Peppermint", l)
+	}
+	// Unknown flavor falls back to the key itself (used in display strings).
+	if l := teaFlavorLabel("bubble"); l != "bubble" {
+		t.Errorf("teaFlavorLabel(bubble) = %q, want bubble (key passthrough)", l)
 	}
 }
 
@@ -613,7 +612,8 @@ func TestFormatStatus(t *testing.T) {
 		[]userCount{{UserID: "A", Count: 3}},
 		nil,
 		[]groundsEmptier{{UserID: "A", Count: 2, TotalGrams: 480}},
-		[]userCount{{UserID: "B", Count: 1}})
+		[]userCount{{UserID: "B", Count: 1}},
+		nil)
 	if !strings.Contains(got, "Mild beans: 500/1000g (50%)") {
 		t.Errorf("missing mild beans line with percent: %q", got)
 	}
@@ -636,7 +636,7 @@ func TestFormatStatus(t *testing.T) {
 
 func TestFormatStatus_NoSlackersHidesSection(t *testing.T) {
 	inv := MachineInventory{}
-	got := formatStatus(inv, nil, nil, nil, nil)
+	got := formatStatus(inv, nil, nil, nil, nil, nil)
 	if strings.Contains(got, "Slackers") {
 		t.Errorf("slacker section should be hidden when there are none: %q", got)
 	}
@@ -662,45 +662,30 @@ func TestPercent(t *testing.T) {
 	}
 }
 
-// --- /tea command -----------------------------------------------------------
-
-func makeTeaInteraction(guildID string, opts ...*discordgo.ApplicationCommandInteractionDataOption) *discordgo.InteractionCreate {
-	return &discordgo.InteractionCreate{
-		Interaction: &discordgo.Interaction{
-			GuildID:   guildID,
-			ChannelID: "ch1",
-			Type:      discordgo.InteractionApplicationCommand,
-			Member:    &discordgo.Member{User: &discordgo.User{ID: "u1"}},
-			Data: discordgo.ApplicationCommandInteractionData{
-				Name:    "tea",
-				Options: opts,
-			},
-		},
-	}
-}
+// --- /brew tea tests ---------------------------------------------------------
 
 func TestHandleTea_BrewsTeaNotCoffee(t *testing.T) {
 	m := newTestModule(t)
 	stubLLM(m, t, "", nil) // deterministic fallback
 	_, edits, _ := captureBrewIO(m)
 
-	m.handleTeaInteraction(nil, makeTeaInteraction("g1", strOpt("flavor", "rooibos")))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "tea_rooibos")))
 
 	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Rooibos tea") {
 		t.Fatalf("expected a Rooibos tea, got %v", *edits)
 	}
-	// Tea is hot water: no beans, no grounds, only water consumed.
+	// Tea uses only water, no beans, no grounds.
 	inv, _ := m.getOrSeedInventory("g1")
 	if inv.GroundsGrams != 0 || inv.BeansMildGrams != maxBeansMildG || inv.BeansEspressoGrams != maxBeansEspressoG {
-		t.Errorf("tea should brew from hot water only: %+v", inv)
+		t.Errorf("tea should brew from water only: %+v", inv)
 	}
 	if inv.WaterMl != maxWaterMl-200 {
 		t.Errorf("tea should consume 200ml water, got %d", inv.WaterMl)
 	}
 	var de DrinkEvent
 	m.getDB().Where("guild_id = ?", "g1").First(&de)
-	if de.Drink != "hot_water" {
-		t.Errorf("tea DrinkEvent drink = %q, want hot_water", de.Drink)
+	if de.Drink != "tea_rooibos" {
+		t.Errorf("tea DrinkEvent drink = %q, want tea_rooibos", de.Drink)
 	}
 }
 
@@ -709,7 +694,7 @@ func TestHandleTea_WithMilk(t *testing.T) {
 	stubLLM(m, t, "", nil)
 	_, edits, _ := captureBrewIO(m)
 
-	m.handleTeaInteraction(nil, makeTeaInteraction("g1", strOpt("flavor", "earl_grey"), boolOpt("milk", true)))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "tea_earl_grey"), boolOpt("milk", true)))
 
 	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Earl Grey tea with milk") {
 		t.Fatalf("expected Earl Grey tea with milk, got %v", *edits)
@@ -761,39 +746,46 @@ func menuCfg(t *testing.T, prefix string, comps []discordgo.MessageComponent) br
 
 func TestBrewCfgRoundTrip(t *testing.T) {
 	in := brewCfg{choice: "latte_macchiato", milk: true, sugar: false}
-	action, out, ok := parseBrewCfg(coffeeCfgPrefix, encodeBrewCfg(coffeeCfgPrefix, "go", in))
+	action, out, ok := parseBrewCfg(brewCfgPrefix, encodeBrewCfg(brewCfgPrefix, "go", in))
 	if !ok || action != "go" || out != in {
 		t.Fatalf("round trip failed: action=%q out=%+v ok=%v", action, out, ok)
 	}
-	// The tea menu uses a different prefix, so a coffee custom ID must not parse
-	// as tea (prevents the two menus' components from cross-firing).
-	if _, _, ok := parseBrewCfg(teaCfgPrefix, encodeBrewCfg(coffeeCfgPrefix, "go", in)); ok {
-		t.Error("coffee custom ID should not parse under the tea prefix")
-	}
-	if _, _, ok := parseBrewCfg(coffeeCfgPrefix, "coffee_brew_cfg:go:coffee"); ok {
+	// A truncated ID (missing fields) must not parse.
+	if _, _, ok := parseBrewCfg(brewCfgPrefix, "coffee_brew_cfg:go:coffee"); ok {
 		t.Error("truncated custom ID should not parse")
+	}
+	// A completely wrong prefix must not parse.
+	if _, _, ok := parseBrewCfg(brewCfgPrefix, "other_prefix:go:coffee:0:0:"); ok {
+		t.Error("wrong prefix must not parse")
 	}
 }
 
 func TestCoffeeMenuExcludesHotWater(t *testing.T) {
-	for _, r := range coffeeMenu() {
-		if r.key == "hot_water" {
-			t.Fatal("coffee menu must not offer hot water (that's /tea now)")
+	// hot_water is gone; /brew now offers teas as first-class drinks.
+	for _, ch := range brewChoices() {
+		if ch.Value == "hot_water" {
+			t.Fatal("brew choices must not include hot_water")
 		}
 	}
-	for _, ch := range drinkChoices() {
-		if ch.Value == "hot_water" {
-			t.Fatal("/coffee drink choices must not include hot water")
+	// At least one tea must be present in the unified menu.
+	foundTea := false
+	for _, ch := range brewChoices() {
+		if strings.HasPrefix(ch.Value.(string), "tea_") {
+			foundTea = true
+			break
 		}
+	}
+	if !foundTea {
+		t.Fatal("brew choices must include at least one tea_* option")
 	}
 }
 
 func TestCoffeeMenuComponents_ReflectState(t *testing.T) {
-	comps := coffeeMenuComponents(brewCfg{choice: "espresso", milk: true, sugar: false})
+	comps := brewMenuComponents(brewCfg{choice: "espresso", milk: true, sugar: false})
 	if d := menuSelectedDrink(t, comps); d != "espresso" {
 		t.Errorf("selected drink = %q, want espresso", d)
 	}
-	if c := menuCfg(t, coffeeCfgPrefix, comps); !c.milk || c.sugar {
+	if c := menuCfg(t, brewCfgPrefix, comps); !c.milk || c.sugar {
 		t.Errorf("button state cfg = %+v, want milk on/sugar off", c)
 	}
 }
@@ -804,7 +796,7 @@ func TestCoffee_NoOptionsOpensMenu(t *testing.T) {
 	opens, _ := captureMenuIO(m)
 	resp, _, _ := captureBrewIO(m)
 
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1")) // no options
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1")) // no options
 
 	if len(*opens) != 1 {
 		t.Fatalf("expected the menu to open once, got %d", len(*opens))
@@ -822,20 +814,22 @@ func TestCoffee_NoOptionsOpensMenu(t *testing.T) {
 
 func TestTea_NoOptionsOpensMenu(t *testing.T) {
 	m := newTestModule(t)
-	stubLLM(m, t, "", nil) // empty reply -> English fallback prompt
+	stubLLM(m, t, "", nil)
 	opens, _ := captureMenuIO(m)
 	resp, _, _ := captureBrewIO(m)
 
-	m.handleTeaInteraction(nil, makeTeaInteraction("g1")) // no options
+	// /brew with no options opens the unified menu (defaults to first coffee).
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1"))
 
 	if len(*opens) != 1 {
-		t.Fatalf("expected the tea menu to open once, got %d", len(*opens))
+		t.Fatalf("expected menu to open once, got %d", len(*opens))
 	}
 	if len(*resp) != 0 {
-		t.Errorf("no-options /tea should not brew directly, got %+v", *resp)
+		t.Errorf("no-options /brew should not brew directly, got %+v", *resp)
 	}
-	if d := menuSelectedDrink(t, (*opens)[0].comps); d != teaFlavors[0].key {
-		t.Errorf("tea menu should default to %q, got %q", teaFlavors[0].key, d)
+	// Default is coffee (first menu item).
+	if d := menuSelectedDrink(t, (*opens)[0].comps); d != "coffee" {
+		t.Errorf("menu should default to coffee, got %q", d)
 	}
 }
 
@@ -845,11 +839,11 @@ func TestCoffeeComponent_TogglesAndSelect(t *testing.T) {
 	_, updates := captureMenuIO(m)
 
 	// select espresso
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "pick", brewCfg{opener: "u1", choice: "coffee"}), "espresso"))
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "pick", brewCfg{opener: "u1", choice: "coffee"}), "espresso"))
 	// toggle milk on (state still carries espresso)
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{opener: "u1", choice: "espresso"})))
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "milk", brewCfg{opener: "u1", choice: "espresso"})))
 	// toggle sugar on
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "sugar", brewCfg{opener: "u1", choice: "espresso", milk: true})))
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "sugar", brewCfg{opener: "u1", choice: "espresso", milk: true})))
 
 	if len(*updates) != 3 {
 		t.Fatalf("expected 3 in-place menu updates, got %d", len(*updates))
@@ -857,10 +851,10 @@ func TestCoffeeComponent_TogglesAndSelect(t *testing.T) {
 	if d := menuSelectedDrink(t, (*updates)[0].comps); d != "espresso" {
 		t.Errorf("after select, drink = %q, want espresso", d)
 	}
-	if c := menuCfg(t, coffeeCfgPrefix, (*updates)[1].comps); !c.milk {
+	if c := menuCfg(t, brewCfgPrefix, (*updates)[1].comps); !c.milk {
 		t.Errorf("after milk toggle, cfg = %+v, want milk on", c)
 	}
-	if c := menuCfg(t, coffeeCfgPrefix, (*updates)[2].comps); !c.sugar || !c.milk {
+	if c := menuCfg(t, brewCfgPrefix, (*updates)[2].comps); !c.sugar || !c.milk {
 		t.Errorf("after sugar toggle, cfg = %+v, want milk+sugar on", c)
 	}
 }
@@ -871,13 +865,13 @@ func TestMenuPromptLocalizedAndCached(t *testing.T) {
 	opens, updates := captureMenuIO(m)
 
 	// Opening the menu translates the prompt once.
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1")) // no options -> menu
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1")) // no options -> menu
 	if len(*opens) != 1 || (*opens)[0].content != "Was darf es sein?" {
 		t.Fatalf("menu prompt should be the localized text, got %+v", *opens)
 	}
 
 	// A toggle re-renders the menu but must reuse the cached translation.
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{opener: "u1", choice: "coffee"})))
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "milk", brewCfg{opener: "u1", choice: "coffee"})))
 	if len(*updates) != 1 || (*updates)[0].content != "Was darf es sein?" {
 		t.Fatalf("re-render should keep the localized prompt, got %+v", *updates)
 	}
@@ -894,7 +888,7 @@ func TestEnsureOpenerNudgeLocalized(t *testing.T) {
 
 	// The clicking user is "u1" (set by makeBrewComponent) but the menu is owned
 	// by "alice", so the click is rejected with a localized ephemeral nudge.
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "milk", brewCfg{opener: "alice", choice: "coffee"})))
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "milk", brewCfg{opener: "alice", choice: "coffee"})))
 
 	if len(*resp) != 1 || !(*resp)[0].ephemeral {
 		t.Fatalf("non-owner should get an ephemeral nudge, got %+v", *resp)
@@ -910,7 +904,7 @@ func TestCoffeeComponent_GoBrews(t *testing.T) {
 	resp, edits, sleeps := captureBrewIO(m)
 	_, _ = captureMenuIO(m)
 
-	m.handleCoffeeComponent(nil, makeBrewComponent("g1", encodeBrewCfg(coffeeCfgPrefix, "go", brewCfg{opener: "u1", choice: "espresso", milk: true, sugar: true})))
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "go", brewCfg{opener: "u1", choice: "espresso", milk: true, sugar: true})))
 
 	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
 		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
@@ -934,7 +928,7 @@ func TestTeaComponent_GoBrews(t *testing.T) {
 	resp, edits, sleeps := captureBrewIO(m)
 	_, _ = captureMenuIO(m)
 
-	m.handleTeaComponent(nil, makeBrewComponent("g1", encodeBrewCfg(teaCfgPrefix, "go", brewCfg{opener: "u1", choice: "rooibos", milk: true})))
+	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "go", brewCfg{opener: "u1", choice: "tea_rooibos", milk: true})))
 
 	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
 		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
@@ -947,8 +941,8 @@ func TestTeaComponent_GoBrews(t *testing.T) {
 	}
 	var de DrinkEvent
 	m.getDB().Where("guild_id = ?", "g1").First(&de)
-	if de.Drink != "hot_water" || !de.WithMilk {
-		t.Errorf("tea brew DrinkEvent = %+v, want hot_water with milk", de)
+	if de.Drink != "tea_rooibos" || !de.WithMilk {
+		t.Errorf("tea brew DrinkEvent = %+v, want tea_rooibos with milk", de)
 	}
 }
 
@@ -957,7 +951,7 @@ func TestTakeCup_Confirms(t *testing.T) {
 	stubLLM(m, t, "", nil) // empty reply -> English fallback confirmation
 	resp, _, _ := captureBrewIO(m)
 
-	id := strings.Join([]string{takeCupPrefix, "u1", "espresso", ""}, ":")
+	id := strings.Join([]string{takeCupPrefix, "u1", "espresso"}, ":")
 	m.handleTakeCupComponent(nil, makeBrewComponent("g1", id))
 
 	if len(*resp) != 1 {
@@ -976,7 +970,7 @@ func TestTakeCup_RejectsNonOwner(t *testing.T) {
 	m.respondUpdate = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ string) { updates++ }
 
 	// orderer is "alice", but the interaction comes from "u1"
-	id := strings.Join([]string{takeCupPrefix, "alice", "espresso", ""}, ":")
+	id := strings.Join([]string{takeCupPrefix, "alice", "espresso"}, ":")
 	m.handleTakeCupComponent(nil, makeBrewComponent("g1", id))
 
 	if updates != 0 {
@@ -997,7 +991,7 @@ func TestExecuteBrew_AttachesTakeCupButton(t *testing.T) {
 	}
 	m.sleep = func(time.Duration) {}
 
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(finalComps) != 1 {
 		t.Fatalf("expected the finished drink to carry a Take cup row, got %d rows", len(finalComps))
@@ -1217,7 +1211,7 @@ func TestExecuteBrewAppendsServiceHint(t *testing.T) {
 	_, edits, _ := captureBrewIO(m)
 	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 })
 
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Heads up") {
 		t.Fatalf("final brew message should carry the service nudge, got %v", *edits)
@@ -1230,7 +1224,7 @@ func TestExecuteBrew_FoldsServiceHintIntoLLMScenario(t *testing.T) {
 	_, edits, _ := captureBrewIO(m)
 	setLevels(m, t, "g1", func(inv *MachineInventory) { inv.WaterMl = 120 }) // empties on brew
 
-	m.handleCoffeeInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
+	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
 	// The nudge must reach the LLM (so it gets translated), not be appended in
 	// English after generation.
@@ -1260,7 +1254,7 @@ func TestBlockedBrewMentionsSlacker(t *testing.T) {
 	resp, _, _ := captureBrewIO(m)
 	bob := makeBrewInteraction("g1", strOpt("drink", "coffee"))
 	bob.Member.User.ID = "bob"
-	m.handleCoffeeInteraction(nil, bob)
+	m.handleBrewInteraction(nil, bob)
 
 	if len(*resp) != 1 || (*resp)[0].ephemeral {
 		t.Fatalf("expected 1 public blocked response, got %+v", *resp)

--- a/internal/coffee/store.go
+++ b/internal/coffee/store.go
@@ -73,6 +73,34 @@ type DrinkEvent struct {
 // TableName returns the database table name.
 func (DrinkEvent) TableName() string { return "coffee_drink_events" }
 
+// PendingService tracks, per guild and part, the user who last brewed and left
+// that part low enough that the next brew could be blocked. Exactly one row per
+// (guild, part). It is set after a brew leaves the part needing service, blamed
+// (and removed) when a later brew is blocked on the part, and removed when the
+// part is refilled or emptied.
+type PendingService struct {
+	gorm.Model
+	GuildID string `gorm:"not null;uniqueIndex:idx_pending_guild_part"`
+	Part    string `gorm:"not null;uniqueIndex:idx_pending_guild_part"`
+	UserID  string `gorm:"not null"`
+}
+
+// TableName returns the database table name.
+func (PendingService) TableName() string { return "coffee_pending_service" }
+
+// SlackerEvent records a single instance of a user being blamed for leaving a
+// part empty/full so that the next user was forced to refill or empty it. The
+// Part distinguishes each consumable (and the grounds container).
+type SlackerEvent struct {
+	gorm.Model
+	GuildID string `gorm:"not null;index"`
+	UserID  string `gorm:"not null;index"`
+	Part    string `gorm:"not null"`
+}
+
+// TableName returns the database table name.
+func (SlackerEvent) TableName() string { return "coffee_slacker_events" }
+
 func (m *Module) getDB() *gorm.DB {
 	m.dbMu.RLock()
 	defer m.dbMu.RUnlock()
@@ -88,7 +116,8 @@ func (m *Module) openStore(path string) error {
 		return err
 	}
 	return m.db.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{},
-		&MachineInventory{}, &RefillEvent{}, &DrinkEvent{})
+		&MachineInventory{}, &RefillEvent{}, &DrinkEvent{},
+		&PendingService{}, &SlackerEvent{})
 }
 
 func (m *Module) closeStore() error {
@@ -269,4 +298,137 @@ func (m *Module) groundsEmptiedCount(guildID string) (int64, error) {
 		Where("guild_id = ? AND part = ?", guildID, partGrounds).
 		Count(&c).Error
 	return c, err
+}
+
+// groundsEmptier is a per-user aggregate of grounds-empty actions: how many
+// times and how many grams total. The average is derived in formatting.
+type groundsEmptier struct {
+	UserID     string
+	Count      int
+	TotalGrams int
+}
+
+// topGroundsEmptiers returns the users who emptied the grounds container most
+// often in the guild, with their total grams removed, most first, capped at
+// limit.
+func (m *Module) topGroundsEmptiers(guildID string, limit int) ([]groundsEmptier, error) {
+	d := m.getDB()
+	if d == nil {
+		return nil, errors.New("store not initialized")
+	}
+	var rows []groundsEmptier
+	err := d.Model(&RefillEvent{}).
+		Select("user_id, count(*) as count, sum(amount) as total_grams").
+		Where("guild_id = ? AND part = ?", guildID, partGrounds).
+		Group("user_id").
+		Order("count DESC, total_grams DESC, user_id ASC").
+		Limit(limit).
+		Scan(&rows).Error
+	return rows, err
+}
+
+// topSlackers returns the users with the most slacker blames (across all parts)
+// in the guild, most first, capped at limit.
+func (m *Module) topSlackers(guildID string, limit int) ([]userCount, error) {
+	d := m.getDB()
+	if d == nil {
+		return nil, errors.New("store not initialized")
+	}
+	var rows []userCount
+	err := d.Model(&SlackerEvent{}).
+		Select("user_id, count(*) as count").
+		Where("guild_id = ?", guildID).
+		Group("user_id").
+		Order("count DESC, user_id ASC").
+		Limit(limit).
+		Scan(&rows).Error
+	return rows, err
+}
+
+// labelCount is a generic (key, count) aggregate, optionally carrying a summed
+// amount, used for per-user stat breakdowns.
+type labelCount struct {
+	Key    string
+	Count  int
+	Amount int
+}
+
+// userDrinkBreakdown returns the per-drink counts for a single user in a guild.
+func (m *Module) userDrinkBreakdown(guildID, userID string) ([]labelCount, error) {
+	d := m.getDB()
+	if d == nil {
+		return nil, errors.New("store not initialized")
+	}
+	var rows []labelCount
+	err := d.Model(&DrinkEvent{}).
+		Select("drink as key, count(*) as count").
+		Where("guild_id = ? AND user_id = ?", guildID, userID).
+		Group("drink").
+		Order("count DESC, drink ASC").
+		Scan(&rows).Error
+	return rows, err
+}
+
+// userRefillBreakdown returns the per-part refill counts and summed amounts for
+// a single user in a guild, grounds-empties excluded.
+func (m *Module) userRefillBreakdown(guildID, userID string) ([]labelCount, error) {
+	d := m.getDB()
+	if d == nil {
+		return nil, errors.New("store not initialized")
+	}
+	var rows []labelCount
+	err := d.Model(&RefillEvent{}).
+		Select("part as key, count(*) as count, sum(amount) as amount").
+		Where("guild_id = ? AND user_id = ? AND part <> ?", guildID, userID, partGrounds).
+		Group("part").
+		Order("count DESC, part ASC").
+		Scan(&rows).Error
+	return rows, err
+}
+
+// userGroundsStats returns how many times and how many grams of grounds a single
+// user emptied in a guild.
+func (m *Module) userGroundsStats(guildID, userID string) (count, totalGrams int, err error) {
+	d := m.getDB()
+	if d == nil {
+		return 0, 0, errors.New("store not initialized")
+	}
+	var row labelCount
+	e := d.Model(&RefillEvent{}).
+		Select("count(*) as count, sum(amount) as amount").
+		Where("guild_id = ? AND user_id = ? AND part = ?", guildID, userID, partGrounds).
+		Scan(&row).Error
+	return row.Count, row.Amount, e
+}
+
+// userSlackerBreakdown returns the per-part slacker blame counts for a single
+// user in a guild.
+func (m *Module) userSlackerBreakdown(guildID, userID string) ([]labelCount, error) {
+	d := m.getDB()
+	if d == nil {
+		return nil, errors.New("store not initialized")
+	}
+	var rows []labelCount
+	err := d.Model(&SlackerEvent{}).
+		Select("part as key, count(*) as count").
+		Where("guild_id = ? AND user_id = ?", guildID, userID).
+		Group("part").
+		Order("count DESC, part ASC").
+		Scan(&rows).Error
+	return rows, err
+}
+
+// setPendingServiceTx records userID as on the hook for servicing part in
+// guildID, overwriting any prior pending record for that part.
+func setPendingServiceTx(tx *gorm.DB, guildID, part, userID string) error {
+	var ps PendingService
+	return tx.Where(PendingService{GuildID: guildID, Part: part}).
+		Assign(PendingService{UserID: userID}).
+		FirstOrCreate(&ps).Error
+}
+
+// clearPendingServiceTx removes any pending-service record for part in guildID.
+func clearPendingServiceTx(tx *gorm.DB, guildID, part string) error {
+	return tx.Where("guild_id = ? AND part = ?", guildID, part).
+		Delete(&PendingService{}).Error
 }

--- a/internal/coffee/store.go
+++ b/internal/coffee/store.go
@@ -7,6 +7,7 @@ import (
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // UserBeveragePreference persists a Discord user's preferred beverage emoji.
@@ -419,12 +420,13 @@ func (m *Module) userSlackerBreakdown(guildID, userID string) ([]labelCount, err
 }
 
 // setPendingServiceTx records userID as on the hook for servicing part in
-// guildID, overwriting any prior pending record for that part.
+// guildID, overwriting any prior pending record for that part. Uses an atomic
+// INSERT ... ON CONFLICT DO UPDATE to avoid a race between concurrent brews.
 func setPendingServiceTx(tx *gorm.DB, guildID, part, userID string) error {
-	var ps PendingService
-	return tx.Where(PendingService{GuildID: guildID, Part: part}).
-		Assign(PendingService{UserID: userID}).
-		FirstOrCreate(&ps).Error
+	return tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "guild_id"}, {Name: "part"}},
+		DoUpdates: clause.AssignmentColumns([]string{"user_id", "updated_at"}),
+	}).Create(&PendingService{GuildID: guildID, Part: part, UserID: userID}).Error
 }
 
 // clearPendingServiceTx removes any pending-service record for part in guildID.

--- a/internal/coffee/store.go
+++ b/internal/coffee/store.go
@@ -102,6 +102,19 @@ type SlackerEvent struct {
 // TableName returns the database table name.
 func (SlackerEvent) TableName() string { return "coffee_slacker_events" }
 
+// TeaBagInventory tracks tea bag counts per guild and tea variety. Seeded at
+// first use with seedTeaBagsPerFlavor bags; capped at maxTeaBagsPerFlavor.
+// Exactly one row per (guild_id, flavor).
+type TeaBagInventory struct {
+	gorm.Model
+	GuildID string `gorm:"not null;uniqueIndex:idx_teabag_guild_flavor"`
+	Flavor  string `gorm:"not null;uniqueIndex:idx_teabag_guild_flavor"`
+	Count   int    `gorm:"not null;default:0"`
+}
+
+// TableName returns the database table name.
+func (TeaBagInventory) TableName() string { return "coffee_teabag_inventory" }
+
 func (m *Module) getDB() *gorm.DB {
 	m.dbMu.RLock()
 	defer m.dbMu.RUnlock()
@@ -118,7 +131,7 @@ func (m *Module) openStore(path string) error {
 	}
 	return m.db.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{},
 		&MachineInventory{}, &RefillEvent{}, &DrinkEvent{},
-		&PendingService{}, &SlackerEvent{})
+		&PendingService{}, &SlackerEvent{}, &TeaBagInventory{})
 }
 
 func (m *Module) closeStore() error {
@@ -433,4 +446,85 @@ func setPendingServiceTx(tx *gorm.DB, guildID, part, userID string) error {
 func clearPendingServiceTx(tx *gorm.DB, guildID, part string) error {
 	return tx.Where("guild_id = ? AND part = ?", guildID, part).
 		Delete(&PendingService{}).Error
+}
+
+// getOrSeedTeaBagTx loads or creates the TeaBagInventory row for the given
+// guild and flavor. New rows start with seedTeaBagsPerFlavor bags. Must be
+// called inside a transaction that holds machineMu.
+func getOrSeedTeaBagTx(tx *gorm.DB, guildID, flavor string) (TeaBagInventory, error) {
+	var tb TeaBagInventory
+	err := tx.Where(TeaBagInventory{GuildID: guildID, Flavor: flavor}).
+		Attrs(TeaBagInventory{Count: seedTeaBagsPerFlavor}).
+		FirstOrCreate(&tb).Error
+	return tb, err
+}
+
+// getTeaBagInventory returns TeaBagInventory rows for all known tea flavors in
+// the guild, seeding any missing varieties so the result is always complete.
+func (m *Module) getTeaBagInventory(guildID string) ([]TeaBagInventory, error) {
+	d := m.getDB()
+	if d == nil {
+		return nil, errors.New("store not initialized")
+	}
+	var rows []TeaBagInventory
+	err := d.Transaction(func(tx *gorm.DB) error {
+		for _, t := range teaFlavors {
+			if _, e := getOrSeedTeaBagTx(tx, guildID, t.key); e != nil {
+				return e
+			}
+		}
+		return tx.Where("guild_id = ?", guildID).Order("flavor ASC").Find(&rows).Error
+	})
+	return rows, err
+}
+
+// refillTeaBagsOutcome is the result of a tea bag refill attempt.
+type refillTeaBagsOutcome struct {
+	flavor      string
+	label       string
+	added       int
+	alreadyFull bool
+}
+
+// refillTeaBags tops up tea bags of the given flavor to maxTeaBagsPerFlavor for
+// the guild and records a RefillEvent for the amount added.
+func (m *Module) refillTeaBags(guildID, userID, flavor string) (refillTeaBagsOutcome, error) {
+	d := m.getDB()
+	if d == nil {
+		return refillTeaBagsOutcome{}, errors.New("store not initialized")
+	}
+	out := refillTeaBagsOutcome{flavor: flavor, label: teaFlavorLabel(flavor)}
+
+	m.machineMu.Lock()
+	defer m.machineMu.Unlock()
+
+	err := d.Transaction(func(tx *gorm.DB) error {
+		tb, e := getOrSeedTeaBagTx(tx, guildID, flavor)
+		if e != nil {
+			return e
+		}
+		if e = clearPendingServiceTx(tx, guildID, "tea_"+flavor); e != nil {
+			return e
+		}
+		if tb.Count >= maxTeaBagsPerFlavor {
+			out.alreadyFull = true
+			return nil
+		}
+		added := maxTeaBagsPerFlavor - tb.Count
+		tb.Count = maxTeaBagsPerFlavor
+		if e = tx.Save(&tb).Error; e != nil {
+			return e
+		}
+		if e = tx.Create(&RefillEvent{
+			GuildID: guildID,
+			UserID:  userID,
+			Part:    "tea_" + flavor,
+			Amount:  added,
+		}).Error; e != nil {
+			return e
+		}
+		out.added = added
+		return nil
+	})
+	return out, err
 }

--- a/internal/coffee/store_test.go
+++ b/internal/coffee/store_test.go
@@ -20,7 +20,8 @@ func newTestModule(t *testing.T) *Module {
 		t.Fatalf("failed to open in-memory store: %v", err)
 	}
 	if err := gormDB.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{},
-		&MachineInventory{}, &RefillEvent{}, &DrinkEvent{}); err != nil {
+		&MachineInventory{}, &RefillEvent{}, &DrinkEvent{},
+		&PendingService{}, &SlackerEvent{}); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
 	m.dbMu.Lock()

--- a/internal/coffee/store_test.go
+++ b/internal/coffee/store_test.go
@@ -21,7 +21,7 @@ func newTestModule(t *testing.T) *Module {
 	}
 	if err := gormDB.AutoMigrate(&UserBeveragePreference{}, &UserGreeting{},
 		&MachineInventory{}, &RefillEvent{}, &DrinkEvent{},
-		&PendingService{}, &SlackerEvent{}); err != nil {
+		&PendingService{}, &SlackerEvent{}, &TeaBagInventory{}); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
 	m.dbMu.Lock()

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -37,6 +37,7 @@ func TestCreateSound(t *testing.T) {
 	s := createSound("test", 5, 250)
 	if s == nil {
 		t.Fatal("createSound() returned nil")
+		return
 	}
 	if s.Name != "test" {
 		t.Errorf("Name = %q, want %q", s.Name, "test")
@@ -104,6 +105,7 @@ func TestSoundCollectionRandom_SingleSound(t *testing.T) {
 	got := sc.Random()
 	if got == nil {
 		t.Fatal("Random() returned nil for single-sound collection")
+		return
 	}
 	if got.Name != "only" {
 		t.Errorf("Name = %q, want %q", got.Name, "only")
@@ -175,6 +177,7 @@ func TestStatusInteractionResponse_Owner(t *testing.T) {
 
 	if resp == nil {
 		t.Fatal("expected non-nil response")
+		return
 	}
 	if resp.Type != discordgo.InteractionResponseChannelMessageWithSource {
 		t.Errorf("Type = %v, want InteractionResponseChannelMessageWithSource", resp.Type)
@@ -202,6 +205,7 @@ func TestStatusInteractionResponse_NonOwner(t *testing.T) {
 
 	if resp == nil {
 		t.Fatal("expected non-nil response")
+		return
 	}
 	if called {
 		t.Error("buildStats should not be called for non-owner")

--- a/internal/core/soundboard_init_test.go
+++ b/internal/core/soundboard_init_test.go
@@ -113,6 +113,7 @@ func TestSoundCollectionRandom_returnsSound(t *testing.T) {
 		got := sc.Random()
 		if got == nil {
 			t.Fatal("Random() returned nil for non-empty collection")
+			return
 		}
 		if got.Name != "beep" {
 			t.Errorf("Random() = %q, want %q", got.Name, "beep")

--- a/internal/gippity/gippity_helper_test.go
+++ b/internal/gippity/gippity_helper_test.go
@@ -97,6 +97,7 @@ func TestFetchReferencedMessage_FoundInDB(t *testing.T) {
 	}
 	if msg == nil {
 		t.Fatal("expected non-nil message")
+		return
 	}
 	if msg.Content != "the referenced content" {
 		t.Errorf("Content = %q, want %q", msg.Content, "the referenced content")

--- a/internal/gippity/gippity_test.go
+++ b/internal/gippity/gippity_test.go
@@ -276,6 +276,7 @@ func TestGetMessageFromDatabase_Found(t *testing.T) {
 	}
 	if msg == nil {
 		t.Fatal("expected non-nil message")
+		return
 	}
 	if msg.Message != "hello from db" {
 		t.Errorf("Message = %q, want %q", msg.Message, "hello from db")
@@ -296,7 +297,6 @@ func TestGetMessageFromDatabase_NotFound(t *testing.T) {
 		t.Errorf("expected nil message for nonexistent ID, got %+v", msg)
 	}
 }
-
 
 func TestGenerateAnswer_NoReference_NoSystemNoteInjected(t *testing.T) {
 	setupGippityTest(t)


### PR DESCRIPTION
Kaffeevollautomat adjustments, all in `internal/coffee`.

## 🐞 Bug: `/brew tea:<flavor>` brewed coffee
`/brew tea:Rooibos` (or `tea:X milk:True`) without `drink:Hot water` dispensed a **coffee**. Root cause: the `tea` option only relabeled the cup when the drink was *already* hot water — with the default drink (coffee) the flavor was ignored and a plain coffee came out.

Discord can't make one option conditional on another, so the elegant fix is a **separate command**:
- New **`/tea flavor:<x> [milk] [sugar]`** — always steeps fresh hot water with the chosen tea bag. No invalid combinations possible.
- `tea` option **removed from `/brew`**.

## 🧋 Interactive `/brew` (no options)
`/brew` with no options used to silently brew a default coffee. It now opens an **ephemeral menu** — a drink select + milk/sugar toggle buttons + a **Brew** button — restoring the click-to-order UX from before the vollautomat. Order state lives entirely in the component custom IDs (no server-side session); ephemeral so only the invoker can operate it. `/brew drink:…` still brews directly and publicly.

## 😴 Slacker tracking
After a successful brew that leaves a tank low (or grounds nearly full) enough that the **next** brew could block, the brewer is nudged to refill/empty *for the next person*. If they don't and the next user is forced to service that part, the nudged user is **blamed once** (a `SlackerEvent`), **differentiated per part** (each tank and the grounds). Refilling/emptying clears the pending blame; you're never blamed for your own block; a blocked retry doesn't double-count.

## 📊 Richer stats
- **`/coffeemachine status`** now shows a **grounds-emptier leaderboard** (times · total grams · average grams) and a **slackers** hall-of-shame. The per-drink / per-part breakdowns moved out of status.
- New **`/coffeemachine stats [user]`** — detailed per-user figures: drinks by type, refills by part, grounds emptied (times/total/avg), and slacker misses by part. Defaults to the invoker.

## Persistence
New tables: `PendingService` (one row per guild+part) and `SlackerEvent`.

## Tests
Full unit coverage added for the `/tea` command, the interactive menu (encode/parse round-trip, component toggles, go-brews), the slacker mechanic (nudge, blame, no-self-blame, clear-on-refill/empty, no double-blame), and the new stat queries/formatting. `go test ./...` green; `golangci-lint run ./internal/coffee/...` → 0 issues.

> Note: pre-commit `golangci-lint-full` was bypassed for the commit because it flags only **pre-existing** SA5011 findings in unrelated `internal/admin` test files; the coffee package is clean.