### PR TITLE
coffee: defer interactions before LLM calls to fix 10062/10015 errors

### DIFF
--- a/internal/coffee/coffee.go
+++ b/internal/coffee/coffee.go
@@ -60,6 +60,7 @@ type Module struct {
 	detectLanguage       func(*discordgo.Session, string) (string, error)
 	generateLLMMessage   func(context.Context, string, string) (string, error)
 	deferInteraction     func(*discordgo.Session, *discordgo.InteractionCreate, bool) error
+	deferUpdate          func(*discordgo.Session, *discordgo.InteractionCreate) error
 	editDeferredResponse func(*discordgo.Session, *discordgo.InteractionCreate, string)
 	editWithComponents   func(*discordgo.Session, *discordgo.InteractionCreate, string, []discordgo.MessageComponent)
 	respond              func(*discordgo.Session, *discordgo.InteractionCreate, string, bool)
@@ -80,6 +81,7 @@ func New() *Module {
 	m.detectLanguage = llm.DetectChannelLanguage
 	m.generateLLMMessage = llm.GenerateMessage
 	m.deferInteraction = m.deferInteractionImpl
+	m.deferUpdate = m.deferUpdateImpl
 	m.editDeferredResponse = m.editDeferredResponseImpl
 	m.editWithComponents = m.editWithComponentsImpl
 	m.respond = m.respondImpl
@@ -236,6 +238,15 @@ func (m *Module) deferInteractionImpl(s *discordgo.Session, i *discordgo.Interac
 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{Flags: flags},
+	})
+}
+
+// deferUpdateImpl acknowledges a component interaction by deferring an in-place
+// message update, giving the handler time to call LLM without hitting the 3-second
+// Discord acknowledgment deadline.
+func (m *Module) deferUpdateImpl(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredMessageUpdate,
 	})
 }
 

--- a/internal/coffee/machine.go
+++ b/internal/coffee/machine.go
@@ -787,22 +787,16 @@ type brewResponder struct {
 }
 
 // brewResponder builds the responder used by both the slash commands and the
-// interactive menu. Output is public either way: the slash path posts a public
-// reply and edits it; the menu path edits its (public) menu message in place.
-// The final reveal carries the supplied components (the Take cup button);
-// brewing/blocked drop components.
-func (m *Module) brewResponder(s *discordgo.Session, i *discordgo.InteractionCreate, fromMenu bool) brewResponder {
-	r := brewResponder{
-		final: func(c string, comps []discordgo.MessageComponent) { m.editWithComponents(s, i, c, comps) },
+// interactive menu. Both callers defer the interaction before calling executeBrew,
+// so all messages here are edits. The final reveal carries the supplied components
+// (the Take cup button); brewing and blocked messages drop components.
+func (m *Module) brewResponder(s *discordgo.Session, i *discordgo.InteractionCreate) brewResponder {
+	empty := []discordgo.MessageComponent{}
+	return brewResponder{
+		brewing: func(c string) { m.editWithComponents(s, i, c, empty) },
+		blocked: func(c string) { m.editWithComponents(s, i, c, empty) },
+		final:   func(c string, comps []discordgo.MessageComponent) { m.editWithComponents(s, i, c, comps) },
 	}
-	if fromMenu {
-		r.brewing = func(c string) { m.respondUpdate(s, i, c) }
-		r.blocked = func(c string) { m.respondUpdate(s, i, c) }
-	} else {
-		r.brewing = func(c string) { m.respond(s, i, c, false) }
-		r.blocked = func(c string) { m.respond(s, i, c, false) }
-	}
-	return r
 }
 
 // handleBrewInteraction serves /brew. With no options it opens the interactive
@@ -811,6 +805,12 @@ func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.Intera
 	data := i.ApplicationCommandData()
 	if len(data.Options) == 0 {
 		m.openBrewMenu(s, i)
+		return
+	}
+	// Acknowledge immediately so the 3-second Discord deadline doesn't expire
+	// while generateInteractionMessage calls the LLM.
+	if err := m.deferInteraction(s, i, false); err != nil {
+		slog.Error("coffee: defer brew failed", "error", err)
 		return
 	}
 	drinkKey := menu[0].key
@@ -825,7 +825,7 @@ func (m *Module) handleBrewInteraction(s *discordgo.Session, i *discordgo.Intera
 			addSugar = o.BoolValue()
 		}
 	}
-	m.executeBrew(s, i, drinkKey, addMilk, addSugar, m.brewResponder(s, i, false))
+	m.executeBrew(s, i, drinkKey, addMilk, addSugar, m.brewResponder(s, i))
 }
 
 // executeBrew dispenses one drink and drives the brewing animation through the
@@ -1118,7 +1118,11 @@ func (m *Module) handleBrewComponent(s *discordgo.Session, i *discordgo.Interact
 		return
 	}
 	if action == "go" {
-		m.executeBrew(s, i, c.choice, c.milk, c.sugar, m.brewResponder(s, i, true))
+		if err := m.deferUpdate(s, i); err != nil {
+			slog.Error("coffee: defer brew component failed", "error", err)
+			return
+		}
+		m.executeBrew(s, i, c.choice, c.milk, c.sugar, m.brewResponder(s, i))
 		return
 	}
 	prompt := m.localizeUI(s, i.ChannelID, brewMenuPrompt)
@@ -1156,10 +1160,14 @@ func (m *Module) handleTakeCupComponent(s *discordgo.Session, i *discordgo.Inter
 	if r, ok := recipeByKey(drinkKey); ok {
 		label = drinkLabel(r)
 	}
+	if err := m.deferUpdate(s, i); err != nil {
+		slog.Error("coffee: defer take-cup failed", "error", err)
+		return
+	}
 	msg := m.generateInteractionMessage(s, i.ChannelID,
 		fmt.Sprintf("User <@%s> just grabbed their %s out of the coffee machine. Tell the channel to enjoy it, in one short sentence, keeping the <@%s> mention.", opener, label, opener),
 		fmt.Sprintf("%s <@%s> grabbed their %s out of the machine. Enjoy!", drinkEmojiForKey(drinkKey), opener, label))
-	m.respondUpdate(s, i, msg)
+	m.editWithComponents(s, i, msg, []discordgo.MessageComponent{})
 }
 
 // drinkEmojiForKey is drinkEmoji by key, falling back to a coffee cup.

--- a/internal/coffee/machine_test.go
+++ b/internal/coffee/machine_test.go
@@ -435,12 +435,15 @@ type respCall struct {
 }
 
 // captureBrewIO stubs the interaction response, edit, and sleep hooks so brew
-// handler behavior can be asserted without a live Discord session. respondUpdate
-// (used by the interactive-menu brew path) is captured alongside respond.
+// handler behavior can be asserted without a live Discord session. All brew paths
+// now defer immediately and edit rather than posting a new response, so the brewing
+// and final messages both land in edits; resp captures only ephemeral nudges.
 func captureBrewIO(m *Module) (*[]respCall, *[]string, *[]time.Duration) {
 	resp := &[]respCall{}
 	edits := &[]string{}
 	sleeps := &[]time.Duration{}
+	m.deferInteraction = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ bool) error { return nil }
+	m.deferUpdate = func(_ *discordgo.Session, _ *discordgo.InteractionCreate) error { return nil }
 	m.respond = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, content string, ephemeral bool) {
 		*resp = append(*resp, respCall{content, ephemeral})
 	}
@@ -529,14 +532,14 @@ func TestHandleBrew_BlockedShowsErrorNoBrewing(t *testing.T) {
 
 	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
-	if len(*resp) != 1 || (*resp)[0].ephemeral {
-		t.Fatalf("expected 1 public error response, got %+v", *resp)
+	if len(*edits) != 1 {
+		t.Fatalf("expected 1 public error edit, got %d", len(*edits))
 	}
-	if !strings.Contains((*resp)[0].content, "water") {
-		t.Errorf("error should name the missing ingredient: %q", (*resp)[0].content)
+	if !strings.Contains((*edits)[0], "water") {
+		t.Errorf("error should name the missing ingredient: %q", (*edits)[0])
 	}
-	if len(*edits) != 0 || len(*sleeps) != 0 {
-		t.Errorf("blocked brew must not brew/edit: edits=%d sleeps=%d", len(*edits), len(*sleeps))
+	if len(*resp) != 0 || len(*sleeps) != 0 {
+		t.Errorf("blocked brew must not post responses or sleep: resp=%d sleeps=%d", len(*resp), len(*sleeps))
 	}
 	if c := countDrinks(m, t, "g1"); c != 0 {
 		t.Errorf("blocked brew should record no drink, got %d", c)
@@ -548,28 +551,25 @@ func TestHandleBrew_SuccessShowsBrewingThenFinalNoStats(t *testing.T) {
 	now := time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC)
 	useNow(m, t, now)
 	stubLLM(m, t, "", nil) // fallback messages
-	resp, edits, sleeps := captureBrewIO(m)
+	_, edits, sleeps := captureBrewIO(m)
 
 	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
-	if len(*resp) != 1 || (*resp)[0].ephemeral {
-		t.Fatalf("expected 1 public brewing response, got %+v", *resp)
+	if len(*edits) != 2 {
+		t.Fatalf("expected 2 edits (brewing + final), got %d", len(*edits))
 	}
-	if !strings.Contains((*resp)[0].content, "Brewing") {
-		t.Errorf("first response should be a brewing status: %q", (*resp)[0].content)
+	if !strings.Contains((*edits)[0], "Brewing") {
+		t.Errorf("first edit should be the brewing status: %q", (*edits)[0])
 	}
 	coffee, _ := recipeByKey("coffee")
 	wantTS := fmt.Sprintf("<t:%d:R>", now.Add(brewTime(coffee)).Unix())
-	if !strings.Contains((*resp)[0].content, wantTS) {
-		t.Errorf("brewing status should carry the relative ready time %q, got %q", wantTS, (*resp)[0].content)
+	if !strings.Contains((*edits)[0], wantTS) {
+		t.Errorf("brewing status should carry the relative ready time %q, got %q", wantTS, (*edits)[0])
 	}
 	if len(*sleeps) != 1 || (*sleeps)[0] != brewTime(coffee) {
 		t.Errorf("expected one sleep of %v, got %v", brewTime(coffee), *sleeps)
 	}
-	if len(*edits) != 1 {
-		t.Fatalf("expected 1 final edit, got %d", len(*edits))
-	}
-	final := (*edits)[0]
+	final := (*edits)[1]
 	if !strings.Contains(final, "Coffee is ready") {
 		t.Errorf("final message wrong: %q", final)
 	}
@@ -588,8 +588,11 @@ func TestHandleBrew_UsesLLMForVariation(t *testing.T) {
 
 	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
-	if len(*edits) != 1 || (*edits)[0] != "Dein Kaffee ist fertig!" {
-		t.Errorf("final message should come from the LLM, got %v", *edits)
+	if len(*edits) != 2 {
+		t.Fatalf("expected 2 edits (brewing + final), got %d", len(*edits))
+	}
+	if (*edits)[1] != "Dein Kaffee ist fertig!" {
+		t.Errorf("final message should come from the LLM, got %q", (*edits)[1])
 	}
 }
 
@@ -671,8 +674,8 @@ func TestHandleTea_BrewsTeaNotCoffee(t *testing.T) {
 
 	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "tea_rooibos")))
 
-	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Rooibos tea") {
-		t.Fatalf("expected a Rooibos tea, got %v", *edits)
+	if len(*edits) != 2 || !strings.Contains((*edits)[1], "Rooibos tea") {
+		t.Fatalf("expected a Rooibos tea in final edit, got %v", *edits)
 	}
 	// Tea uses only water, no beans, no grounds.
 	inv, _ := m.getOrSeedInventory("g1")
@@ -696,8 +699,8 @@ func TestHandleTea_WithMilk(t *testing.T) {
 
 	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "tea_earl_grey"), boolOpt("milk", true)))
 
-	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Earl Grey tea with milk") {
-		t.Fatalf("expected Earl Grey tea with milk, got %v", *edits)
+	if len(*edits) != 2 || !strings.Contains((*edits)[1], "Earl Grey tea with milk") {
+		t.Fatalf("expected Earl Grey tea with milk in final edit, got %v", *edits)
 	}
 	inv, _ := m.getOrSeedInventory("g1")
 	if inv.MilkMl != maxMilkMl-addMilkMl {
@@ -901,19 +904,22 @@ func TestEnsureOpenerNudgeLocalized(t *testing.T) {
 func TestCoffeeComponent_GoBrews(t *testing.T) {
 	m := newTestModule(t)
 	stubLLM(m, t, "", nil)
-	resp, edits, sleeps := captureBrewIO(m)
+	_, edits, sleeps := captureBrewIO(m)
 	_, _ = captureMenuIO(m)
 
 	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "go", brewCfg{opener: "u1", choice: "espresso", milk: true, sugar: true})))
 
-	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
-		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
+	if len(*edits) != 2 {
+		t.Fatalf("expected 2 edits (brewing + final), got %d", len(*edits))
+	}
+	if !strings.Contains((*edits)[0], "Brewing") {
+		t.Errorf("first edit should be an in-place brewing update: %q", (*edits)[0])
 	}
 	if len(*sleeps) != 1 {
 		t.Errorf("expected one brew delay, got %d", len(*sleeps))
 	}
-	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Espresso with milk and sugar") {
-		t.Fatalf("expected final espresso with milk+sugar, got %v", *edits)
+	if !strings.Contains((*edits)[1], "Espresso with milk and sugar") {
+		t.Errorf("expected final espresso with milk+sugar, got %q", (*edits)[1])
 	}
 	var de DrinkEvent
 	m.getDB().Where("guild_id = ?", "g1").First(&de)
@@ -925,19 +931,22 @@ func TestCoffeeComponent_GoBrews(t *testing.T) {
 func TestTeaComponent_GoBrews(t *testing.T) {
 	m := newTestModule(t)
 	stubLLM(m, t, "", nil)
-	resp, edits, sleeps := captureBrewIO(m)
+	_, edits, sleeps := captureBrewIO(m)
 	_, _ = captureMenuIO(m)
 
 	m.handleBrewComponent(nil, makeBrewComponent("g1", encodeBrewCfg(brewCfgPrefix, "go", brewCfg{opener: "u1", choice: "tea_rooibos", milk: true})))
 
-	if len(*resp) != 1 || !strings.Contains((*resp)[0].content, "Brewing") {
-		t.Fatalf("expected an in-place brewing update, got %+v", *resp)
+	if len(*edits) != 2 {
+		t.Fatalf("expected 2 edits (brewing + final), got %d", len(*edits))
+	}
+	if !strings.Contains((*edits)[0], "Brewing") {
+		t.Errorf("first edit should be an in-place brewing update: %q", (*edits)[0])
 	}
 	if len(*sleeps) != 1 {
 		t.Errorf("expected one brew delay, got %d", len(*sleeps))
 	}
-	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Rooibos tea with milk") {
-		t.Fatalf("expected final Rooibos tea with milk, got %v", *edits)
+	if !strings.Contains((*edits)[1], "Rooibos tea with milk") {
+		t.Errorf("expected final Rooibos tea with milk, got %q", (*edits)[1])
 	}
 	var de DrinkEvent
 	m.getDB().Where("guild_id = ?", "g1").First(&de)
@@ -949,16 +958,16 @@ func TestTeaComponent_GoBrews(t *testing.T) {
 func TestTakeCup_Confirms(t *testing.T) {
 	m := newTestModule(t)
 	stubLLM(m, t, "", nil) // empty reply -> English fallback confirmation
-	resp, _, _ := captureBrewIO(m)
+	_, edits, _ := captureBrewIO(m)
 
 	id := strings.Join([]string{takeCupPrefix, "u1", "espresso"}, ":")
 	m.handleTakeCupComponent(nil, makeBrewComponent("g1", id))
 
-	if len(*resp) != 1 {
-		t.Fatalf("expected 1 confirmation update, got %d", len(*resp))
+	if len(*edits) != 1 {
+		t.Fatalf("expected 1 confirmation edit, got %d", len(*edits))
 	}
-	if !strings.Contains((*resp)[0].content, "grabbed their Espresso") {
-		t.Errorf("take-cup confirmation should name the drink: %q", (*resp)[0].content)
+	if !strings.Contains((*edits)[0], "grabbed their Espresso") {
+		t.Errorf("take-cup confirmation should name the drink: %q", (*edits)[0])
 	}
 }
 
@@ -985,7 +994,7 @@ func TestExecuteBrew_AttachesTakeCupButton(t *testing.T) {
 	m := newTestModule(t)
 	stubLLM(m, t, "", nil)
 	var finalComps []discordgo.MessageComponent
-	m.respond = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ string, _ bool) {}
+	m.deferInteraction = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ bool) error { return nil }
 	m.editWithComponents = func(_ *discordgo.Session, _ *discordgo.InteractionCreate, _ string, comps []discordgo.MessageComponent) {
 		finalComps = comps
 	}
@@ -1213,7 +1222,7 @@ func TestExecuteBrewAppendsServiceHint(t *testing.T) {
 
 	m.handleBrewInteraction(nil, makeBrewInteraction("g1", strOpt("drink", "coffee")))
 
-	if len(*edits) != 1 || !strings.Contains((*edits)[0], "Heads up") {
+	if len(*edits) != 2 || !strings.Contains((*edits)[1], "Heads up") {
 		t.Fatalf("final brew message should carry the service nudge, got %v", *edits)
 	}
 }
@@ -1238,7 +1247,7 @@ func TestExecuteBrew_FoldsServiceHintIntoLLMScenario(t *testing.T) {
 		t.Errorf("service nudge should be folded into an LLM scenario, calls=%v", getCalls())
 	}
 	// The final message is the LLM output, with no English nudge appended.
-	if len(*edits) != 1 || (*edits)[0] != "Fertig!" {
+	if len(*edits) != 2 || (*edits)[1] != "Fertig!" {
 		t.Errorf("final should be the LLM message only, got %v", *edits)
 	}
 }
@@ -1251,16 +1260,16 @@ func TestBlockedBrewMentionsSlacker(t *testing.T) {
 		t.Fatalf("alice brew: %v", err)
 	}
 
-	resp, _, _ := captureBrewIO(m)
+	_, edits, _ := captureBrewIO(m)
 	bob := makeBrewInteraction("g1", strOpt("drink", "coffee"))
 	bob.Member.User.ID = "bob"
 	m.handleBrewInteraction(nil, bob)
 
-	if len(*resp) != 1 || (*resp)[0].ephemeral {
-		t.Fatalf("expected 1 public blocked response, got %+v", *resp)
+	if len(*edits) != 1 {
+		t.Fatalf("expected 1 public blocked edit, got %d", len(*edits))
 	}
-	if !strings.Contains((*resp)[0].content, "<@alice>") {
-		t.Errorf("blocked message should name the slacker: %q", (*resp)[0].content)
+	if !strings.Contains((*edits)[0], "<@alice>") {
+		t.Errorf("blocked message should name the slacker: %q", (*edits)[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

- `/brew` (and the menu "go" button) called `generateInteractionMessage` (LLM) before sending any Discord response, so the 3-second acknowledgment window expired → `10062 Unknown interaction`
- When `r.brewing()` failed with 10062, `r.final()` then tried to edit a response that was never sent → `10015 Unknown Webhook`
- `handleTakeCupComponent` had the same race on its LLM call

## Fix

Immediately defer every interaction that does LLM work before responding:
- `/brew` direct: `DeferredChannelMessageWithSource` (new public loading message)
- menu "go" + "Take cup": `DeferredMessageUpdate` (loading state on existing message)

All subsequent messages use `InteractionResponseEdit`. This makes both brew paths identical, so the `fromMenu bool` distinction in `brewResponder` is removed entirely.

## Test plan

- [ ] Run `make test` — all coffee tests pass
- [ ] Deploy and run `/brew espresso` — brewing + ready message appear without errors
- [ ] Run `/brew` (no options) → pick drink → Brew — same flow works via menu
- [ ] Press Take cup button — confirmation edit appears without errors