### PR TITLE
renovate: auto-apply patch version label to renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "extends": [
         "config:recommended"
     ],
+    "labels": ["patch"],
     "packageRules": [
         {
             "matchPackageNames": ["github.com/yeongaori/discordgo-fork", "github.com/bwmarrin/discordgo"],


### PR DESCRIPTION
## Why

Every open renovate PR fails CI on the **Require version label** gate: renovate applies no labels, and `require-version-label.yaml` fails any PR without one of `major`/`minor`/`breaking`/`patch`.

## What

Add `"labels": ["patch"]` to `renovate.json` so renovate labels its PRs `patch` by default. Dependency bumps are chores → patch is the right default; relabel manually before merge when a bump warrants more.

Existing open renovate PRs were labeled `patch` manually (the gate re-runs on `labeled`).