### PR TITLE
core: bound gateway websocket reads/writes to fix silent reconnect hang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/sessions v1.4.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/mattn/go-sqlite3 v1.14.45
 	github.com/openai/openai-go/v3 v3.39.0
 	github.com/simplesurance/go-ip-anonymizer v0.0.0-20200429124537-35a880f8e87d
@@ -29,7 +30,6 @@ require (
 
 require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 )

--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -326,6 +326,14 @@ func StartGidbig() {
 		return
 	}
 
+	// The pinned discordgo fork sets no read/write deadlines on its
+	// websockets, so a degraded network can hang Open() (waiting for the
+	// Hello packet while holding the session lock) or the heartbeat write
+	// (holding wsMutex) forever, silently stalling the reconnect loop.
+	// Bound every read/write at the transport level so stalls turn into
+	// errors and discordgo reconnects on its own. See wsdeadline.go.
+	discord.Dialer = newDeadlineDialer()
+
 	// Surface the discordgo voice-protocol logs so #113 can be diagnosed from
 	// production: encryption mode negotiated, DAVE handshake progress, UDP
 	// errors, etc. Only on dev mode — LogDebug is very verbose.

--- a/internal/core/wsdeadline.go
+++ b/internal/core/wsdeadline.go
@@ -1,0 +1,84 @@
+package gidbig
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Timeouts for the Discord gateway and voice websocket connections.
+//
+// The pinned discordgo fork never sets read or write deadlines on its
+// websockets, so on a degraded network ReadMessage/WriteJSON can block
+// forever: Open() hangs waiting for the Hello packet while holding the
+// session lock, and the heartbeat goroutine hangs in WriteJSON while
+// holding wsMutex — in both cases the reconnect loop stalls silently
+// without logging anything. Wrapping the underlying net.Conn bounds
+// every read and write, so a stalled connection surfaces as an error
+// and discordgo's own close-and-reconnect path takes over.
+const (
+	// wsReadTimeout must comfortably exceed the gateway heartbeat
+	// interval (~41s): heartbeat ACKs guarantee at least one read per
+	// interval on a healthy connection, so two minutes of read silence
+	// means the connection is dead.
+	wsReadTimeout = 2 * time.Minute
+	// wsWriteTimeout bounds a single websocket frame write; on a
+	// healthy connection writes complete in milliseconds.
+	wsWriteTimeout = 30 * time.Second
+	// wsDialTimeout bounds the TCP connect during (re)connects.
+	wsDialTimeout = 30 * time.Second
+)
+
+// deadlineConn arms a fresh deadline before every Read/Write so a dead
+// TCP connection can never block a websocket operation indefinitely.
+//
+// Deadlines set externally via the promoted SetReadDeadline /
+// SetWriteDeadline still reach the underlying conn, but are
+// deliberately overwritten on the next Read/Write: the per-call
+// deadline is the whole point of the wrapper. The pinned discordgo
+// fork never sets its own deadlines (verified against 930441e7); if a
+// future fork bump introduces them, revisit this wrapper.
+type deadlineConn struct {
+	net.Conn
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+}
+
+func (c *deadlineConn) Read(b []byte) (int, error) {
+	if err := c.SetReadDeadline(time.Now().Add(c.readTimeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
+}
+
+func (c *deadlineConn) Write(b []byte) (int, error) {
+	if err := c.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Write(b)
+}
+
+// newDeadlineDialer returns a websocket dialer that wraps every
+// connection in a deadlineConn. Assigned to discordgo's Session.Dialer,
+// which is used for both the gateway and voice websockets.
+func newDeadlineDialer() *websocket.Dialer {
+	return &websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: websocket.DefaultDialer.HandshakeTimeout,
+		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			d := &net.Dialer{Timeout: wsDialTimeout}
+			conn, err := d.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return &deadlineConn{
+				Conn:         conn,
+				readTimeout:  wsReadTimeout,
+				writeTimeout: wsWriteTimeout,
+			}, nil
+		},
+	}
+}

--- a/internal/core/wsdeadline_test.go
+++ b/internal/core/wsdeadline_test.go
@@ -1,0 +1,132 @@
+package gidbig
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func newTestDeadlineConn(c net.Conn, timeout time.Duration) *deadlineConn {
+	return &deadlineConn{Conn: c, readTimeout: timeout, writeTimeout: timeout}
+}
+
+func assertTimeoutErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	var nerr net.Error
+	if !errors.As(err, &nerr) || !nerr.Timeout() {
+		t.Fatalf("expected net timeout error, got %v", err)
+	}
+}
+
+func TestDeadlineConnReadTimesOut(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	c := newTestDeadlineConn(client, 50*time.Millisecond)
+
+	buf := make([]byte, 1)
+	_, err := c.Read(buf)
+	assertTimeoutErr(t, err)
+}
+
+func TestDeadlineConnWriteTimesOut(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	c := newTestDeadlineConn(client, 50*time.Millisecond)
+
+	// Nobody reads from server, so the pipe write blocks until the
+	// armed deadline fires.
+	_, err := c.Write([]byte("x"))
+	assertTimeoutErr(t, err)
+}
+
+func TestDeadlineConnReadWithinDeadlineSucceeds(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	c := newTestDeadlineConn(client, time.Second)
+
+	go func() {
+		_, _ = server.Write([]byte("ok"))
+	}()
+
+	buf := make([]byte, 2)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if string(buf[:n]) != "ok" {
+		t.Fatalf("expected %q, got %q", "ok", string(buf[:n]))
+	}
+}
+
+func TestDeadlineConnDeadlineRearmsPerCall(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	timeout := 200 * time.Millisecond
+	c := newTestDeadlineConn(client, timeout)
+
+	// Two reads, each delayed by more than half the timeout: combined
+	// they exceed a single deadline window, so both only succeed if the
+	// deadline is re-armed on every Read call.
+	go func() {
+		for range 2 {
+			time.Sleep(120 * time.Millisecond)
+			_, _ = server.Write([]byte("x"))
+		}
+	}()
+
+	buf := make([]byte, 1)
+	for i := range 2 {
+		if _, err := c.Read(buf); err != nil {
+			t.Fatalf("read %d failed: %v", i, err)
+		}
+	}
+}
+
+func TestNewDeadlineDialerWrapsConn(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			defer func() { _ = conn.Close() }()
+		}
+	}()
+
+	dialer := newDeadlineDialer()
+	if dialer.NetDialContext == nil {
+		t.Fatal("expected NetDialContext to be set")
+	}
+
+	conn, err := dialer.NetDialContext(t.Context(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	dc, ok := conn.(*deadlineConn)
+	if !ok {
+		t.Fatalf("expected *deadlineConn, got %T", conn)
+	}
+	if dc.readTimeout != wsReadTimeout {
+		t.Errorf("readTimeout = %v, want %v", dc.readTimeout, wsReadTimeout)
+	}
+	if dc.writeTimeout != wsWriteTimeout {
+		t.Errorf("writeTimeout = %v, want %v", dc.writeTimeout, wsWriteTimeout)
+	}
+}


### PR DESCRIPTION
## Problem

After a network degradation the bot sometimes never reconnects and logs nothing. The pinned discordgo fork (`yeongaori/discordgo-fork@930441e7`, pinned for DAVE — see #113) sets **no read/write deadlines** on its websockets, leaving three unbounded blocking paths:

1. **`Open()`** blocks in `ReadMessage()` waiting for the Hello/READY packet while holding the session lock (`wsapi.go:116/182`) — the reconnect loop stalls forever and the whole session freezes.
2. **`heartbeat()`** blocks in `WriteJSON` holding `wsMutex` once the dead connection's TCP send buffer fills (`wsapi.go:309`) — the heartbeat-ACK watchdog never runs and `Close()` deadlocks on the same mutex.
3. **`listen()`** blocks in `ReadMessage()` with no read deadline (`wsapi.go:227`).

An earlier draft of this branch set a 30s `http.Client` timeout — that only re-bounded the REST gateway-URL lookup, which discordgo already bounds at 20s by default, and could not affect the websocket at all.

## Fix

Inject a `websocket.Dialer` via the public `Session.Dialer` field whose `NetDialContext` wraps every connection in a `deadlineConn` that arms a fresh deadline before each read (2m) and write (30s). A stalled connection now surfaces as a timeout error and discordgo's existing close-and-reconnect path recovers on its own — no fork patch needed.

- Read timeout (2m) comfortably exceeds the gateway heartbeat interval (~41s); heartbeat ACKs guarantee at least one read per interval on a healthy connection, so false positives can't occur.
- Applies to both gateway and voice websockets (they share `Session.Dialer`); voice heartbeats are even more frequent (~14s).
- The fork sets no deadlines of its own anywhere, so the wrapper is the sole deadline authority.

## Tests

`internal/core/wsdeadline_test.go`: read timeout fires, write timeout fires, read within deadline succeeds, deadline re-arms per call, dialer wraps connections with the configured timeouts.