### PR TITLE
renovate: auto-merge non-major bumps after 4-day grace period

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,25 @@
         "config:recommended"
     ],
     "labels": ["patch"],
+    "platformAutomerge": false,
+    "automergeStrategy": "rebase",
     "packageRules": [
         {
             "matchPackageNames": ["github.com/yeongaori/discordgo-fork", "github.com/bwmarrin/discordgo"],
             "enabled": false,
             "description": "Pinned to 930441e7 — later commits break DAVE voice encryption (see go.mod comment and issue #113)"
+        },
+        {
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+            "automerge": true,
+            "minimumReleaseAge": "4 days",
+            "description": "Auto-merge non-major bumps only after the release is 4 days old, to mitigate supply-chain attacks via freshly published malicious releases. Majors stay manual."
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "automerge": false,
+            "minimumReleaseAge": null,
+            "description": "GitHub Actions bumps are reviewed and merged manually, without the grace-period delay."
         }
     ]
 }


### PR DESCRIPTION
## What

- **Automerge** for `minor` / `patch` / `pin` / `digest` updates, using the `rebase` strategy with `platformAutomerge: false` (the repo has GitHub auto-merge disabled, so renovate merges via API once checks pass).
- **4-day `minimumReleaseAge` gate** on those automerged updates: a release must be at least 4 days old before renovate opens/merges its PR. This mitigates supply-chain attacks — compromised releases are usually reported and yanked within days of publication.
- **GitHub Actions excluded**: `github-actions` manager keeps `automerge: false` and no release-age delay, so action bump PRs appear immediately and are reviewed/merged manually.
- **Major bumps stay manual** for all managers.

Version labels from #222 still apply, so automerged PRs pass the require-version-label gate and tag a patch release on merge.